### PR TITLE
[FIX] l10n_ar_account_tax_settlement: agregar xml_id cuando se importan registros de ajuste por inflación.

### DIFF
--- a/l10n_ar_account_tax_settlement/models/inflation_adjustment_index.py
+++ b/l10n_ar_account_tax_settlement/models/inflation_adjustment_index.py
@@ -58,7 +58,7 @@ class InflationAdjustmentIndex(models.Model):
     def check_xml_id(self):
         """ always create the xml_id when create a new record of this model.
         """
-        if self.env.context.get('install_mode', False):
+        if self.env.context.get('install_mode', False) and not self.env.context.get('import_file'):
             return
 
         model_data = self.env['ir.model.data']


### PR DESCRIPTION
Tarea: 37387
Agregar xml_id cuando se importan registros de índices de ajuste por inflación.