### PR TITLE
[FIX] l10n_ar_account_tax_settlement: acción de ventana para ver asiento que se crea

### DIFF
--- a/l10n_ar_account_tax_settlement/wizards/inflation_adjustment.py
+++ b/l10n_ar_account_tax_settlement/wizards/inflation_adjustment.py
@@ -255,4 +255,4 @@ class InflationAdjustment(models.TransientModel):
             'ref': _('Ajuste por inflación %s') % (date_to.year),
             'line_ids': [(0, 0, line_data) for line_data in lines],
         })
-        return {}
+        return move._get_access_action()


### PR DESCRIPTION
Ticket: 64177
Se incorpora la acción de ventana que permite visualizar el asiento que se crea. Esta funcionalidad había sido quitada en este pr https://github.com/ingadhoc/odoo-argentina-ee/pull/251 pero ahora la volvemos a incorporar con el método _get_access_action() ya que get_access_action() no existe más en 16.