### PR TITLE
[13.0] [FIX] l10n_ar_edi_ux: Allow to search padron AFIP

### DIFF
--- a/l10n_ar_edi_ux/models/res_partner.py
+++ b/l10n_ar_edi_ux/models/res_partner.py
@@ -40,7 +40,7 @@ class ResPartner(models.Model):
         vat = self.ensure_vat()
 
         # if there is certificate for current company use that one, if not use the company with first certificate found
-        company = self.env.company if self.env.company.sudo().l10n_ar_afip_ws_crt else self.env['res.company'].search(
+        company = self.env.company if self.env.company.sudo().l10n_ar_afip_ws_crt else self.env['res.company'].sudo().search(
             [('l10n_ar_afip_ws_crt', '!=', False)], limit=1)
         if not company:
             raise UserError(_('Please configure an AFIP Certificate in order to continue'))


### PR DESCRIPTION
 for user with not administrators rights regardless with companies are standing in the tab.