### PR TITLE
[FIX] l10n_ar_currency_update: remove __init__.py test file to fix "ci/runbot-modified-modules"

### DIFF
--- a/l10n_ar_currency_update/tests/__init__.py
+++ b/l10n_ar_currency_update/tests/__init__.py
@@ -1,5 +1,0 @@
-##############################################################################
-# For copyright and license notices, see __manifest__.py file in module root
-# directory
-##############################################################################
-# from . import test_l10n_ar_currency_update


### PR DESCRIPTION
Temporalmente removemos el archivo l10n_ar_currency_update/tests/__init__.py porque hacía que falle el check de runbot "ci/runbot-modified-modules" porque no se estaban corriendo los tests automáticamente del módulo l10n_ar_currency_update. Se crea tarea 59148 para volver a agregar el archivo y hacer que funcionen los tests automáticamente sin que falle el check "ci/runbot-modified-modules" de runbot. El hecho de que falle "ci/runbot-modified-modules" hace que no se cree la instancia de "ci/runbot-oba".
Task Adhoc side: 52605