### PR TITLE
[FIX] l10n_ar_currency_update: avoid access error

### DIFF
--- a/l10n_ar_currency_update/models/res_company.py
+++ b/l10n_ar_currency_update/models/res_company.py
@@ -64,7 +64,7 @@ class ResCompany(models.Model):
         for currency in available_currencies:
             valid_certificate = self.env['certificate.certificate'].search(
                 [('active', '=', True), ('date_end', '>=', today), ("country_code", "=", "AR")])
-            if self.env.company.l10n_ar_afip_ws_crt_id in valid_certificate:
+            if self.env.company.sudo().l10n_ar_afip_ws_crt_id in valid_certificate:
                 company = self.env.company
             else:
                 company = valid_certificate[:1].company_id if valid_certificate else False


### PR DESCRIPTION
l10n_ar_afip_ws_crt field can only be access by administrators. We take this into account, but we miss to also made the exception on the search() method.
Ticket: 86501