### PR TITLE
[FIX] l10n_ar_account_tax_settlement: vat on sicore txt.

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -1278,7 +1278,7 @@ class AccountJournal(models.Model):
             content += "%02d" % int(partner.l10n_latam_identification_type_id.l10n_ar_afip_code)
 
             # Numero Documento Retenido      [20]
-            content += partner.vat.ljust(20)
+            content += partner.l10n_ar_vat.ljust(20)
 
             # Numero Certificado Original    [14]
             content += "%014d" % 0  # TODO: ????


### PR DESCRIPTION
Ticket: 94960
En el archivo txt de sicore hay que informar el campo Numero Documento Retenido sin guiones. Por ejemplo: si tengo cuit 20-12345678-9, en el txt debe ir 20123456789. De lo contrario al subir el archivo al aplicativo solamente se van a tener en cuenta los dos primeros dígitos del cuit y el resto se ignorará.

https://www.afip.gob.ar/aplicativos/oProgramasImpositivos/documentos/dit.sicore.AP_INS_sicore-50.pdf  --> ver página 16 "Los números de CUIT, CUIL o CDI, deben importarse sin guiones."