### PR TITLE
[FIX] l10n_ar_edi_ux: correct super() call in _l10n_ar_do_afip_ws_request_cae

### DIFF
--- a/l10n_ar_edi_ux/models/account_move.py
+++ b/l10n_ar_edi_ux/models/account_move.py
@@ -79,7 +79,7 @@ class AccountMove(models.Model):
         """Check if the partner has CondicionIVAReceptorId configured."""
         for inv in self.filtered(lambda x: x.journal_id.l10n_ar_afip_ws and not x.l10n_ar_afip_auth_code):
             inv._check_vat_condition()
-            super(AccountMove, inv)._l10n_ar_do_afip_ws_request_cae(client, auth, transport)
+        return super()._l10n_ar_do_afip_ws_request_cae(client, auth, transport)
 
     def _post(self, soft=True):
         """Be able to validate electronic vendor bills that are type AFIP POS"""


### PR DESCRIPTION
Ticket Adhoc side: 102349
Se arregla bug introducido en https://github.com/ingadhoc/odoo-argentina-ee/pull/696
Se estaba llamando mal al super del método _l10n_ar_do_afip_ws_request_cae, lo que hace que no se retorne el error de arca (si existe) al momento de publicar facturas electrónicas.