### PR TITLE
[FIX] l10n_ar_account_tax_settlement: bug al descargar txt sicore.

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -1275,7 +1275,7 @@ class AccountJournal(models.Model):
                         codcond = "13" if tax.amount == 3 else "14"
                     # Si el código de régimen es 214 entonces el código de condición debe ser '00'.
                     # Más información en archivo l10n_ar_account_tax_settlement/data/relaciones-codigos-sicore.csv
-                    if line.l10n_ar_code == "214":
+                    if tax.l10n_ar_code == "214":
                         codcond = "00"
             else:
                 # Percepción de IVA


### PR DESCRIPTION
Ticket Adhoc side: 102281
Al descargar el txt de sicore, se produce un error y es porque el modelo account.move.line no tiene el campo l10n_ar_code, pertenece al modelo account.tax.