### PR TITLE
[13.0] [FIX] l10n_ar_edi_ux: Avoid error with m2o fields when update the padron afip.

### DIFF
--- a/l10n_ar_edi_ux/wizards/res_partner_update_from_padron_wizard.py
+++ b/l10n_ar_edi_ux/wizards/res_partner_update_from_padron_wizard.py
@@ -149,6 +149,8 @@ class ResPartnerUpdateFromPadronWizard(models.TransientModel):
         for field in self.field_ids:
             if field.field in ('impuestos_padron', 'actividades_padron'):
                 vals[field.field] = [(6, False, literal_eval(field.new_value))]
+            elif field.field in ('state_id', 'l10n_ar_afip_responsibility_type_id'):
+                vals[field.field] = literal_eval(field.new_value)
             else:
                 vals[field.field] = field.new_value
         self.partner_id.write(vals)


### PR DESCRIPTION
**Ticket 40817**