### PR TITLE
[IMP] l10n_ar_edi_ux: Padron Consorcio/Fidecomiso

### DIFF
--- a/l10n_ar_edi_ux/models/res_partner.py
+++ b/l10n_ar_edi_ux/models/res_partner.py
@@ -268,4 +268,11 @@ class ResPartner(models.Model):
         else:
             _logger.info("We couldn't infer the AFIP responsability from padron, you must set it manually.")
 
+        # Si somos un consorcio entonces no colocamos responsbilidad afip y dejamos mensajito en el contecto avisando
+        if '681098' in actividades or [item for item in ["Fideicomiso", "Consorcio", "Cons.", "Cons "] if item in denominacion]:
+            values.pop('l10n_ar_afip_responsibility_type_id', None)
+            self.message_post(body=_(
+                'Posiblemente este cliente sea un consorcio/fideicomiso. Por favor debe consultar directamente con el'
+                ' cliente sus datos y agregar manualmente la responsabilidad de AFIP en el Odoo'))
+
         return values


### PR DESCRIPTION
ARCA Padron detects if the partner to update is a Consorcio or Fidecomiso will not set the AFIP Responsibility and will let the user know so they can manually set it (message in the partner chatter). This way we avoid wrong suggestions of document types

If the user tries to issue an invoice to a Consorcio will first have the error "need to set AFIP Responsibility" and then go to the form view of the partner and will see the message in the chatter explaining why the Responsibility is not set and how to proceed.

Ticket 89235