### PR TITLE
[FIX] l10n_ar_edi_ux: update partner from AFIP

### DIFF
--- a/l10n_ar_edi_ux/models/res_partner.py
+++ b/l10n_ar_edi_ux/models/res_partner.py
@@ -83,7 +83,7 @@ class ResPartner(models.Model):
                      for imp in data_mt.get("impuesto", []) + data_rg.get("impuesto", [])
                      if data.get('estadoClave') == 'ACTIVO']
 
-        data_mt_actividades = data_mt.get("actividadMonotributista", [])
+        data_mt_actividades = data_mt.get("actividadMonotributista", []) or []
         if isinstance(data_mt_actividades, (dict,)):
             data_mt_actividades = [data_mt_actividades]
 


### PR DESCRIPTION
In case the data returned by AFIP has the value "actividadMonotributista"
empty we force to continue with an empty list in order to avoid
concatenations problems.