### PR TITLE
[IMP] Set default foreign currency payment policy for AR companies on install

### DIFF
--- a/l10n_ar_edi_ux/__init__.py
+++ b/l10n_ar_edi_ux/__init__.py
@@ -5,3 +5,15 @@
 from . import models
 from . import wizards
 from .monkey_patches import monkey_patches
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def post_init_hook(env):
+    ar_companies = env["res.company"].search([]).filtered(lambda x: x.country_id.code == "AR")
+    for company in ar_companies:
+        logger.info("Set default foreign currency payment policy for AR companies on install")
+        key = f"l10n_ar_edi.{company.id}_foreign_currency_payment"
+        env["ir.config_parameter"].sudo().set_param(key, "account")

--- a/l10n_ar_edi_ux/__manifest__.py
+++ b/l10n_ar_edi_ux/__manifest__.py
@@ -26,5 +26,6 @@
     "installable": True,
     "auto_install": True,
     "application": False,
+    "post_init_hook": "post_init_hook",
     "post_load": "monkey_patches",
 }

--- a/l10n_ar_edi_ux/models/__init__.py
+++ b/l10n_ar_edi_ux/models/__init__.py
@@ -8,3 +8,4 @@ from . import account_move
 from . import account_journal
 from . import l10n_ar_boarding_permission
 from . import res_config_settings
+from . import res_company

--- a/l10n_ar_edi_ux/models/res_company.py
+++ b/l10n_ar_edi_ux/models/res_company.py
@@ -1,0 +1,14 @@
+from odoo import api, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        companies = super().create(vals_list)
+        for company in companies:
+            if company.country_id.code == "AR":
+                key = f"l10n_ar_edi.{company.id}_foreign_currency_payment"
+                self.env["ir.config_parameter"].sudo().set_param(key, "account")
+        return companies


### PR DESCRIPTION


This commit adds a post-init hook that sets the default value of the 'l10n_ar_payment_foreign_currency' field to 'account' for all Argentinian companies upon module installation.

This ensures the correct default behavior is applied without requiring manual configuration after installation.