### PR TITLE
[IMP] l10n_ar_account_tax_settlement: ARBA archivos txt postergados al 01/03/2026

### DIFF
--- a/l10n_ar_account_tax_settlement/README.rst
+++ b/l10n_ar_account_tax_settlement/README.rst
@@ -34,7 +34,7 @@ Especificación de archivos:
 * SIFERE en xml web?: http://www.comarb.gov.ar/descargar/faqs/sifere_web/importacion_xml_sifereweb.pdf
 
 * ARBA:
-   * Archivos txt: https://web.arba.gov.ar/instructivo-y-marco-normativo (ese enlace se obtiene de https://web.arba.gov.ar/agentes#presentacion-de-ddjj , luego hay que ir a la sección "DDJJ Periódicas Web IIBB NOVEDAD" y hacer click en "Instructivos y Marco Normativo - NOVEDAD -").
+   * Archivos txt: https://web.arba.gov.ar/instructivo-y-marco-normativo (ese enlace se obtiene de https://web.arba.gov.ar/agentes#presentacion-de-ddjj , luego hay que ir a la sección "DDJJ Periódicas Web IIBB NOVEDAD" y hacer click en "Instructivos y Marco Normativo - NOVEDAD -"). Vigente para operaciones a partir del 01/03/2026.
 
 * AGIP:  https://www.agip.gob.ar/agentes/agentes-de-recaudacion/ib-agentes-recaudacion/aplicativo-arciba/aclaraciones-sobre-las-adecuaciones-al-aplicativo-e-arciba- (Version 3.0 aplicada el 07-05-2024)
    * Notas de credito  https://www.agip.gob.ar/filemanager/source/Agentes/De%20Recaudacion/Ingresos%20brutos/NC.PDF

--- a/l10n_ar_account_tax_settlement/__manifest__.py
+++ b/l10n_ar_account_tax_settlement/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Tax Settlements For Argentina',
-    'version': "16.0.1.20.0",
+    'version': "16.0.1.21.0",
     'category': 'Accounting',
     'website': 'www.adhoc.com.ar',
     'license': 'LGPL-3',

--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -62,8 +62,9 @@ class AccountJournal(models.Model):
         ('iibb_aplicado_sircar', 'TXT Perc/Ret IIBB aplicadas SIRCAR'),
         ('iibb_aplicado_dgr_mendoza', 'TXT  Perc/Ret IIBB aplicado DGR Mendoza'),
         ('retenciones_iva', 'TXT Retenciones/Percepciones Sufridas IVA'),
-        ('iibb_aplicado_arba_desde_01122025', 'TXT Perc/Ret IIBB aplicadas ARBA desde 01/12/2025: Percepciones ( excepto actividad 29, 7 quincenal, 7 y 17 de Bancos)'),
-        ('iibb_aplicado_arba_act_7_desde_01122025', 'TXT Perc/Ret IIBB aplicadas ARBA desde 01/12/2025: Percepciones Act. 7 método Percibido (quincenal)'),
+        # TODO descomentar las 2 opciones de abajo cuando se acerque la fecha 01/03/2026
+        # ('iibb_aplicado_arba_desde_01032026', 'TXT Perc/Ret IIBB aplicadas ARBA desde 01/03/2026: Percepciones ( excepto actividad 29, 7 quincenal, 7 y 17 de Bancos)'),
+        # ('iibb_aplicado_arba_act_7_desde_01032026', 'TXT Perc/Ret IIBB aplicadas ARBA desde 01/03/2026: Percepciones Act. 7 método Percibido (quincenal)'),
         # ('other', 'Other')
     ])
 
@@ -1549,15 +1550,15 @@ class AccountJournal(models.Model):
             'txt_content': content,
         }]
 
-    def iibb_aplicado_arba_act_7_desde_01122025_files_values(self, move_lines):
-        return self.iibb_aplicado_arba_desde_01122025_files_values(move_lines, act_7=True)
+    def iibb_aplicado_arba_act_7_desde_01032026_files_values(self, move_lines):
+        return self.iibb_aplicado_arba_desde_01032026_files_values(move_lines, act_7=True)
 
-    def iibb_aplicado_arba_desde_01122025_files_values(self, move_lines, act_7=None):
+    def iibb_aplicado_arba_desde_01032026_files_values(self, move_lines, act_7=None):
         """ Desarrollado según especificación https://web.arba.gov.ar/instructivo-y-marco-normativo
         (ese enlace se obtiene de https://web.arba.gov.ar/agentes#presentacion-de-ddjj ,
         luego hay que ir a la sección "DDJJ Periódicas Web IIBB NOVEDAD" y hacer click en
         "Instructivos y Marco Normativo - NOVEDAD -"). Finalmente descargar la especificación
-        donde dice 'Descargar PDF (Nuevo Diseño - Vigente para operaciones a partir del 01/12/2025)'
+        donde dice 'Descargar PDF (Nuevo Diseño - Vigente para operaciones a partir del 01/03/2026)'
         Implementados:
             - 1.2 Percepciones Act. 7 método Percibido (quincenal)
             - 1.7 Retenciones ( excepto actividad 29, 6 de Bancos y 17 de


### PR DESCRIPTION
Tarea: 57326
Se postega para el 01/03/2026 el desarrollo de nuevos archivos txt para la presentación de declaraciones juradas de impuestos provinciales de ARBA de acuerdo a la Resolución Normativa N° 38/11. Este commit lo que hace es comentar las opciones "iibb_aplicado_arba_desde_01032026" y "iibb_aplicado_arba_act_7_desde_01032026" del campo settlement_tax del modelo account.journal para que no sean seleccionables por el usuario hasta que llegue la fecha indicada (en dicha fecha 01/03/2026 habría que descomentar dichas opciones para que puedan ser seleccionables por el usuario).