### PR TITLE
[BFW] Backport: [FIX] account_accountant_ux: Fix in filter amount in the reconciliation widget

### DIFF
--- a/account_accountant_ux/models/account_move_line.py
+++ b/account_accountant_ux/models/account_move_line.py
@@ -24,14 +24,16 @@ class AccountMovetLine(models.Model):
                 amount_currency = statement_line['amount']
 
             if value != 0 and operator == '=':
-                base_amount = ((100 - value)/100) * amount
-                top_amount = ((100 + value)/100) * amount
-                base_amount_currency = ((100 - value)/100) * amount_currency
-                top_amount_currency = ((100 + value)/100) * amount_currency
-                res += osv.expression.OR([
-                    [('amount_residual', '>',  base_amount),('amount_residual', '<',  top_amount)],
-                    [('amount_residual_currency', '>',  base_amount_currency),('amount_residual_currency', '<',  top_amount_currency)]
-                ])
+                if primary_currency:
+                    base_amount = ((100 - value)/100) * amount
+                    top_amount = ((100 + value)/100) * amount
+                    res.append(('amount_residual', '>',  base_amount))
+                    res.append(('amount_residual', '<',  top_amount))
+                else:
+                    base_amount = ((100 - value)/100) * amount_currency
+                    top_amount = ((100 + value)/100) * amount_currency
+                    res.append(('amount_residual_currency', '>',  base_amount))
+                    res.append(('amount_residual_currency', '<',  top_amount))
             else:
                 amount = ((100 - value)/100) * amount
                 amount_currency = ((100 - value)/100) * amount_currency
@@ -39,5 +41,5 @@ class AccountMovetLine(models.Model):
                 if primary_currency:
                     res.append(('amount_residual', operator,  amount))
                 else:
-                    res.append(('amount_residual', operator,  amount_currency))
+                    res.append(('amount_residual_currency', operator,  amount_currency))
         return res


### PR DESCRIPTION


commit https://github.com/ingadhoc/odoo-argentina-ee/commit/f072efe28f0633650ff909e694638439c6999a71

This commit fixes the logic of the amount filter in the reconciliation widget. It was not working correctly when dealing with transactions in a secondary currency, causing incorrect matching or missing matches.