### PR TITLE
[FIX] l10n_ar_account_tax_settlement: Remove invalid 'record' key from default_get

### DIFF
--- a/l10n_ar_account_tax_settlement/wizards/inflation_adjustment.py
+++ b/l10n_ar_account_tax_settlement/wizards/inflation_adjustment.py
@@ -60,9 +60,10 @@ class InflationAdjustment(models.TransientModel):
         company = self.env.company
         res["company_id"] = company.id
         company_fiscalyear_dates = company.compute_fiscalyear_dates(today - relativedelta(year=today.year - 1))
+        # Filter out keys that are not fields of this model (e.g., 'record')
         for key, value in company_fiscalyear_dates.items():
-            company_fiscalyear_dates[key] = value
-        res.update(company_fiscalyear_dates)
+            if key in self._fields:
+                res[key] = value
         return res
 
     @api.depends("date_from", "date_to")


### PR DESCRIPTION
The compute_fiscalyear_dates() method returns a dictionary that includes
a 'record' key (the fiscal year recordset) along with 'date_from' and
'date_to'. When default_get() was updating res with all keys from this
dictionary, it was adding 'record' which is not a field of the model.

This caused a KeyError when Odoo's _add_missing_default_values() tried
to access self._fields['record'].

Fixed by filtering the fiscalyear dates dictionary to only include keys
that correspond to actual model fields before updating the result.