### PR TITLE
[FIX] l10n_ar_account_tax_settlement: ceros antes del importe de la retención iva

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -1483,10 +1483,13 @@ class AccountJournal(models.Model):
                 content += fields.Date.from_string(payment.payment_date).strftime('%d/%m/%Y')
 
                 # número comprobante (long 16)
-                content += re.sub('[^0-9\.]', '', payment.withholding_number).ljust(16)
+                content += re.sub('[^0-9\.]', '', payment.withholding_number).ljust(16, '0')
 
+                # Aclaración importante: estamos agregando ceros entre el número de comprobante y el importe de retención
+                # esto contradice la especificación que dice que debe haber espacios pero en la tarea 31418 nos indicaron
+                # que debe haber espacios. Ver nota en dicha tarea 14/07/2023 10:31:00 y 13/07/2023 14:39:47
                 # importe retención (long 16)
-                content += '%16.2f' % payment.amount
+                content += '%016.2f' % payment.amount
                 content += '\r\n'
             elif line.move_id.is_invoice():
                 # regimen (long 3)


### PR DESCRIPTION
Task: 31418
Estamos agregando ceros entre el número de comprobante y el importe de retención esto contradice la especificación que dice que debe haber espacios pero en la tarea 31418 nos indicaron que debe haber espacios. Ver nota en dicha tarea 14/07/2023 10:31:00 y 13/07/2023 14:39:47 .