### PR TITLE
[FIX] l10n_ar_edi_ux: avoid access error

### DIFF
--- a/l10n_ar_edi_ux/models/res_partner.py
+++ b/l10n_ar_edi_ux/models/res_partner.py
@@ -102,8 +102,10 @@ class ResPartner(models.Model):
 
         # if there is certificate for current company use that one, if not use the company with first certificate found
         today = fields.Date.context_today(self.with_context(tz='America/Argentina/Buenos_Aires'))
-        company = self.env.company if self.env.company.sudo().l10n_ar_afip_ws_crt and self.env.company.sudo().l10n_ar_crt_exp_date > today else self.env['res.company'].search(
-            [('l10n_ar_afip_ws_crt', '!=', False), ('l10n_ar_crt_exp_date', '>', today)], limit=1)
+        company = self.env.company \
+            if self.env.company.sudo().l10n_ar_afip_ws_crt and self.env.company.sudo().l10n_ar_crt_exp_date > today \
+            else self.env['res.company'].sudo().search(
+                [('l10n_ar_afip_ws_crt', '!=', False), ('l10n_ar_crt_exp_date', '>', today)], limit=1)
         if not company:
             raise UserError(_('Please configure an AFIP Certificate in order to continue'))
         client, auth = company._l10n_ar_get_connection('ws_sr_constancia_inscripcion')._get_client()


### PR DESCRIPTION
l10n_ar_afip_ws_crt field can only be access by administrators. We take this into account, but we miss to also made the exception on the search() method.

Ticket 86102