### PR TITLE
[FIX] l10n_ar_account_tax_settlement: txt retenciones de misiones

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -1331,14 +1331,6 @@ class AccountJournal(models.Model):
                 # Razón Social
                 content += payment.partner_id.name.replace(',','')[:100] + ','
 
-                # Domicilio
-                if not payment.partner_id.street:
-                    raise ValidationError(_(
-                    'No hay dirección configurada en el partner '
-                    '"%s" (id: %s)') % (
-                        line.partner_id.name, line.partner_id.id))
-                content += payment.partner_id.street.replace(',','')[:200] + ','
-
                 # CUIT
                 payment.partner_id.ensure_vat()
                 content += payment.partner_id.l10n_ar_formatted_vat + ','


### PR DESCRIPTION
Ticket: 73035
No corresponde incluir la dirección en txt de retenciones de misiones. En 13 se eliminó la dirección pero no se contempló en el fp a 16.