### PR TITLE
[FIX] l10n_ar_currency_update: Fix currency update interval unit is "weekly" or "monthly"

### DIFF
--- a/l10n_ar_currency_update/models/res_company.py
+++ b/l10n_ar_currency_update/models/res_company.py
@@ -43,30 +43,50 @@ class ResCompany(models.Model):
     def re_check_afip_currency_rate(self):
         """If afip provider and set interval unit daily then check the
         currency multiple times at day (in case the default odoo cron couldn't
-        update the currency with AFIP)"""
+        update the currency with AFIP). Also check for weekly and monthly
+        interval units."""
         today = fields.Date.context_today(self.with_context(tz="America/Argentina/Buenos_Aires"))
-        records = self.search(
+        # Daily
+        self._filter_recheck_afip_currency_rate_companies(
+            currency_interval_unit="daily", l10n_ar_last_currency_sync_date=today
+        )
+        # Weekly
+        last_seven_days = today - relativedelta(days=7)
+        self._filter_recheck_afip_currency_rate_companies(
+            currency_interval_unit="weekly",
+            l10n_ar_last_currency_sync_date=last_seven_days,
+            l10n_ar_force_create_rate=True,
+        )
+        # Monthly
+        last_month = today - relativedelta(months=1)
+        self._filter_recheck_afip_currency_rate_companies(
+            currency_interval_unit="monthly", l10n_ar_last_currency_sync_date=last_month, l10n_ar_force_create_rate=True
+        )
+
+    def _filter_recheck_afip_currency_rate_companies(
+        self, currency_interval_unit, l10n_ar_last_currency_sync_date, l10n_ar_force_create_rate=False
+    ):
+        """Filters companies that use the 'afip' currency provider and require a currency rate update,
+        based on the provided interval unit and last sync date. If applicable, triggers the rate update."""
+        self.search(
             [
                 ("currency_provider", "=", "afip"),
-                ("currency_interval_unit", "not in", [False, "manually"]),
+                ("currency_interval_unit", "=", currency_interval_unit),
                 "|",
-                ("l10n_ar_last_currency_sync_date", "<", today),
+                ("l10n_ar_last_currency_sync_date", "<", l10n_ar_last_currency_sync_date),
                 ("l10n_ar_last_currency_sync_date", "=", False),
             ]
-        )
-        records.filtered(
-            lambda record: record.currency_interval_unit == "daily"
-            or record.l10n_ar_last_currency_sync_date == False
-            or record.currency_interval_unit == "weekly"
-            and (today - record.l10n_ar_last_currency_sync_date).days >= 7
-            or record.currency_interval_unit == "monthly"
-            and relativedelta(today, record.l10n_ar_last_currency_sync_date).months >= 1
-        ).update_currency_rates()
+        ).with_context(l10n_ar_force_create_rate=l10n_ar_force_create_rate).update_currency_rates()
+
+    def update_currency_rates(self):
+        """When the first cron 'Currency: rate update' runs, we only need to update the rates for Argentine companies that have a daily update interval. If the interval is weekly or monthly, the rates will be updated in the second cron 'Currency: Re Check Afip Currency Rate'."""
+        if not self.env.context.get("l10n_ar_force_create_rate"):
+            self = self.filtered(lambda c: c.currency_interval_unit == "daily")
+        super(ResCompany, self).update_currency_rates()
 
     def _parse_afip_data(self, available_currencies):
         """This method is used to update the currency rates using AFIP provider. Rates are given against AR"""
         res = {}
-
         currency_ars = self.env.ref("base.ARS")
         today = fields.Date.context_today(self.with_context(tz="America/Argentina/Buenos_Aires"))
         if currency_ars in available_currencies:
@@ -74,21 +94,21 @@ class ResCompany(models.Model):
         available_currencies = available_currencies.filtered("l10n_ar_afip_code") - currency_ars
         rate_date = today
 
+        valid_certificate = (
+            self.env["certificate.certificate"]
+            .search([("active", "=", True), ("date_end", ">=", today)])
+            .filtered(lambda c: c.country_code == "AR")
+        )
+        if self.l10n_ar_afip_ws_crt_id in valid_certificate:
+            company = self
+        else:
+            company = valid_certificate[:1].company_id if valid_certificate else False
+        if not company:
+            _logger.log(25, "No pudimos encontrar compañía con certificados de AFIP validos")
+            return False
+        env_company = self.env.company
+        self.env.company = company
         for currency in available_currencies:
-            valid_certificate = (
-                self.env["certificate.certificate"]
-                .search([("active", "=", True), ("date_end", ">=", today)])
-                .filtered(lambda c: c.country_code == "AR")
-            )
-            if self.env.company.l10n_ar_afip_ws_crt_id in valid_certificate:
-                company = self.env.company
-            else:
-                company = valid_certificate[:1].company_id if valid_certificate else False
-            if not company:
-                _logger.log(25, "No pudimos encontrar compañía con certificados de AFIP validos")
-                return False
-            env_company = self.env.company
-            self.env.company = company
             try:
                 # Obtain the currencies to be updated
                 _logger.log(25, "Connecting to AFIP to update the currency rates for %s", currency.name)
@@ -96,7 +116,7 @@ class ResCompany(models.Model):
                 # Do not pass company since we need to find the one that has certificate
                 afip_date, rate = currency._l10n_ar_get_afip_ws_currency_rate()
                 afip_date = datetime.strptime(afip_date, "%Y%m%d").date() + relativedelta(days=1)
-                if afip_date == rate_date:
+                if afip_date == rate_date or self.env.context.get("l10n_ar_force_create_rate"):
                     res.update({currency.name: (1.0 / rate, rate_date)})
                     _logger.log(25, "Currency %s %s %s", currency.name, rate_date, rate)
                 else:


### PR DESCRIPTION
Actualmente no está funcionando correctamente la actualización automática de monedas en Odoo para Argentina cuando el intervalo de actualización es semanal o mensual. Por ejemplo: si la actualización es mensual el cron para actualizar la tasa se va a correr una vez por mes pero si no hay cotización para el día en el cual se corre el cron de actualización de monedas entonces no se crea. Este pr lo corrige.
Lo que hacemos es que en el primer cron "Currency: rate update" solamente se actualice la tasa para las compañías que tienen configurado el intervalo en "diario". Luego, en un segundo cron "Currency: rate update (others)" se actualizan las tasas para las compañías que tienen configurado el intervalo en "semanal" o "mensual". De esta forma nos aseguramos que si la compañía tiene configurado un intervalo mayor a diario, la tasa se actualice solamente cuando corresponda.
Task Adhoc side: 52605