### PR TITLE
[FIX] l10n_ar_account_tax_settlement: redondeo incorrecto del monto sujeto a retención

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -1,5 +1,6 @@
 from odoo import models, fields, api, _
 from odoo.exceptions import ValidationError
+from odoo.tools.float_utils import float_round
 # from odoo.tools.misc import formatLang
 # from odoo.tools import DEFAULT_SERVER_DATE_FORMAT
 import re
@@ -582,9 +583,9 @@ class AccountJournal(models.Model):
             if payment_group:
                 # solo en comprobantes A, M segun especificacion
                 vat_amount = 0.0
-                total_amount = payment_group.payments_amount
+                total_amount = float_round(payment_group.payments_amount, precision_digits=2)
                 # es lo mismo que payment_group.matched_amount_untaxed
-                taxable_amount = payment.withholdable_base_amount
+                taxable_amount = float_round(payment.withholdable_base_amount, precision_digits=2)
 
                 # lo sacamos por diferencia
                 other_taxes_amount = company_currency.round(


### PR DESCRIPTION
Task: 59214
Importe total y monto sujeto a retención no se redondean a 2 decimales y eso genera inconvenientes en la presentación del archivo correspondiente. Especificación: https://www.agip.gob.ar/filemanager/source/Agentes/DocTecnicoImpoOperacionesDise%C3%B1odeRegistro.pdf

Los campos modificados son "Monto del comprobante" y "Monto Sujeto a Retención / Percepción" --> ver en especificación.
![image](https://user-images.githubusercontent.com/89547436/218178773-ada4d5aa-8df2-4f0d-9df3-2b6f666fa12a.png)
![image](https://user-images.githubusercontent.com/89547436/218178695-cf46aed7-36a8-463c-a67f-685c879ba207.png)
