### PR TITLE
[FIX] l10n_ar_tax_settlement_backward_comp: correct taxes in Credit Note

### DIFF
--- a/l10n_ar_tax_settlement_backward_comp/models/__init__.py
+++ b/l10n_ar_tax_settlement_backward_comp/models/__init__.py
@@ -1,2 +1,3 @@
 from . import account_tax
 from . import account_move_line
+from . import account_move

--- a/l10n_ar_tax_settlement_backward_comp/models/account_move.py
+++ b/l10n_ar_tax_settlement_backward_comp/models/account_move.py
@@ -1,0 +1,45 @@
+from odoo import _, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def copy(self, default=None):
+        res = super().copy(default=default)
+        # para facturas que se duplican y:
+        # a) venian de la versión anterior
+        # b) y no tenian fp o la fp no tenía "percepciones argentinas"
+        # c) tiene impuestos con "is_backward_tax" archivados
+        # re-calculamos pa percepción desde partner tax
+        for rec in self.filtered(lambda m: m.is_sale_document() and not m.fiscal_position_id.l10n_ar_tax_ids):
+            backward_taxes = rec.line_ids.mapped("tax_line_id").filtered("is_backward_tax")
+            for bw_tax in backward_taxes:
+                if bw_tax.active:
+                    # if its active then is created in new version, so we skip it
+                    continue
+
+                partner_field = rec.partner_id.l10n_ar_partner_perception_ids
+                tax_line = rec.line_ids.filtered(lambda l: l.tax_line_id == bw_tax)[:1]
+
+                if partner_tax := partner_field.filtered(
+                    lambda x: x.company_id == tax_line.company_id
+                    and x.tax_id.l10n_ar_state_id == tax_line.tax_line_id.l10n_ar_state_id
+                    and (x.from_date <= tax_line.date if x.from_date else not x.from_date)
+                    and (x.to_date >= tax_line.date if x.to_date else not x.from_date)
+                ):
+                    for line in res.line_ids.filtered(lambda l: bw_tax in l.tax_ids):
+                        # remove backward tax and add partner tax
+                        line.tax_ids = [(3, bw_tax.id), (4, partner_tax.tax_id.id)]
+                else:
+                    for line in res.line_ids.filtered(lambda l: bw_tax in l.tax_ids):
+                        # just remove backward tax
+                        line.tax_ids = [(3, bw_tax.id)]
+                res.message_post(
+                    body=_(
+                        "The backward tax '%(tax_name)s (id: %(tax_id)s)' was removed from the copied move "
+                        "because there is no corresponding partner tax configured."
+                    )
+                    % {"tax_name": bw_tax.name, "tax_id": bw_tax.id},
+                )
+
+        return res


### PR DESCRIPTION
This commit inherits copy functionality from account_move to ensure that when a Credit Note is created from an Invoice, the tax lines are taken from partner settings instead of copying them from the original Invoice. This change addresses the issue where tax lines were incorrectly duplicated, leading to inaccurate tax settlements.