### PR TITLE
[FIX] l10n_ar_account_tax_settlement: iibb aplicado sircar

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -847,7 +847,7 @@ class AccountJournal(models.Model):
 
             # 4 Número del comprobante
             content.append('%012d' % int(
-                re.sub('[^0-9]', '', line.move_id.l10n_latam_document_number or '')))
+                re.sub('[^0-9]', '', line.payment_id.withholding_number or '')))
 
             # 5 Cuit del contribuyene
             content.append(line.partner_id.ensure_vat())


### PR DESCRIPTION
Ticket: 60795
En el txt de iibb aplicado sircar en lugar de informar como número del comprobante el nro de op informamos el "Número de Retención"