### PR TITLE
[FIX] l10n_ar_account_tax_settlement: chart installation

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_chart_template.py
+++ b/l10n_ar_account_tax_settlement/models/account_chart_template.py
@@ -88,6 +88,9 @@ class AccountChartTemplate(models.Model):
         # for name, code, tax, report, partner, credit_id, debit_id, tag \
         for name, code, type, tax, partner, credit_id, debit_id, tag \
                 in journals:
+            if not credit_id or debit_id:
+                _logger.info("Skip creation of journal %s because we didn't found debit/credit account")
+                continue
             # journal_data.append({
             self.env['account.journal'].create({
                 'type': 'general',


### PR DESCRIPTION
Si se instala un plan de cuentas distinto al "l10n_ar_account" la constraint check_tax_settlement bloquea instalacion.
Si no encontramos cuentas, NO creamos estos diarios y listo