### PR TITLE
[IMP] l10n_ar_currency_update: Reincorporate unit test for currency update

### DIFF
--- a/l10n_ar_currency_update/tests/__init__.py
+++ b/l10n_ar_currency_update/tests/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import test_l10n_ar_currency_update

--- a/l10n_ar_currency_update/tests/test_l10n_ar_currency_update.py
+++ b/l10n_ar_currency_update/tests/test_l10n_ar_currency_update.py
@@ -3,12 +3,13 @@
 # directory
 ##############################################################################
 import datetime
-from unittest import mock
 from unittest.mock import patch
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
 
 
+@tagged("post_install", "-at_install")
 class TestL10nArCurrencyUpdate(AccountTestInvoicingCommon):
 
     @classmethod


### PR DESCRIPTION
Task Adhoc side: 59148
Reagregamos el test unitario que habíamos sacado acá https://github.com/ingadhoc/odoo-argentina-ee/pull/739 y lo ajustamos para que funcione y no de error el check de runbot "ci/runbot-modified-modules"