### PR TITLE
[FIX] l10n_ar_edi_ux: CN/DN from customer receipts

### DIFF
--- a/l10n_ar_edi_ux/__manifest__.py
+++ b/l10n_ar_edi_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian Electronic Invoicing UX',
-    'version': "13.0.1.3.0",
+    'version': "13.0.1.4.0",
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',
@@ -17,6 +17,7 @@
     'data': [
         'wizards/res_config_settings_view.xml',
         'wizards/res_partner_update_from_padron_wizard_view.xml',
+        'wizards/account_payment_group_invoice_wizard_view.xml',
         'views/res_partner_view.xml',
         'views/account_move_view.xml',
     ],

--- a/l10n_ar_edi_ux/wizards/__init__.py
+++ b/l10n_ar_edi_ux/wizards/__init__.py
@@ -4,3 +4,4 @@
 ##############################################################################
 from . import res_partner_update_from_padron_wizard
 from . import res_config_settings
+from . import account_payment_group_invoice_wizard

--- a/l10n_ar_edi_ux/wizards/account_payment_group_invoice_wizard.py
+++ b/l10n_ar_edi_ux/wizards/account_payment_group_invoice_wizard.py
@@ -1,0 +1,33 @@
+from odoo import fields, models
+
+
+class AccountPaymentGroupInvoiceWizard(models.TransientModel):
+    _inherit = "account.payment.group.invoice.wizard"
+
+    l10n_ar_afip_asoc_period_start = fields.Date(
+        'Associate Period From',
+    )
+
+    l10n_ar_afip_asoc_period_end = fields.Date(
+        'Associate Period To',
+    )
+
+    origin_invoice_id = fields.Many2one(
+        'account.move',
+    )
+
+    commercial_partner_id = fields.Many2one(
+        'res.partner',
+        related="payment_group_id.partner_id.commercial_partner_id"
+    )
+
+    def get_invoice_vals(self):
+        self.ensure_one()
+        invoice_vals = super().get_invoice_vals()
+        origin_doc = "reversed_entry_id" if invoice_vals['type'] in ['in_refund', 'out_refund'] else "debit_origin_id"
+        invoice_vals.update({
+            'l10n_ar_afip_asoc_period_start': self.l10n_ar_afip_asoc_period_start,
+            'l10n_ar_afip_asoc_period_end': self.l10n_ar_afip_asoc_period_end,
+            origin_doc: self.origin_invoice_id
+        })
+        return invoice_vals

--- a/l10n_ar_edi_ux/wizards/account_payment_group_invoice_wizard_view.xml
+++ b/l10n_ar_edi_ux/wizards/account_payment_group_invoice_wizard_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="view_account_payment_group_invoice_wizard">
+        <field name="name">account.payment.group.invoice.wizard.form</field>
+        <field name="model">account.payment.group.invoice.wizard</field>
+        <field name="inherit_id" ref="account_payment_group.view_account_payment_group_invoice_wizard"/>
+        <field name="arch" type="xml">
+            <field name="date" position="after">
+                <field name="l10n_ar_afip_asoc_period_start"/>
+                <field name="l10n_ar_afip_asoc_period_end"/>
+                <field name="commercial_partner_id" invisible="1"/>
+                <field name="origin_invoice_id" domain="context.get('refund') and [('type', '=', 'out_invoice'), ('partner_id.commercial_partner_id', '=', commercial_partner_id), ('state', '=', 'posted')] or [('type', 'in', ('out_invoice', 'out_refund')), ('partner_id.commercial_partner_id', '=', commercial_partner_id), ('state', '=', 'posted')]"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
We add new fields on the "Credit / Debit Note" wizard to support the RG 4540 when creating a debit/credit note from customer receipts.
When posting debit/credit notes to AFIP we need to report the original document. If there is not original document related, then the user can set the PeriodoAsoc information.

New fields:
 * l10n_ar_afip_asoc_period_start
 * l10n_ar_afip_asoc_period_end
 * origin_invoice_id