### PR TITLE
[FIX] l10n_ar_account_tax_settlement: base de cáculo txt sicore ganancias

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -1162,7 +1162,7 @@ class AccountJournal(models.Model):
                 issue_date = payment.date
                 amount_tot = abs(payment.payment_total)
                 # withholdable_base_amount es para ret de gcias, withholding_base_amount es para ret de iva
-                base_amount = line.withholding_id.withholdable_base_amount or line.withholding_id.withholdable_base_amount
+                base_amount = line.withholding_id.withholdable_base_amount or line.withholding_id.base_amount
 
             elif move.is_invoice():
                 # Codigo del Comprobante         [ 2]


### PR DESCRIPTION
Ticket: 89104
En txt de sicore de ganancias si se pone manualmente la base de cálculo entonces en la retención como no es calculada automáticamente no existe el valor para withholdable_base_amount. Si la retención se hizo de manera manual entonces debe tomar base_amount. De todos modos si lo hacen manualmente no es recomendable ya que pueden tener problemas al exportar el txt.