### PR TITLE
[REM] Remove unnecessary backslash in regular expression

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -1493,7 +1493,7 @@ class AccountJournal(models.Model):
                 content += fields.Date.from_string(payment.date).strftime('%d/%m/%Y')
 
                 # número comprobante (long 16)
-                content += re.sub('[^0-9\.]', '', payment.withholding_number).ljust(16, '0')
+                content += re.sub('[^0-9.]', '', payment.withholding_number).ljust(16, '0')
 
                 # Aclaración importante: estamos agregando ceros entre el número de comprobante y el importe de retención
                 # esto contradice la especificación que dice que debe haber espacios pero en la tarea 31418 nos indicaron


### PR DESCRIPTION
Remove unnecessary backslash in regular expression

ODOO WARNING
py.warnings: /home/odoo/src/user/submodules/ingadhoc/odoo-argentina-ee/l10n_ar_account_tax_settlement/models/account_journal.py:1496: DeprecationWarning: invalid escape sequence '\.'
  File "/home/odoo/src/odoo/odoo-bin", line 8, in <module>
    odoo.cli.main()
  File "/home/odoo/src/odoo/odoo/cli/command.py", line 66, in main
    o.run(args)
  File "/home/odoo/src/odoo/odoo/cli/server.py", line 180, in run
    main(args)
  File "/home/odoo/src/odoo/odoo/cli/server.py", line 173, in main
    rc = odoo.service.server.start(preload=preload, stop=stop)
  File "/home/odoo/src/odoo/odoo/service/server.py", line 1399, in start
    rc = server.run(preload, stop)
  File "/home/odoo/src/odoo/odoo/service/server.py", line 579, in run
    rc = preload_registries(preload)
  File "/home/odoo/src/odoo/odoo/service/server.py", line 1299, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "<decorator-gen-16>", line 2, in new
  File "/home/odoo/src/odoo/odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/odoo/modules/registry.py", line 90, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/src/odoo/odoo/modules/loading.py", line 484, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/home/odoo/src/odoo/odoo/modules/loading.py", line 372, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/home/odoo/src/odoo/odoo/modules/loading.py", line 188, in load_module_graph
    load_openerp_module(package.name)
  File "/home/odoo/src/odoo/odoo/modules/module.py", line 471, in load_openerp_module
    __import__('odoo.addons.' + module_name)
  File "/home/odoo/src/user/submodules/ingadhoc/odoo-argentina-ee/l10n_ar_account_tax_settlement/__init__.py", line 5, in <module>
    from . import models
  File "/home/odoo/src/user/submodules/ingadhoc/odoo-argentina-ee/l10n_ar_account_tax_settlement/models/__init__.py", line 2, in <module>
    from . import account_journal
  File "/usr/lib/python3.10/warnings.py", line 109, in _showwarnmsg
    sw(msg.message, msg.category, msg.filename, msg.lineno,
  File "/home/odoo/src/odoo/odoo/netsvc.py", line 290, in showwarning_with_traceback
    for frame in traceback.extract_stack():