### PR TITLE
[FIX] l10n_ar_currency_update: tasa de recargo por compañía

### DIFF
--- a/l10n_ar_currency_update/models/res_company.py
+++ b/l10n_ar_currency_update/models/res_company.py
@@ -122,7 +122,12 @@ class ResCompany(models.Model):
         """
         currency_rate = self.env["res.currency.rate"]
         currency_object = self.env["res.currency"]
-        for company in self.filtered(lambda x: x.currency_provider == "afip" and (x.rate_surcharge or x.rate_perc)):
+        companies_with_surcharge = self.filtered(
+            lambda x: x.currency_provider == "afip" and (x.rate_surcharge or x.rate_perc)
+        )
+        for company in companies_with_surcharge:
+            # Hacemos una copia del diccionario por cada compañía para no modificar el original
+            new_parsed_data = parsed_data.copy()
             for currency, (rate, date_rate) in parsed_data.items():
                 already_existing_rate = currency_rate.search(
                     [
@@ -136,6 +141,6 @@ class ResCompany(models.Model):
                     rate = rate * (1.0 + (company.rate_perc or 0.0))
                     rate += company.rate_surcharge or 0.0
                     rate = 1.0 / rate
-                    parsed_data[currency] = (rate, date_rate)
-
-        super()._generate_currency_rates(parsed_data)
+                    new_parsed_data[currency] = (rate, date_rate)
+            super(ResCompany, company)._generate_currency_rates(new_parsed_data)
+        super(ResCompany, self - companies_with_surcharge)._generate_currency_rates(parsed_data)


### PR DESCRIPTION
Ticket: 101786
Si hay varias compañías argentinas con tasa de recargo entonces al crear las cotizaciones para cada moneda la cotización se termina capitalizando (se acumula la tasa de cada compañía) lo cual es incorrecto. Este commit soluciona el problema haciendo una copia del diccionario de cotizaciones para cada compañía y aplicar los recargos sobre esa copia para cada compañía.