### PR TITLE
[FIX] l10n_ar_edi_ux: re add dummy empty view

### DIFF
--- a/l10n_ar_edi_ux/__manifest__.py
+++ b/l10n_ar_edi_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian Electronic Invoicing UX',
-    'version': "16.0.1.4.0",
+    'version': "16.0.1.5.0",
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',
@@ -16,6 +16,7 @@
         'python': ['zeep'],
     },
     'data': [
+        'wizards/res_config_settings_view.xml',
         'wizards/res_partner_update_from_padron_wizard_view.xml',
         'wizards/account_check_action_wizard_view.xml',
         'views/res_partner_view.xml',

--- a/l10n_ar_edi_ux/wizards/res_config_settings_view.xml
+++ b/l10n_ar_edi_ux/wizards/res_config_settings_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="res_config_settings_view_form">
+        <field name="name">res.config.settings.view.form.inherit.l10n_ar_edi_ux</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="l10n_ar_edi.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <form/>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
To avoid problem with updating other modules that also extend from res_config_setting. This is required because Odoo does not delete the views until the end after all the modules has been updated, if another module has been update will check the status of the view and will let us know that the button we have in the view refence to a non exist one.

task 70617