### PR TITLE
[FIX] l10n_ar_account_tax_settlement: Account Chart Installation

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_chart_template.py
+++ b/l10n_ar_account_tax_settlement/models/account_chart_template.py
@@ -16,7 +16,9 @@ class AccountChartTemplate(models.Model):
             AccountChartTemplate, self)._create_bank_journals(
             company, acc_template_ref)
 
-        if company.localization != 'argentina':
+        # When creating a DB with multicompany and there another chart template is installed from another
+        # localization or the company localization is not argentina we should not install the journals from argentina
+        if company.localization != 'argentina' or company.chart_template_id:
             return res
 
         ref = self.env.ref


### PR DESCRIPTION
 When creating a DB with multi-company and the main company is from Argentina, but we need to install another localization when the chart template from the new localization is installed we are getting an error that corresponds to the Argentinean localization because is trying to install also the Argentinean data.

Cc. @hugho-ad