### PR TITLE
[FIX] account_tax_settlement: retenciones en borrador (líneas a liquidar)

### DIFF
--- a/account_tax_settlement/__manifest__.py
+++ b/account_tax_settlement/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Tax Settlement",
-    "version": "18.0.1.1.0",
+    "version": "18.0.1.2.0",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",

--- a/account_tax_settlement/migrations/18.0.1.2.0/post-migration.py
+++ b/account_tax_settlement/migrations/18.0.1.2.0/post-migration.py
@@ -1,0 +1,11 @@
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    """
+    Computar el tax_state de aquellos apuntes contables de impuestos que están en borrador. Si el asiento está en borrador entonces el tax_state debe ser False.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env.ref["account.move.line"].search(
+        [("parent_state", "=", "draft"), ("tax_state", "!=", False)]
+    )._compute_tax_state()

--- a/account_tax_settlement/models/account_move_line.py
+++ b/account_tax_settlement/models/account_move_line.py
@@ -76,13 +76,10 @@ class AccountMoveLine(models.Model):
         move = journal.create_tax_settlement_entry(self)
         return move
 
-    @api.depends(
-        "tax_repartition_line_id",
-        "tax_settlement_move_id.line_ids.full_reconcile_id",
-    )
+    @api.depends("tax_repartition_line_id", "tax_settlement_move_id.line_ids.full_reconcile_id", "parent_state")
     def _compute_tax_state(self):
         for rec in self:
-            if not rec.tax_repartition_line_id:
+            if not rec.tax_repartition_line_id or rec.parent_state == "draft":
                 state = False
             elif not rec.tax_settlement_move_id:
                 state = "to_settle"


### PR DESCRIPTION
Tarea: 45527
Cuando paso a borrador un pago con retención, el mismo se sigue viendo en la cantidad de líneas a liquidar en el diario de liquidación. Lo que hace este cambio es que si se pasa el pago a borrador entonces no sea incluída la retención en la cantidad de líneas a liquidar del diario de liquidación.