### PR TITLE
[FIX] l10n_ar_edi_ux: botón 'Agregar botón de débito' en diarios.

### DIFF
--- a/l10n_ar_edi_ux/__manifest__.py
+++ b/l10n_ar_edi_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': 'Argentinian Electronic Invoicing UX',
-    'version': "16.0.1.5.0",
+    'version': "16.0.1.6.0",
     'category': 'Localization/Argentina',
     'sequence': 14,
     'author': 'ADHOC SA',

--- a/l10n_ar_edi_ux/models/account_journal.py
+++ b/l10n_ar_edi_ux/models/account_journal.py
@@ -8,8 +8,8 @@ class AccountJournal(models.Model):
     _inherit = "account.journal"
 
     check_add_debit_button = fields.Boolean(
-        string="Agregar botón de débito",
-        help="Si marca esta opción podrá debitar los cheques con un botón desde los mismo.")
+        string="Agregar botón de débito", compute='_compute_check_add_debit_journal', store=True, readonly=False,
+        help="Si marca esta opción podrá debitar los cheques con un botón desde los mismos. Para realizar el asiento de débito se buscará un método de pago saliente del tipo Manual con nombre Manual, si no se encuentra uno se utilizará el primero que sea del tipo Manual (sin importar el nombre). Se utilizará luego la cuenta configurada en dicho método de ese método de pago.")
     check_debit_journal_id = fields.Many2one('account.journal', compute='_compute_check_debit_journal', store=True, readonly=False, domain="[('company_id', '=', company_id), ('type', '=', 'general')]", help="Debe seleccionar un diario de tipo 'Varios' donde se realizará el asiento del débito")
 
     def l10n_ar_check_afip_doc_types(self):
@@ -73,3 +73,9 @@ class AccountJournal(models.Model):
         """ En caso de que el campo 'Agregar botón de débito' (check_debit_journal_id) sea 'False' entonces debemos asegurarnos que el campo check_debit_journal_id esté vacío para evitar inconvenientes en caso de necesitar debitar un cheque. """
         for journal in self.filtered(lambda x: not x.check_add_debit_button):
             journal.check_debit_journal_id = False
+
+    @api.depends('l10n_latam_manual_checks')
+    def _compute_check_add_debit_journal(self):
+        """ Si el campo 'Use electronic and deferred checks' (l10n_latam_manual_checks) es 'False' entonces el campo 'Agregar botón de débito' (check_add_debit_button) también debe ser 'False'. """
+        for journal in self.filtered(lambda x: not x.l10n_latam_manual_checks):
+            journal.check_add_debit_button = False

--- a/l10n_ar_edi_ux/views/account_journal_view.xml
+++ b/l10n_ar_edi_ux/views/account_journal_view.xml
@@ -19,7 +19,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='l10n_latam_manual_checks']" position="after">
                 <field name="check_add_debit_button" attrs="{'invisible': [('l10n_latam_manual_checks', '=', False)]}"/>
-                <field name="check_debit_journal_id" attrs="{'invisible': [('check_add_debit_button', '=', False)], 'required':[('check_add_debit_button','=',True)]}"/>
+                <field name="check_debit_journal_id" attrs="{'invisible': [('l10n_latam_manual_checks', '=', False), ('check_add_debit_button', '=', False)], 'required':[('check_add_debit_button','=',True)]}"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Ticket: 70425
1) Si el campo 'Use electronic and deferred checks' (l10n_latam_manual_checks) es 'False' entonces el campo 'Agregar botón de débito' (check_add_debit_button) también debe ser 'False'. El campo 'Agregar botón de débito' (check_add_debit_button) para a ser computado, almacenado, readonly=False. También le actualizamos el help a la definición del campo. 2) Hacer invisible en la vista form de diarios el campo 'Check Debit Journal' (check_debit_journal_id) si el campo 'Use electronic and deferred checks' (l10n_latam_manual_checks) es 'False'.
2) Hacer invisible en la vista form de diarios el campo 'Check Debit Journal' (check_debit_journal_id) si el campo 'Use electronic and deferred checks' (l10n_latam_manual_checks) es 'False'.