### PR TITLE
[ADD] l10n_ar_edi_ux: compatibility with module subchange

### DIFF
--- a/l10n_ar_edi_ux/wizards/account_payment_group_invoice_wizard.py
+++ b/l10n_ar_edi_ux/wizards/account_payment_group_invoice_wizard.py
@@ -30,4 +30,18 @@ class AccountPaymentGroupInvoiceWizard(models.TransientModel):
             'l10n_ar_afip_asoc_period_end': self.l10n_ar_afip_asoc_period_end,
             origin_doc: self.origin_invoice_id
         })
+
+        # Si estamos creando una ND automatica con el modulo de  account_payment_group_financial_surcharge entonces
+        # seteamos automaticamente los campos l10n_ar_afip_asoc_period_start / l10n_ar_afip_asoc_period_end que son
+        # necesarios para poder validar la ND electronica automatica. El periodo lo seteamos conforme a la fecha del
+        # dia que se esta validando el recibo de pago. Fecha Hasta  (dicha fecha) Fecha Desde (dicha fecha - 1 mes)
+        if self.env.context.get('is_automatic_subcharge'):
+            journal = self.env['account.journal'].browse(invoice_vals.get('journal_id'))
+            if journal.l10n_ar_afip_ws:  # Si soy diario electronico
+                period_date = fields.Date.context_today(self)
+                invoice_vals.update({
+                    'l10n_ar_afip_asoc_period_start': fields.Date().subtract(period_date, months=1),
+                    'l10n_ar_afip_asoc_period_end': period_date,
+                })
+
         return invoice_vals


### PR DESCRIPTION
Be able to auto complete the missing required EDI values when the subchange is automatically created because of the use of financial plan