### PR TITLE
[FIX] l10n_ar_account_tax_settlement: Error en ValidationError

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -1353,8 +1353,8 @@ class AccountJournal(models.Model):
                 if not alicuot_line:
                     raise ValidationError(
                     'No hay alicuota configurada en el partner '
-                    '"%s" (id: %s)') % (
-                        line.partner_id.name, line.partner_id.id)
+                    '"%s" (id: %s)' % (
+                        line.partner_id.name, line.partner_id.id))
 
                 content += str(line.tax_line_id.get_partner_alicuot(
                 line.partner_id, line.date).alicuota_retencion) + ','


### PR DESCRIPTION
Originalmente el fragmento de la función era
`    if not alicuot_line:

                    raise ValidationError(
                    'No hay alicuota configurada en el partner '
                    '"%s" (id: %s)') % (
                        line.partner_id.name, line.partner_id.id)`
Nótese los params de cadena fuera de la función lo que detonaba el siguiente error
ValueError: <class 'TypeError'>: "unsupported operand type(s) for %: 'ValidationError' and 'tuple'" while evaluating

Solucionado:
```
raise ValidationError(
                        'No hay alicuota configurada en el partner "{}" (id: {})'.format(
                            line.partner_id.name, line.partner_id.id)
```
                        
@jjscarafia @ivantodorovich por favor atender este tema, saludos y muchas gracias