### PR TITLE
[IMP] l10n_ar_edi_ux: uso certificado digital en update from afip

### DIFF
--- a/l10n_ar_edi_ux/models/res_partner.py
+++ b/l10n_ar_edi_ux/models/res_partner.py
@@ -30,10 +30,11 @@ class ResPartner(models.Model):
         vat = self.ensure_vat()
 
         # if there is certificate for current company use that one, if not use the company with first certificate found
-        company = self.env.company if self.env.company.sudo().l10n_ar_afip_ws_crt else self.env['res.company'].sudo().search(
-            [('l10n_ar_afip_ws_crt', '!=', False)], limit=1)
+        today = fields.Date.context_today(self.with_context(tz='America/Argentina/Buenos_Aires'))
+        company = self.env.company if self.env.company.sudo().l10n_ar_afip_ws_crt and self.env.company.sudo().l10n_ar_crt_exp_date > today else self.env['res.company'].sudo().search(
+            [('l10n_ar_afip_ws_crt', '!=', False), ('l10n_ar_crt_exp_date', '>', today)], limit=1)
         if not company:
-            raise UserError(_('Please configure an AFIP Certificate in order to continue'))
+            raise UserError(_('Please configure an active AFIP Certificate in order to continue'))
         client, auth = company._l10n_ar_get_connection('ws_sr_constancia_inscripcion')._get_client()
 
         error_msg = _(


### PR DESCRIPTION
Si se quiere hacer update from afip posicionado en una compañía con certificado digital vencido o sin certificado digital entonces no usa dicho certificado y busca el certificado de la primer compañía que se encuentre y que esté vigente (no expirado) el certificado de dicha compañía. Esto es similar a lo que hacemos en https://github.com/ingadhoc/odoo-argentina-ee/blob/16.0/l10n_ar_currency_update/models/res_company.py#L75:L76