### PR TITLE
[IMP] account_tax_settlement: Replace account_payment_pro dependency with account_payment_pro_receiptbook

### DIFF
--- a/account_tax_settlement/__manifest__.py
+++ b/account_tax_settlement/__manifest__.py
@@ -13,8 +13,10 @@
         # por ahora agregamos esta dep para permitir vincular a reportes
         'account_reports',
         # dependencia porque llevamos a pagos y tmb porque usamos el boton
-        # en apuntes contables para abrir documento relacionado
-        'account_payment_pro'
+        # en apuntes contables para abrir documento relacionado y tamnien precisamos
+        # para la liquidacion de impuesto el uso de talonarios por la nomenclatura de los
+        # pagos
+        'account_payment_pro_receiptbook'
     ],
     'data': [
         'wizards/account_tax_settlement_wizard_view.xml',


### PR DESCRIPTION
This change replaces the dependency on account_payment_pro with account_payment_pro_receiptbook, 
which also depends on account_payment_pro.
The goal is to ensure the use of the receipt books, which is necessary for the tax settlement process performed in this module. The use of receipt books standardizes the payment sequence and ensures compatibility with tax settlement.