### PR TITLE
[FIX] l10n_ar_account_tax_settlement: año fiscal en asiento con ajuste por inflación

### DIFF
--- a/l10n_ar_account_tax_settlement/wizards/inflation_adjustment.py
+++ b/l10n_ar_account_tax_settlement/wizards/inflation_adjustment.py
@@ -68,6 +68,8 @@ class InflationAdjustment(models.TransientModel):
         res['company_id'] = company.id
         company_fiscalyear_dates = company.compute_fiscalyear_dates(
             (today - relativedelta(year=today.year-1)))
+        if 'record' in company_fiscalyear_dates:
+            del company_fiscalyear_dates['record']
         for key, value in company_fiscalyear_dates.items():
             company_fiscalyear_dates[key] = value
         res.update(company_fiscalyear_dates)


### PR DESCRIPTION
Ticket: 71732
Cuando se define en ajustes de contabilidad un ejercicio fiscal se obtiene error al confirmar asiento de ajuste por inflación.

Video con explicación funcional del bug:
https://drive.google.com/file/d/1w6XRcjtQxOKLQgGvbhxx4vHc0_IAZF-u/view

Video con explicación técnica del fix:
https://drive.google.com/file/d/1p2NgeZaB0Bi2LPPvMOiX7EKGJmjxLhdV/view