### PR TITLE
[FIX] l10n_ar_currency_update: update currency rates when there are c…

### DIFF
--- a/l10n_ar_currency_update/models/res_company.py
+++ b/l10n_ar_currency_update/models/res_company.py
@@ -72,7 +72,7 @@ class ResCompany(models.Model):
 
         for currency in available_currencies:
             company = self.env.company if self.env.company.sudo().l10n_ar_afip_ws_crt else self.env['res.company'].search(
-                [('l10n_ar_afip_ws_crt', '!=', False)], limit=1)
+                [('l10n_ar_afip_ws_crt', '!=', False), ('l10n_ar_crt_exp_date' '>', today)], limit=1)
             if not company:
                 _logger.log(25, "No pudimos encontrar compañía con certificados de AFIP validos")
                 return False


### PR DESCRIPTION
…ompanies with expired digital certificate (afip)

Ticket: 62824

Cuando tenemos una compañía que tiene realizada la configuración para sincronizar tasas de cambio con afip y la misma no tiene certificado digital, estábamos buscando una compañía que lo tenga. Pero la compañía que lo tiene puede tener el certificado expirado; en ese caso tenemos un conflicto porque no se terminan actualizando las tasas. En este commit lo que hacemos es buscar una compañía que tenga certificado y no esté expirado.