### PR TITLE
[IMP] l10n_ar_account_tax_settlement: agregar código de impuesto al instalar el módulo.

### DIFF
--- a/l10n_ar_account_tax_settlement/README.rst
+++ b/l10n_ar_account_tax_settlement/README.rst
@@ -18,6 +18,8 @@ Este módulo imlementa:
 
 * archivos para declaración de distintos impuestos (principalmente percepciones y retenciones)
 * Funcionalidad y datos para auste por inflación (The index are extracted from https://www.facpce.org.ar/indices-facpce/)
+* Al momento de instalar el módulo se agregan los códigos de impuestos correspondientes para retenciones de ganancias aplicadas y retenciones de iva aplicadas. También se agregan al momento de instalar el módulo las etiquetas de en las repartition lines de impuestos para percepciones. Lo descripto en este punto sucede en compañías argentinas responsable inscripto con plan de cuentas ri establecido.
+* Se agregan códigos de impuestos a impuestos de retenciones de ganancias aplicadas y retenciones de iva aplicadas. Y también se agregan las etiquetas de en las repartition lines de impuestos para percepciones. Lo descripto en este punto se agrega en compañías responsable inscripto argentinas nuevas al momento de instalar plan de cuentas responsable inscripto.
 
 Archivos para declaración de impuestos
 ======================================

--- a/l10n_ar_account_tax_settlement/__init__.py
+++ b/l10n_ar_account_tax_settlement/__init__.py
@@ -4,3 +4,4 @@
 ##############################################################################
 from . import models
 from . import wizards
+from .hooks import l10n_ar_account_tax_settlement_post_init_hook

--- a/l10n_ar_account_tax_settlement/__manifest__.py
+++ b/l10n_ar_account_tax_settlement/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Tax Settlements For Argentina',
-    'version': "17.0.1.0.0",
+    'version': "17.0.1.1.0",
     'category': 'Accounting',
     'website': 'www.adhoc.com.ar',
     'license': 'LGPL-3',
@@ -29,6 +29,7 @@
         'account_tax_settlement',
         'l10n_ar_account_reports',
         'l10n_ar_ux',
+        'l10n_ar_account_withholding',
     ],
     'data': [
         'data/inflation_adjustment_index.xml',
@@ -44,4 +45,5 @@
     'installable': True,
     'auto_install': True,
     'application': False,
+    'post_init_hook': 'l10n_ar_account_tax_settlement_post_init_hook',
 }

--- a/l10n_ar_account_tax_settlement/hooks.py
+++ b/l10n_ar_account_tax_settlement/hooks.py
@@ -1,0 +1,25 @@
+import logging
+_logger = logging.getLogger(__name__)
+
+
+def l10n_ar_account_tax_settlement_post_init_hook(env):
+    """ Al instalar este módulo (l10n_ar_account_tax_settlement), en caso de que existan compañías responsable inscripto argentinas y con plan de cuentas ya establecido entonces a los impuestos de retenciones de ganancias e iva les agregamos el código de impuesto correspondiente. También agregamos etiquetas a las repartition lines de impuestos de retenciones. """
+
+    # verificamos que la compañía sea argentina, responsable inscripto y tenga plan de cuentas instalado
+    companies = env['res.company'].search([('l10n_ar_afip_responsibility_type_id.code', '=', '1'), ('chart_template', '=', 'ar_ri')])
+    for company in companies:
+        # Retenciones aplicadas de ganancias
+        impuesto_ret_gcias_aplic = env.ref("account.%s_%s" % (company.id, 'ri_tax_withholding_ganancias_applied'))
+        if impuesto_ret_gcias_aplic:
+            impuesto_ret_gcias_aplic.codigo_impuesto = '01'
+        # Retenciones aplicadas de iva
+        impuesto_ret_iva_aplic = env.ref("account.%s_%s" % (company.id, 'ri_tax_withholding_vat_applied'))
+        if impuesto_ret_iva_aplic:
+            impuesto_ret_iva_aplic.codigo_impuesto = '02'
+        # Agregamos impuestos etiquetas de impuestos
+        env['account.chart.template']._add_wh_taxes(company)
+
+    # Dejamos registro en los logs de las compañías en las cuales se estableció el código de impuesto
+    if companies:
+        _logger.info("Se agregaron los códigos de impuestos correspondientes para retenciones de ganancias aplicadas y retenciones de iva aplicadas y las etiquetas de impuestos para compañías %s." % ', '.join(companies.mapped('name')))
+

--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -71,30 +71,6 @@ class AccountJournal(models.Model):
     #     return super(
     #         AccountJournal, self).action_create_tax_settlement_entry()
 
