### PR TITLE
[FIX] l10n_ar_currency_update: sincronización de tasa afip.

### DIFF
--- a/l10n_ar_currency_update/models/res_company.py
+++ b/l10n_ar_currency_update/models/res_company.py
@@ -93,6 +93,9 @@ class ResCompany(models.Model):
             except Exception as e:
                 self.env.company = env_company
                 _logger.log(25, "Could not get rate for currency %s. This is what we get:\n%s", currency.name, e)
+            else:
+                for company in self.filtered(lambda x: x.currency_provider == 'afip'):
+                    company.l10n_ar_last_currency_sync_date = fields.Date.context_today(self.with_context(tz='America/Argentina/Buenos_Aires'))
         return res or False
 
     def _generate_currency_rates(self, parsed_data):
@@ -126,5 +129,3 @@ class ResCompany(models.Model):
                 super(ResCompany, company)._generate_currency_rates(new_parsed_data)
             else:
                 super(ResCompany, company)._generate_currency_rates(parsed_data)
-            if company.currency_provider == 'afip':
-                company.l10n_ar_last_currency_sync_date = fields.Date.context_today(self.with_context(tz='America/Argentina/Buenos_Aires'))


### PR DESCRIPTION
Tarea: 39433
Cuando no logra crearse las tasas con el primer cron "Moneda: actualizar tasa" entonces el segundo cron "Moneda: Re chequear la tasa de moneda AFIP" no termina de crear las tasas correspondientes porque queda marcado en las compañías argentinas que se corrió la sincronización estableciendo en el campo "AFIP Last Sync Date" la fecha del día en que se corrió el primer cron y no logró crearse las tasas. Este commit soluciona eso, es decir, si el primer cron no logra crear las tasas entonces no habrá cambios en el campo "AFIP Last Sync Date" de la compañía.