### PR TITLE
[FIX] l10n_ar_account_tax_settlement: modificación de fechas en índices de ajuste por inflación.

### DIFF
--- a/l10n_ar_account_tax_settlement/models/inflation_adjustment_index.py
+++ b/l10n_ar_account_tax_settlement/models/inflation_adjustment_index.py
@@ -39,7 +39,7 @@ class InflationAdjustmentIndex(models.Model):
     def check_date_unique(self):
         for rec in self:
             repeated = self.find(rec.date)
-            if len(repeated) > 1:
+            if len(repeated) > 1 or repeated.id != rec.id:
                 rec_date = fields.Date.from_string(rec.date)
                 raise ValidationError(_(
                     "Ya existe un indice para el periodo %s %s. Solo"


### PR DESCRIPTION
Ticket: 71668
Este commit lo que hace es no permitir que se pueda modificar la fecha a un registro existente y que sea igual a la fecha de otro registro existente.