### PR TITLE
[FIX] l10n_ar_edi_ux: Obtener Tipos de Documents

### DIFF
--- a/l10n_ar_edi_ux/models/account_journal.py
+++ b/l10n_ar_edi_ux/models/account_journal.py
@@ -31,11 +31,12 @@ class AccountJournal(models.Model):
 
     def _format_afip_doc_types(self, ws, response):
         """ Given the response and the Webservice used, returns a more legible message to be shown to the users. """
+        events = False
         if ws == 'wsfe':
             if response['Errors']:
                 raise UserError(response['Errors'])
             elif response['Events']:
-                raise UserError(response['Events'])
+                events = str(response['Events'])
             result_key = 'ResultGet'
             voucher_key = 'CbteTipo'
             id_key = 'Id'
@@ -48,8 +49,7 @@ class AccountJournal(models.Model):
             if response[error_key]['ErrMsg'] != 'OK':
                 raise UserError(response[error_key]['ErrMsg'])
             elif response[events_key]['EventMsg'] != 'Ok':
-                raise UserError(response[events_key]['EventMsg'])
-
+                events = str(response[events_key]['EventMsg'])
             result_key = 'FEXResultGet' if ws == 'wsfex' else 'BFEResultGet'
             voucher_key = 'ClsFEXResponse_Cbte_Tipo' if ws == 'wsfex' else 'ClsBFEResponse_Tipo_Cbte'
             id_key = 'Cbte_Id'
@@ -65,6 +65,8 @@ class AccountJournal(models.Model):
                 date_to = format_date(self.env, datetime.datetime.strptime(document[date_to_key], '%Y%m%d'), date_format='dd/MM/Y')
                 line += " hasta: " + date_to
             msg += line + "\n"
+        if events:
+            msg += "\n\nAdicional AFIP devuelve este evento: " + events
         return msg
 
     @api.depends('l10n_latam_manual_checks')


### PR DESCRIPTION
Si hay un evento de AFIP disponible, no permite checar la info de los tipos de documentos disponibles. Lo cambiamos para que ahora salgan ambos datos

Ticket 91663