### PR TITLE
[FIX] l10n_ar_edi_ux: set wizard date for debit check.

### DIFF
--- a/l10n_ar_edi_ux/wizards/account_check_action_wizard.py
+++ b/l10n_ar_edi_ux/wizards/account_check_action_wizard.py
@@ -30,8 +30,8 @@ class AccountCheckActionWizard(models.TransientModel):
                             'amount': abs(sum(liquidity_lines.mapped('balance'))),
                             'account_id': outstanding_account.id,
                             'journal_id': payment.journal_id.id,
-                            'date': self.date,
-                            'move_line_ids': move_line_ids
+                            'move_line_ids': move_line_ids,
+                            'date': self.date
                             }
         # Aquí hacemos el asiento del débito.
         wizard = self.env['account.reconcile.wizard'].with_context(active_model='account.move.line', active_ids=move_line_ids).new({})


### PR DESCRIPTION
**Ticket**: 82880

**Explicación funcional del fix**:
Cuando se quiere debitar un cheque en un pago haciendo click en el botón "Debit Check" se abre un wizard en el cual se puede establecer la fecha en la cual el usuario necesita que se realice el débito. Si el usuario establece una fecha distinta a la del día en el cual se encuentra haciendo la operación, al confirmar el wizard el asiento contable se crea con la fecha del día en el cual se encuentra haciendo la operación en lugar de la fecha que estableció el usuario en el wizard. Este fix resuelve dicho comportamiento y el asiento contable de débito de cheque va a tener la fecha que estableció el usuario en el wizard.

**Explicación técnica del fix**:
Lo que hago en el pr es establecer en el wizard primero move_line_ids y luego date ya que move_line_ids está en el depends del método _compute_date https://github.com/odoo/enterprise/blob/17.0/account_accountant/wizard/account_reconcile_wizard.py#L147 entoces como no queremos que se corra dicho método una vez que seteamos la fecha establecemos primero move_line_ids en el wizard y luego de establecemos la fecha que nosotros queremos que es la fecha del wizard.