-    @api.constrains('settlement_tax')
-    def check_withholding_autmatic_installed(self):
-        l10n_ar_withholding_ux = self.env['ir.module.module'].search([
-            ('name', '=', 'l10n_ar_withholding_ux'),
-            ('state', '=', 'installed'),
-        ])
-        if not l10n_ar_withholding_ux and any(self.filtered(
-                lambda x: x.settlement_tax in ['iibb_aplicado_api',
-                                               'sicore_aplicado'])):
-            raise ValidationError(_(
-                'No puede utilizar exportación a "SICORE Aplicado"'
-                ' o "Perc/Ret IIBB aplicadas API"'
-                ' si no tiene instalado el módulo de retenciones'
-                ' automáticas (l10n_ar_withholding_ux)'))
-
-    def check_l10n_ar_account_withholding_installed(self):
-        l10n_ar_account_withholding_installed = self.env['ir.module.module'].search([
-            ('name', '=', 'l10n_ar_account_withholding'),
-            ('state', '=', 'installed'),
-        ])
-        if not l10n_ar_account_withholding_installed:
-            raise ValidationError(_(
-                'No se encuentra instalado el módulo "l10n_ar_account_withholding"'))
-
     def iibb_aplicado_dgr_mendoza_files_values(self, move_lines):
         self.ensure_one()
         ret = ''
@@ -105,7 +81,6 @@ class AccountJournal(models.Model):
             payment = line.payment_id
             move = line.move_id
             tax = line.tax_line_id
-            self.check_l10n_ar_account_withholding_installed()
 
             alicuot_line = tax.get_partner_alicuot(partner, line.date)
             if not alicuot_line:
@@ -210,7 +185,6 @@ class AccountJournal(models.Model):
         self.ensure_one()
         ret = ''
         perc = ''
-        self.check_l10n_ar_account_withholding_installed()
 
         for line in move_lines:
             partner = line.partner_id
@@ -460,7 +434,6 @@ class AccountJournal(models.Model):
         credito = ''
 
         company_currency = self.company_id.currency_id
-        self.check_l10n_ar_account_withholding_installed()
         for line in move_lines.sorted('date'):
 
             # pay_group = payment.payment_group_id
@@ -852,7 +825,6 @@ class AccountJournal(models.Model):
                 'facturas lo cual es requerido para generar el TXT'))
 
         line_nbr = 1
-        self.check_l10n_ar_account_withholding_installed()
         for line in move_lines.filtered('payment_id'):
             alicuot_line = line.tax_line_id.get_partner_alicuot(
                 line.partner_id, line.date)
@@ -1330,7 +1302,6 @@ class AccountJournal(models.Model):
         """
         self.ensure_one()
         content = ''
-        self.check_l10n_ar_account_withholding_installed()
         for line in move_lines.sorted(key=lambda r: (r.date, r.id)):
             payment = line.payment_id
             if payment:

--- a/l10n_ar_account_tax_settlement/models/account_tax.py
+++ b/l10n_ar_account_tax_settlement/models/account_tax.py
@@ -7,5 +7,5 @@ class AccountTax(models.Model):
     codigo_regimen = fields.Char(string='Codigo de regimen IVA', size=3)
     porcentaje_exclusion = fields.Float(string='Porcentaje de exclusión')
     codigo_impuesto = fields.Selection([('01', 'Retención Ganancias'),
-                                         ('02', 'Retención IVA'),
-                                         ], string='Codigo de impuesto')
+                                        ('02', 'Retención IVA'),
+                                        ])


### PR DESCRIPTION
Tarea: 34379
1) Al momento de instalar el módulo se agregan los códigos de impuestos correspondientes para retenciones de ganancias aplicadas y retenciones de iva aplicadas. También se agregan al momento de instalar el módulo las etiquetas de en las repartition lines de impuestos para percepciones. Lo descripto en este punto sucede en compañías argentinas responsable inscripto con plan de cuentas ri establecido.
2) Se agregan códigos de impuestos a impuestos de retenciones de ganancias aplicadas y retenciones de iva aplicadas. Y también se agregan las etiquetas de en las repartition lines de impuestos para percepciones. Lo descripto en este punto se agrega en compañías responsable inscripto argentinas nuevas al momento de instalar plan de cuentas responsable inscripto.
3) Se elimina aquellas partes de código donde verificamos si el módulo l10n_ar_account_withholding_ux y l10n_ar_account_withholding se encuentran instalados porque se agrega dependencia l10n_ar_account_withholding.