### PR TITLE
[FIX] l10n_ar_account_tax_settlement: AGIP TXT

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -609,10 +609,6 @@ class AccountJournal(models.Model):
                 # la base la sacamos desde las lineas de impuesto
                 # taxable_amount = line.move_id.cc_amount_untaxed
                 taxable_amount = line.tax_base_amount
-                # convert to company currency if in another currency
-                if company_currency != line.move_id.currency_id:
-                    taxable_amount = company_currency.round(
-                        taxable_amount * line.move_id.l10n_ar_currency_rate)
 
                 # tambien lo sacamos por diferencia para no tener error (por el
                 # calculo trucado de taxable_amount por ejemplo) y


### PR DESCRIPTION
ticket 39928
---

For invoices in other currencies the TXT related lines have some errors,  there was a problem in the values of the next columns (taking into account the txt [specification file](https://www.agip.gob.ar/filemanager/source/Agentes/DocTecnicoImpoOperacionesDise%C3%B1odeRegistro.pdf)):

  * Campo 16 - Importe otros conceptos
  * Campo 18 - Monto Sujeto a Retención/ Percepción

This was because the line.tax_base_amount was converted from the other currency to the company currency, but actually, the field is already in the company currency ([see field definition](https://github.com/odoo/odoo/blob/13.0/addons/account/models/account_move.py#L2670-L2671)). The result of this conversion was returning a really big number and wrong value. Removing the conversion we resolved the problem.