### PR TITLE
[FIX] l10n_ar_account_tax_settlement: descargar txt de agip sin problemas de redondeo

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -438,6 +438,9 @@ class AccountJournal(models.Model):
         credito = ""
 
         company_currency = self.company_id.currency_id
+        backward_comp_is_installed = self.env["ir.module.module"].search(
+            [("name", "=", "l10n_ar_tax_settlement_backward_comp"), ("state", "=", "installed")]
+        )
         for line in move_lines.sorted("date"):
             # pay_group = payment.payment_group_id
             move = line.move_id
@@ -580,8 +583,15 @@ class AccountJournal(models.Model):
             if payment:
                 # solo en comprobantes A, M segun especificacion
                 vat_amount = 0.0
+                # es lo mismo que payment_group.matched_amount_untaxed
+                taxable_amount = float_round(line.withholding_id.base_amount, precision_digits=2)
+                rounded_withholding = float_round((taxable_amount * alicuot / 100), precision_digits=2)
+                # TODO en febrero 2026 sacar el if de abajo (más información en tarea 59174).
+                # Hacer revert de https://github.com/ingadhoc/odoo-argentina-ee/pull/743 en febrero 2026
                 total_amount = float_round(payment.move_id.amount_total_in_currency_signed, precision_digits=2)
-                if payment.is_backward_withholding_payment:
+                if rounded_withholding != -line.balance:
+                    total_amount = float_round(total_amount + line.balance + rounded_withholding, precision_digits=2)
+                if backward_comp_is_installed and payment.is_backward_withholding_payment:
                     # Buscamos los payments sin retención que vienen migrados de la versión anterior y le sumamos
                     # el amount total de los mismos (move_id.amount_total_in_currency_signed) al total_amount de la
                     # retención. Esto lo hacemos porque en la migración de 16 a 18 se migran los pagos y las retenciones
@@ -599,8 +609,6 @@ class AccountJournal(models.Model):
                         total_amount += float_round(
                             sum(related_payments.mapped("move_id.amount_total_in_currency_signed")), precision_digits=2
                         )
-                # es lo mismo que payment_group.matched_amount_untaxed
-                taxable_amount = float_round(line.withholding_id.base_amount, precision_digits=2)
 
                 # lo sacamos por diferencia
                 other_taxes_amount = company_currency.round(total_amount - taxable_amount - vat_amount)
@@ -706,8 +714,16 @@ class AccountJournal(models.Model):
 
             # si la línea tiene moneda diferente de la moneda de la compañía queremos que la ret/perc
             # se calcule aplicando la alícuota sobre la base imponible en la moneda de la compañía
-            if line.currency_id and line.currency_id != line.company_id.currency_id:
-                ret_perc_applied = float_round((taxable_amount * alicuot / 100), precision_digits=2)
+            # TODO en febrero 2026 sacar lo que está a la derecha del "or" del if de abajo
+            # (más información en tarea 59174).
+            # Hacer revert de esto https://github.com/ingadhoc/odoo-argentina-ee/pull/743 en febrero 2026
+            rounded_ret_perc_applied = float_round((taxable_amount * alicuot / 100), precision_digits=2)
+            if (
+                line.currency_id
+                and line.currency_id != line.company_id.currency_id
+                or rounded_ret_perc_applied != -line.balance
+            ):
+                ret_perc_applied = rounded_ret_perc_applied
             content += format_amount((-line.balance if not ret_perc_applied else ret_perc_applied), 16, 2, ",")
 
             # 21 - Monto Total Retenido/Percibido

--- a/l10n_ar_account_tax_settlement/models/account_move_line.py
+++ b/l10n_ar_account_tax_settlement/models/account_move_line.py
@@ -4,8 +4,12 @@ from odoo import models
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
-    def _get_settlement_tax(self):
+    def _get_settlement_tax(self, date=None):
         """Método puente para poder usar l10n_ar_tax_settlement_backward_comp
-        Deprecar este método cuando se deprecie con l10n_ar_tax_settlement_backward_comp."""
+        Deprecar este método cuando se deprecie con l10n_ar_tax_settlement_backward_comp.
+        El parámetro date es porque si la base no tiene instalado l10n_ar_tax_settlement_backward_comp
+        entonces va a arrojar error si en alguna llamada al método se le pasa date.
+        Ejemplo: método iibb_aplicado_agip_files_values de account_tax en módulo
+        l10n_ar_account_tax_settlement hace la llamada tax = line._get_settlement_tax(date=date)"""
         self.ensure_one()
         return self.tax_line_id


### PR DESCRIPTION
Tarea Adhoc: 59174
Este pr es un parche temporal que lo podemos borrar en febrero 2026 (es una fecha tentativa y aproximada, en dicha fecha podemos hacer revert de este pr). Tenemos un bug de redondeo en 18 al calcular retenciones argentinas reportado en 101778 "[19.0] account, l10n_ar_withholding: wrong withholding amount by rounding issue". Aplicamos un parche en tarea 59152 "[18+] l10n_ar_withholding: parche redondeo en retenciones (un centavo)" para que se calcule la retención correctamente (hasta que solucione el problema odoo). Pero como hasta el día de hoy 22/10/2025 hay bases que seguramente ya tienen registradas retenciones con el error de redondeo entonces cuando vayan a descargar el txt correspondiente el aplicativo les va a arrojar error, tal como pasó en ticket 100241 "v18 - archivo TXT" entonces para evitar ese error al momento de la descarga del txt (iibb_aplicado_agip) se crea este pr para que se descargue bien el txt. Este parche lo vamos a sacar en 4 meses aprox porque ya se supone que con el primer parche que comenté no van a cargar más retenciones con problema de redondeo entonces los txt de los próximos meses van a ser correctamente descargados. En este pr lo que hacemos es que en el txt de agip (iibb_aplicado_agip) si el redondeo es incorrecto entonces calculamos nosotros el importe de retención con redondeo correcto y lo ponemos en el txt, de esta forma evitamos el error en la descarga del txt.