### PR TITLE
[IMP] account_accountant_ux: Ensure credit and debit search methods return results from all selected companies

### DIFF
--- a/account_accountant_ux/models/res_partner.py
+++ b/account_accountant_ux/models/res_partner.py
@@ -1,10 +1,14 @@
-from odoo import models
+from odoo import models, api, fields
 from odoo.exceptions import UserError
+from odoo.osv import expression
 
 class ResPartner(models.Model):
     _name = 'res.partner'
     _inherit = 'res.partner'
-    
+
+    credit = fields.Monetary(search='_credit_search')
+    debit = fields.Monetary(search='_debit_search')
+
     def open_mass_partner_ledger(self):
         selected_partner_ids = self.env.context.get('active_ids')
         if len(selected_partner_ids) < 1000:
@@ -18,3 +22,43 @@ class ResPartner(models.Model):
             return action
         else:
             raise UserError('Se deben seleccionar menos de 1000 contactos')
+        
+    @api.model
+    def _credit_search(self, operator, operand):
+        if len(self.env.companies) > 1:
+            domain = []
+            for company in self.env.companies:
+                cond = self.with_company(company)._asset_difference_search(
+                    account_type='asset_receivable',
+                    operator=operator,
+                    operand=operand
+                )
+                if cond:
+                    domain = expression.OR([domain, cond])
+
+            if not domain:
+                return [('id', '=', 0)]
+                
+            return domain
+        else:
+            return super()._credit_search(operator, operand)
+
+    @api.model
+    def _debit_search(self, operator, operand):
+        if len(self.env.companies) > 1:
+            domain = []
+            for company in self.env.companies:
+                cond = self.with_company(company)._asset_difference_search(
+                    account_type='liability_payable',
+                    operator=operator,
+                    operand=operand
+                )
+                if cond:
+                    domain = expression.OR([domain, cond])
+
+            if not domain:
+                return [('id', '=', 0)]
+
+            return domain
+        else:
+            return super()._debit_search(operator, operand)


### PR DESCRIPTION

Previously, the search methods were only returning results for the main company. This change refactors the credit and debit search methods to return results from all active companies. By using the new generic _search_by_account_type method, the logic for handling multiple companies is unified, ensuring that the results reflect the data across all selected companies, not just the primary one.

Why the change was made:

Specifies that the previous implementation only returned data for the main company.

How it was improved:

Describes how the refactor ensures results are retrieved from all active companies.