### PR TITLE
[ADD] l10n_ar_edi_ux, l10n_ar_currency_update: Re use AFIP connection

### DIFF
--- a/l10n_ar_currency_update/models/res_company.py
+++ b/l10n_ar_currency_update/models/res_company.py
@@ -63,6 +63,40 @@ class ResCompany(models.Model):
             and relativedelta(today, record.l10n_ar_last_currency_sync_date).months >= 1
         ).update_currency_rates()
 
+    def _find_company_with_ws_connection(self, today, arca_ws):
+        """Find a company with a valid ARCA certificate and that have a valid connection to the given webservice.
+
+        This way all the AR companies can sync the rate if at least one have a valid certificate and webservice
+        connection.
+
+        Args:
+            today (date): The current date.
+            arca_ws (str): The web service to use
+        Returns:
+            res.company or False: A company with a valid certificate (and webservice if given)
+            or False if none found.
+        """
+        def get_connection(company, arca_ws):
+            connection = False
+            try:
+                connection = company._l10n_ar_get_connection(arca_ws)
+            except UserError:
+                pass
+            return connection
+
+        company = self.env.company
+        connection = get_connection(company, arca_ws)
+        if not connection:
+            companies_w_valid_cert = self.env['res.company'].search(
+                [('l10n_ar_afip_ws_crt', '!=', False), ('l10n_ar_crt_exp_date', '>', today)])
+
+            for other_company in companies_w_valid_cert - company:
+                connection = get_connection(other_company, arca_ws)
+                if connection:
+                    return connection.company_id
+
+        return False
+
     def _parse_afip_data(self, available_currencies):
         """This method is used to update the currency rates using AFIP provider. Rates are given against AR"""
         res = {}
@@ -73,22 +107,15 @@ class ResCompany(models.Model):
             res[currency_ars.name] = (1.0, today)
         available_currencies = available_currencies.filtered("l10n_ar_afip_code") - currency_ars
         rate_date = today
+        ws_company = self._find_company_with_ws_connection(today, "wsfe")
+        if not ws_company:
+            _logger.log(25, "No pudimos encontrar compañía con certificado/conexion a AFIP validos")
+            return False
+
+        env_company = self.env.company
+        self.env.company = ws_company
 
         for currency in available_currencies:
-            valid_certificate = (
-                self.env["certificate.certificate"]
-                .search([("active", "=", True), ("date_end", ">=", today)])
-                .filtered(lambda c: c.country_code == "AR")
-            )
-            if self.env.company.l10n_ar_afip_ws_crt_id in valid_certificate:
-                company = self.env.company
-            else:
-                company = valid_certificate[:1].company_id if valid_certificate else False
-            if not company:
-                _logger.log(25, "No pudimos encontrar compañía con certificados de AFIP validos")
-                return False
-            env_company = self.env.company
-            self.env.company = company
             try:
                 # Obtain the currencies to be updated
                 _logger.log(25, "Connecting to AFIP to update the currency rates for %s", currency.name)
@@ -104,15 +131,14 @@ class ResCompany(models.Model):
                         "Returned Afip rate is not today's rate (%s, %s vs %s, %s)"
                         % (afip_date.strftime("%A"), afip_date, rate_date.strftime("%A"), rate_date)
                     )
-                self.env.company = env_company
             except Exception as e:
-                self.env.company = env_company
                 _logger.log(25, "Could not get rate for currency %s. This is what we get:\n%s", currency.name, e)
-            else:
-                for company in self.filtered(lambda x: x.currency_provider == "afip"):
-                    company.l10n_ar_last_currency_sync_date = fields.Date.context_today(
-                        self.with_context(tz="America/Argentina/Buenos_Aires")
-                    )
+
+            self.env.company = env_company
+            if res:
+                self.l10n_ar_last_currency_sync_date = fields.Date.context_today(
+                    self.with_context(tz="America/Argentina/Buenos_Aires"))
+
         return res or False
 
     def _generate_currency_rates(self, parsed_data):

--- a/l10n_ar_edi_ux/__manifest__.py
+++ b/l10n_ar_edi_ux/__manifest__.py
@@ -10,6 +10,7 @@
     "depends": [
         "l10n_ar_ux",
         "l10n_ar_edi",
+        "l10n_ar_currency_update",
         "account_accountant",
     ],
     "data": [

--- a/l10n_ar_edi_ux/models/res_partner.py
+++ b/l10n_ar_edi_ux/models/res_partner.py
@@ -108,27 +108,25 @@ class ResPartner(models.Model):
     def get_data_from_padron_afip(self):  # noqa: C901
         self.ensure_one()
         vat = self.ensure_vat()
-
-        # if there is certificate for current company use that one, if not use the company with first certificate found
-        today = fields.Date.context_today(self.with_context(tz="America/Argentina/Buenos_Aires"))
-        valid_certificate = (
-            self.env["certificate.certificate"]
-            .sudo()
-            .search([("active", "=", True), ("date_end", ">=", today)])
-            .filtered(lambda c: c.country_code == "AR")
-        )
-        if self.env.company.sudo().l10n_ar_afip_ws_crt_id in valid_certificate:
-            company = self.env.company
-        else:
-            company = valid_certificate[:1].company_id if valid_certificate else False
-        if not company:
-            raise UserError(_("Please configure an AFIP Certificate in order to continue"))
-        client, auth = company._l10n_ar_get_connection("ws_sr_constancia_inscripcion")._get_client()
-
         error_msg = _(
             "No pudimos actualizar desde padron afip al partner %s (%s).\nRecomendamos verificar manualmente en la"
             " página de AFIP.\nObtuvimos este error:\n%s"
         )
+
+        # if there is certificate valid to connect to padron for current company use that one, if not find the company
+        # that have a valid connection
+        if ws_company := self.env.company_id._find_company_with_ws_connection(
+            fields.Date.context_today(self.with_context(tz="America/Argentina/Buenos_Aires")),
+            "ws_sr_constancia_inscripcion",
+        ):
+            client, auth = ws_company._l10n_ar_get_connection("ws_sr_constancia_inscripcion")._get_client()
+        else:
+            raise UserError(
+                _(
+                    "Please configure a valid AFIP Certificate with connection to"
+                    " ws_sr_constancia_inscripcion in order to continue"
+                )
+            )
 
         errors = []
         values = {}


### PR DESCRIPTION
**Update From Padron AFIP** and "**Currency rate sincronization** are only working if:

* my logged company has a valid certificate and connection to ws_sr_constancia_inscripcion/wsbe webservice
* my logged company has not certificate and there is only ONE other company with certificate and a valid connection to the
  wsbe/ws_sr_constancia_inscripcion webservices.

This PR changes the logic to always try to find a company that actually can connect to the webserive and use that one in order
to connect to AFIP, avoiding trying to connect with an invalid connection which results on not working padron an rate syncronization (mostly silence errors)
