### PR TITLE
[FIX] l10n_ar_account_tax_settlement: diarios con código corto existentes.

### DIFF
--- a/l10n_ar_account_tax_settlement/__manifest__.py
+++ b/l10n_ar_account_tax_settlement/__manifest__.py
@@ -28,7 +28,7 @@
     "depends": [
         "account_tax_settlement",
         "l10n_ar",
-        #'l10n_ar_account_reports',
+        "l10n_ar_account_reports",
         "l10n_ar_ux",
         "l10n_ar_tax",
         "account_payment_pro_receiptbook",

--- a/l10n_ar_account_tax_settlement/models/account_chart_template.py
+++ b/l10n_ar_account_tax_settlement/models/account_chart_template.py
@@ -81,6 +81,13 @@ class AccountChartTemplate(models.AbstractModel):
                     _logger.info("Skip creation of journal %s because we didn't found default account")
                     continue
                 account_id = "account.%s_%s" % (company.id, account)
+                existing_journal = (
+                    self.env["account.journal"]
+                    .with_context(active_test=False)
+                    .search([("company_id", "=", company.id), ("code", "=", code)], limit=1)
+                )
+                if existing_journal:
+                    continue
                 res[code] = {
                     "type": "general",
                     "name": name,


### PR DESCRIPTION
Ticket: 87647
1) Si ya existe en la base algún diario con el mismo código corto que alguno de los diarios de liquidación que creamos al instalar este módulo entonces no lo volvemos a crear.
2) Aprovecho a agregar la dependencia de l10n_ar_account_reports ya que no estaba migrado dicho módulo cuando se migró l10n_ar_account_tax_settlement.