### PR TITLE
[FIX] l10n_ar_account_tax_settlement: migration error

### DIFF
--- a/l10n_ar_account_tax_settlement/README.rst
+++ b/l10n_ar_account_tax_settlement/README.rst
@@ -29,7 +29,7 @@ Especificación de archivos:
 
 * AGIP: https://www.agip.gob.ar/filemanager/source/Agentes/DocTecnicoImpoOperacionesDise%C3%B1odeRegistro.pdf y https://www.agip.gob.ar/agentes/agentes-de-recaudacion/ib-agentes-recaudacion/aplicativo-arciba/ag-rec-arciba-codigo-de-normas
 
-* MENDOZA https://www.atm.mendoza.gov.ar/portalatm/zoneBottom/serviciosDescargas/sarepe/files/SAREPE.pdf
+* MENDOZA https://www.atm.mendoza.gov.ar/portalatm/ModificarParametros?tipo=descargarUrl&url=/zoneBottom/serviciosDescargas/sarepe/files/SAREPE.pdf
 
 Inflation Adjustment
 --------------------

--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -140,7 +140,7 @@ class AccountJournal(models.Model):
             # Campo 8: Importe Ret./Perc. char(15). Importe retenido y/o percibido. Formato: 999999999999.99 (doce enteros,
             # punto decimal y dos decimales, dejando espacios en blanco a izquierda para completar las 15 posiciones).
             # Ejemplo: "          34.50" "000000000816.88"
-            content += '%15.2f' % line.balance
+            content += '%15.2f' % -line.balance
 
             content += '\r\n'
             ret += content

--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -106,8 +106,8 @@ class AccountJournal(models.Model):
 
             # Campo 1: CUIT char(13). CUIT del Sujeto retenido o percibido. Ejemplo: 20-10111222-3
             # Example "30-58710878-6"
-            partner.cuit_required()
-            content = partner.formated_cuit
+            partner.ensure_vat()
+            content = partner.l10n_ar_formatted_vat
 
             # Campo 2: Denominación char(80). Apellido y Nombre o Razón Social. Formato: 80 posiciones, se completa con
             # blancos a la derecha.
@@ -149,7 +149,7 @@ class AccountJournal(models.Model):
         move_line = move_lines and move_lines[0] or self.env['account.move.line']
         tipo_agente = 'rr'  # This value is fixed just because we are doing the retention txt, when adding the
         # perception we need to change it
-        cuit = move_line.company_id.cuit
+        cuit = move_line.company_id.vat   
         periodo = fields.Date.from_string(move_line.date).strftime('%Y') or ""  # 'pppp' AÑO '2020'
         cuota = fields.Date.from_string(move_line.date).strftime('%m') or ""  # 'cc'
 


### PR DESCRIPTION
ticket 43849
----


Modify the references to field and method that was renamed from version 11.0 to version 13.0

* cuit_required replaced with enssure_vat
* cuit replaced with vat