### PR TITLE
[FIX] l10n_ar_account_tax_settlement: error al instalar si compañía no usa plan de cuentas por defecto argentino.

### DIFF
--- a/l10n_ar_account_tax_settlement/hooks.py
+++ b/l10n_ar_account_tax_settlement/hooks.py
@@ -7,7 +7,7 @@ def l10n_ar_account_tax_settlement_post_init_hook(env):
 
     # Verificamos que la compañía sea argentina. Agregamos ('parent_id', '=', False) en el dominio de la búsqueda porque las branches de una compañía
     # usan los mismos impuestos que la compañía padre. Algo similar a esto se aplicó en este pr https://github.com/ingadhoc/odoo-argentina-ee/pull/446
-    ar_companies = env['res.company'].search([]).filtered(lambda x: x.country_code == 'AR')
+    ar_companies = env['res.company'].search([('chart_template', 'in', ('ar_base', 'ar_ri', 'ar_ex'))])
     for company in ar_companies:
         ChartTemplate = env['account.chart.template'].with_company(company)
         if journals_to_create := env['account.chart.template']._get_latam_withholding_account_journal(template_code=company.chart_template, company=company):

--- a/l10n_ar_account_tax_settlement/models/account_chart_template.py
+++ b/l10n_ar_account_tax_settlement/models/account_chart_template.py
@@ -14,7 +14,7 @@ class AccountChartTemplate(models.AbstractModel):
     def _get_latam_withholding_account_journal(self, template_code=False, company=False):
         """ Creamos diarios de tipo 'varios' para liquidación de impuestos cuando se instala el plan de cuentas de la compañía. Los diarios a crear dependen de la condición fiscal de la compañía """
         company = company or self.env.company
-        if company.country_id.code in ["AR"]:
+        if company.chart_template in ('ar_base', 'ar_ri', 'ar_ex'):
             journals_data = [
                 ('Liquidación de IIBB', 'IIBB', 'allow_per_line', 'iibb_sufrido',
                     self.env.ref('l10n_ar.par_iibb_pagar'),
@@ -53,6 +53,7 @@ class AccountChartTemplate(models.AbstractModel):
                 if not account:
                     _logger.info("Skip creation of journal %s because we didn't found default account")
                     continue
+                account_id = "account.%s_%s" % (company.id, account)
                 res[code] = {
                     'type': 'general',
                     'name': name,
@@ -60,7 +61,7 @@ class AccountChartTemplate(models.AbstractModel):
                     'tax_settlement': type,
                     'settlement_tax': tax,
                     'settlement_partner_id': partner and partner.id or False,
-                    'settlement_account_id': account,
+                    'settlement_account_id': account if self.env.ref(account_id, raise_if_not_found=False) else None,
                     'company_id': company.id,
                     # al final hicimos otro dashboard
                     'show_on_dashboard': False,


### PR DESCRIPTION
Tarea: 43381
Este pr corrige el error al instalar l10n_ar_account_tax_settlement que surge si la compañía no usa el plan de cuentas por defecto argentino. Esto surge al crearse diarios de liquidación en compañías argentinas existentes al momento de instalar el módulo. En dichos diarios se establece la cuenta de contrapartida (settlement_account_id) en base a externals ids del plan de cuentas del módulo l10n_ar, pero si esos external ids no existen entonces se obtiene un error con traceback. Este pr hace que si no existen esos external ids se creen los diarios y no se establezca la cuenta de contrapartida (la tendría que establecer el usuario de manera manual).