### PR TITLE
[IMP] Add amount filters in account reconciliation widget

### DIFF
--- a/account_accountant_ux/__manifest__.py
+++ b/account_accountant_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Accounting Accountant UX',
-    'version': "16.0.1.1.0",
+    'version': "16.0.2.1.0",
     'category': 'Accounting',
     'sequence': 14,
     'summary': '',
@@ -36,6 +36,7 @@
     'data': [
         'views/res_partner_view.xml',
         'views/account_followup_views.xml',
+        'views/account_move_line.xml',
         'wizards/account_change_lock_date_views.xml',
         'wizards/res_config_settings_views.xml',
         'data/account_accountant_data.xml',

--- a/account_accountant_ux/models/__init__.py
+++ b/account_accountant_ux/models/__init__.py
@@ -4,3 +4,5 @@
 ##############################################################################
 from . import account_followup_report
 from . import res_company
+from . import bank_rec_widget
+from . import account_move_line

--- a/account_accountant_ux/models/account_move_line.py
+++ b/account_accountant_ux/models/account_move_line.py
@@ -1,0 +1,25 @@
+from odoo import models, fields
+
+
+class AccountMovetLine(models.Model):
+
+    _inherit = 'account.move.line'
+
+    filter_amount = fields.Float(compute="compute_filter_amout", search='_search_filter_amount')
+    
+    def compute_filter_amout(self):
+        self.filter_amount = False
+
+    def _search_filter_amount(self, operator, value):
+        res = []
+        if self.env.context.get('default_st_line_id'):
+            amount = self.env['account.bank.statement.line'].browse(self.env.context.get('default_st_line_id'))['amount'] 
+            if value != 0 and operator == '=':
+                base_amount = ((100 - value)/100) * amount
+                top_amount = ((100 + value)/100) * amount
+                res.append(('amount_residual', '>',  base_amount))
+                res.append(('amount_residual', '<',  top_amount))
+            else:
+                amount = ((100 - value)/100) * amount
+                res.append(('amount_residual', operator,  amount))
+        return res

--- a/account_accountant_ux/models/bank_rec_widget.py
+++ b/account_accountant_ux/models/bank_rec_widget.py
@@ -1,0 +1,31 @@
+from odoo import models, api
+from odoo.tools.misc import formatLang
+
+class BankRecWidget(models.Model):
+    _inherit = "bank.rec.widget"
+
+    @api.depends('st_line_id')
+    def _compute_amls_widget(self):
+        for wizard in self:
+            super()._compute_amls_widget()
+            amls_widget = wizard.amls_widget
+            amls_widget['context']['default_st_line_id'] = wizard.st_line_id.id
+            amls_widget['context']['search_default_same_amount'] = True
+            wizard.amls_widget = amls_widget
+
+    def collect_global_info_data(self, journal_id):
+
+        # Por ahora no mostramos el valor en el kanban. Porque confunde al cliente 
+        # Deberiaamos aplicar este Cambio a como esta en master 17 ¿usar patch?
+        # Ver commit
+        # https://github.com/odoo/enterprise/commit/e1f0f66a7237d8c8b056cdf2636ccc019818a17d#diff-ee342c09ffb6b8de7f51c4a0ed66fee056e8975e7416d0f85ae0d2b6b1883dfdR1467
+
+        # journal = self.env['account.journal'].browse(journal_id)
+        # balance = formatLang(self.env,
+        #                      journal.current_statement_balance,
+        #                      currency_obj=journal.currency_id or journal.company_id.currency_id)
+        # return {
+        #     'balance_amount': balance,
+        # }
+
+        return {'balance_amount': None}

--- a/account_accountant_ux/views/account_move_line.xml
+++ b/account_accountant_ux/views/account_move_line.xml
@@ -1,0 +1,15 @@
+<odoo>
+    <record id="view_account_move_line_search_bank_rec_widget" model="ir.ui.view">
+        <field name="name">account.move.line.search.bank_rec_widget</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account_accountant.view_account_move_line_search_bank_rec_widget"/> 
+        <field name="arch" type="xml">
+            <filter name="amount_received" position="before">
+                <filter name="same_amount" string="Igual Monto" domain="[('filter_amount', '=', 0.0)]"/>
+                <filter name="close_amount" string="Monto aproximado" domain="[('filter_amount', '=', 4.0)]"/>
+                <filter name="less_amount" string="Monto menor" domain="[('filter_amount', '&lt;', 0.0)]"/>
+                <separator/>
+            </filter>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
	The purpose of this PR is to help the reconciliation when I have a lot of lines.
	When selecting a st during reconciliation the widget will filter the account
	lines of the same amount. We also added filters for close and smaller amounts.