### PR TITLE
 [FIX] l10n_ar_account_tax_settlement: filter draft and canceled moves

### DIFF
--- a/l10n_ar_account_tax_settlement/__manifest__.py
+++ b/l10n_ar_account_tax_settlement/__manifest__.py
@@ -28,6 +28,7 @@
     'depends': [
         'account_tax_settlement',
         'l10n_ar_account_reports',
+        'l10n_ar_ux',
     ],
     'data': [
         'data/account_financial_report_data.xml',

--- a/l10n_ar_account_tax_settlement/wizards/inflation_adjustment.py
+++ b/l10n_ar_account_tax_settlement/wizards/inflation_adjustment.py
@@ -147,6 +147,7 @@ class InflationAdjustment(models.TransientModel):
         res = [
             ('account_id.tag_ids', 'in', no_monetaria_tag.id),
             ('company_id', '=', self.company_id.id),
+            ('move_id.state', '=', 'posted'),
         ]
         if self.open_move_id:
             res += [('move_id', '!=', self.open_move_id.id)]


### PR DESCRIPTION
Improve the domain to filter draft and canceled account moves in the inflation adjustment.