### PR TITLE
[IMP] l10n_ar_account_tax_settlement, l10n_ar_tax_settlement_backward_comp: Importe otros conceptos en txt agip en pagos migrados. Impuesto en apunte contable

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -581,6 +581,24 @@ class AccountJournal(models.Model):
                 # solo en comprobantes A, M segun especificacion
                 vat_amount = 0.0
                 total_amount = float_round(payment.move_id.amount_total_in_currency_signed, precision_digits=2)
+                if payment.is_backward_withholding_payment:
+                    # Buscamos los payments sin retención que vienen migrados de la versión anterior y le sumamos
+                    # el amount total de los mismos (move_id.amount_total_in_currency_signed) al total_amount de la
+                    # retención. Esto lo hacemos porque en la migración de 16 a 18 se migran los pagos y las retenciones
+                    # por separado a diferencia de 16 que estaba todo en el mismo asiento.
+                    related_payments = self.env["account.payment"].search(
+                        [
+                            ("name", "=", payment.name),
+                            ("company_id", "=", payment.company_id.id),
+                            ("partner_id", "=", payment.partner_id.id),
+                            ("id", "!=", payment.id),
+                            ("state", "in", ["paid", "in_process"]),
+                        ]
+                    )
+                    if related_payments:
+                        total_amount += float_round(
+                            sum(related_payments.mapped("move_id.amount_total_in_currency_signed")), precision_digits=2
+                        )
                 # es lo mismo que payment_group.matched_amount_untaxed
                 taxable_amount = float_round(line.withholding_id.base_amount, precision_digits=2)
 

--- a/l10n_ar_tax_settlement_backward_comp/models/account_move_line.py
+++ b/l10n_ar_tax_settlement_backward_comp/models/account_move_line.py
@@ -10,6 +10,10 @@ class AccountMoveLine(models.Model):
             # si tiene vinculada retencion y la misma tiene regime_tax_id es una retencion de ganancias migrada
             # devolvemos ese impuesto, si no, devolvemos el impuesto de la linea
             return self.withholding_id.regime_tax_id or self.tax_line_id
+        if self.tax_line_id.active:
+            # Si el impuesto del apunte está activo entonces no fue migrado (el apunte fue creado en la nueva versión)
+            # por lo tanto devolvemos el impuesto del apunte y no lo buscamos en el contacto
+            return self.tax_line_id
         is_perception = self.move_id.is_invoice()
         partner_field = (
             self.partner_id.l10n_ar_partner_perception_ids if is_perception else self.partner_id.l10n_ar_partner_tax_ids


### PR DESCRIPTION
Commit 1) l10n_ar_account_tax_settlement: Buscamos los payments sin retención que vienen migrados de la versión anterior y le sumamos el amount total de los mismos (move_id.amount_total_in_currency_signed) al total_amount de la retención. Esto lo hacemos porque en la migración de 16 a 18 se migran los pagos y las retenciones por separado a diferencia de 16 que estaba todo en el mismo asiento.
Commit 2) l10n_ar_tax_settlement_backward_comp: Si el impuesto del apunte está activo entonces no fue migrado (el apunte fue creado en la nueva versión) por lo tanto devolvemos el impuesto del apunte y no lo buscamos en el contacto al momento de generar txt de impuestos.
Explicación de los cambios: https://app.screencastify.com/watch/QqTioopqRZExw8KcZNFv (comparto enlace de drive por las dudas https://drive.google.com/file/d/1QENDDYSkgZhcRc254YsCBEMlel-1ZzFn/view )
Ticket Adhoc side: 100241