### PR TITLE
[IMP] l10n_ar_tax_settlement_backward_comp: impuesto en apunte contable

### DIFF
--- a/l10n_ar_tax_settlement_backward_comp/models/account_move_line.py
+++ b/l10n_ar_tax_settlement_backward_comp/models/account_move_line.py
@@ -10,6 +10,10 @@ class AccountMoveLine(models.Model):
             # si tiene vinculada retencion y la misma tiene regime_tax_id es una retencion de ganancias migrada
             # devolvemos ese impuesto, si no, devolvemos el impuesto de la linea
             return self.withholding_id.regime_tax_id or self.tax_line_id
+        if self.tax_line_id.active:
+            # Si el impuesto del apunte está activo entonces no fue migrado (el apunte fue creado en la nueva versión)
+            # por lo tanto devolvemos el impuesto del apunte y no lo buscamos en el contacto
+            return self.tax_line_id
         is_perception = self.move_id.is_invoice()
         partner_field = (
             self.partner_id.l10n_ar_partner_perception_ids if is_perception else self.partner_id.l10n_ar_partner_tax_ids


### PR DESCRIPTION
Si el impuesto del apunte está activo entonces no fue migrado (el apunte fue creado en la nueva versión) por lo tanto devolvemos el impuesto del apunte y no lo buscamos en el contacto al momento de generar txt de impuestos. Explicación de los cambios: https://app.screencastify.com/watch/QqTioopqRZExw8KcZNFv (comparto enlace de drive por las dudas https://drive.google.com/file/d/1QENDDYSkgZhcRc254YsCBEMlel-1ZzFn/view ).
Ticket Adhoc side: 100241