### PR TITLE
[IMP] l10n_ar_account_reports: do not set tax lock date automatically

### DIFF
--- a/l10n_ar_account_reports/__manifest__.py
+++ b/l10n_ar_account_reports/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Accounting Reports Customized for Argentina",
-    "version": "19.0.1.2.0",
+    "version": "19.0.1.3.0",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",
@@ -52,6 +52,7 @@
         "data/misiones_report.xml",
         "data/santa_fe_report.xml",
         "data/tucuman_report.xml",
+        "data/sicore_report.xml",
     ],
     "demo": [
         "demo/res_partner_demo.xml",

--- a/l10n_ar_account_reports/data/sicore_report.xml
+++ b/l10n_ar_account_reports/data/sicore_report.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="l10n_ar_sicore_report" model="account.report">
+        <field name="name">SICORE Profits</field>
+        <field name="root_report_id" ref="account.generic_tax_report"/>
+        <field name="country_id" ref="base.ar"/>
+        <field name="filter_hierarchy">never</field>
+        <field name="filter_unreconciled" eval="False"/>
+        <field name="filter_period_comparison" eval="False"/>
+        <field name="filter_growth_comparison" eval="False"/>
+        <field name="custom_handler_model_id" ref="model_l10n_ar_sicore_report_handler"/>
+        <field name="column_ids">
+            <record id="l10n_ar_sicore_report_column_total" model="account.report.column">
+                <field name="name">Balance</field>
+                <field name="name@es_419">Balance</field>
+                <field name="expression_label">balance</field>
+            </record>
+        </field>
+        <field name="line_ids">
+            <record id="l10n_ar_sicore_report_profits_line" model="account.report.line">
+                <field name="name">Purchase Profits Withholdings</field>
+                <field name="domain_formula">-sum([("tax_line_id.l10n_ar_tax_type", "in", ["earnings", "earnings_scale"]), ("tax_line_id.l10n_ar_withholding_payment_type", "=", "supplier"), ("tax_line_id.country_code", "=", "AR")])</field>
+            </record>
+        </field>
+    </record>
+
+    <record id="sicore_return_type" model="account.return.type">
+        <field name="name">SICORE Ganancias (Agente)</field>
+        <field name="report_id" ref="l10n_ar_account_reports.l10n_ar_sicore_report"/>
+        <field name="default_deadline_periodicity">fortnightly</field>
+        <field name="auto_generate" eval="False"/>
+        <field name="country_id" ref="base.ar"/>
+        <field name="deadline_days_delay">10</field>
+        <field name="default_deadline_days_delay">31</field>
+        <field name="states_workflow">generic_state_review</field>
+    </record>
+</odoo>

--- a/l10n_ar_account_reports/models/__init__.py
+++ b/l10n_ar_account_reports/models/__init__.py
@@ -17,3 +17,4 @@ from . import account_return
 from . import account_return_type
 from . import account_move_line
 from . import helpers
+from . import sicore_report

--- a/l10n_ar_account_reports/models/account_return.py
+++ b/l10n_ar_account_reports/models/account_return.py
@@ -122,3 +122,27 @@ class AccountReturn(models.Model):
 
         moves = self.env["account.move"].sudo().create(closing_move_vals)
         moves.action_post()
+
+    def _proceed_with_locking(self, options_to_inject=None):
+        """
+        EXTENDS account_reports
+        For Argentinian provincial tax returns (Ingresos Brutos), we handle the locking process differently.
+        We don't want to set the tax_lock_date when validating the "asiento de liquidación".
+        We temporarily store the current tax_lock_date, call super(), then restore it to prevent changes.
+        """
+        tax_lock_dates = {
+            company: company.tax_lock_date for company in self.company_ids.filtered(lambda c: c.country_id.code == "AR")
+        }
+        res = super()._proceed_with_locking(options_to_inject=options_to_inject)
+        if (
+            self.type_id
+            and self.type_id.report_id
+            and self.is_tax_return
+            and self.type_id.report_id.country_id.code == "AR"
+            and self.company_id.country_id.code == "AR"
+        ):
+            # Restore tax_lock_date to prevent it from being modified by provincial returns
+            for company, original_date in tax_lock_dates.items():
+                if company.tax_lock_date != original_date:
+                    company.sudo().tax_lock_date = original_date
+        return res

--- a/l10n_ar_account_reports/models/sicore_report.py
+++ b/l10n_ar_account_reports/models/sicore_report.py
@@ -1,0 +1,144 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import re
+
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+from .helpers import get_standard_lines_domain
+
+
+class L10n_ArSicoreReportHandler(models.AbstractModel):
+    _name = "l10n_ar.sicore.report.handler"
+    _inherit = ["account.tax.report.handler"]
+    _description = "Argentinian SICORE Report Custom Handler"
+
+    def _custom_options_initializer(self, report, options, previous_options):
+        super()._custom_options_initializer(report, options, previous_options=previous_options)
+        # TODO falta implementar percepciones aplicadas de iva
+        # Add export button
+        txt_export_button = {
+            "name": _("Sicore Profits Withholdings TXT"),
+            "sequence": 30,
+            "action": "export_file",
+            "action_param": "sicore_book_export_files_to_txt",
+            "file_export_type": "TXT",
+        }
+
+        options["buttons"].append(txt_export_button)
+
+    def sicore_book_export_files_to_txt(self, options):
+        """Export method that lets us export the SICORE book to a txt file.
+        It contains the file that we upload to SICORE application."""
+        return {
+            "file_name": _("SICORE_profits_withholdings.txt"),
+            "file_content": self._sicore_book_get_txt_files(options),
+            "file_type": "txt",
+        }
+
+    def _sicore_book_get_txt_files(self, options):
+        """Returns SICORE txt content"""
+        move_lines = self._sicore_book_get_txt_lines(options)
+        return "".join(self._get_sicore_txt_content(move_lines)).encode("ISO-8859-1", "ignore")
+
+    def _sicore_book_get_txt_lines(self, options):
+        state = options.get("all_entries") and "all" or "posted"
+        if state != "posted":
+            raise UserError(
+                _(
+                    "Can only generate TXT files using posted entries."
+                    " Please remove Include unposted entries filter and try again"
+                )
+            )
+        domain = [
+            ("tax_line_id.l10n_ar_tax_type", "in", ["earnings", "earnings_scale"]),
+            ("tax_line_id.l10n_ar_withholding_payment_type", "=", "supplier"),
+            ("tax_line_id.country_code", "=", "AR"),
+        ] + get_standard_lines_domain(self.env.company.ids, options)
+        return self.env["account.move.line"].search(domain, order="date asc, name asc, id asc")
+
+    def _get_sicore_txt_content(self, move_lines):
+        """Returns the lines to be printed in the txt file."""
+        lines = []
+        for line in move_lines.filtered("amount_currency").sorted(key=lambda r: (r.date, r.id)):
+            content = ""
+
+            partner = line.partner_id
+            if not partner.l10n_latam_identification_type_id.l10n_ar_afip_code:
+                raise UserError(
+                    _(
+                        'The identification type "%(identification_type)s" does not have ARCA code set.',
+                        identification_type=partner.l10n_latam_identification_type_id.name,
+                    )
+                )
+            if not partner.vat:
+                raise UserError(
+                    _(
+                        'The partner "%(partner_name)s" (id %(partner_id)s) does not have the vat set.',
+                        partner_name=partner.name,
+                        partner_id=partner.id,
+                    )
+                )
+
+            payment = line.payment_id
+            move = line.move_id
+
+            # Codigo del Comprobante (document code)        [ 2]
+            content += (
+                (payment.payment_type == "inbound" and "02") or (payment.payment_type == "outbound" and "06") or "00"
+            )
+            # Fecha Emision Comprobante (move line date)     [10] (dd/mm/yyyy)
+            content += fields.Date.from_string(line.date).strftime("%d/%m/%Y")
+
+            # Numero Comprobante (document number)           [16]
+            content += f"{re.sub(r'[^0-9]', '', move.l10n_latam_document_number):0>16}"
+
+            # Fecha de pago del comprobante (document amount)
+            issue_date = payment.date
+
+            # Importe Comprobante (document amount)           [16]
+            content += f"{abs(payment.amount):016.2f}"
+            # Codigo de Impuesto (tax code)            [ 4]
+            # Codigo de Regimen (regime code)             [ 3]
+
+            content += "0217"
+            regimen = line.tax_line_id.l10n_ar_code
+
+            content += f"{''.join(filter(str.isdigit, str(regimen))):0>3}" if regimen else "000"
+
+            # Codigo de Operacion (operation code)           [ 1]
+            content += "1"
+
+            # Base de Calculo (base amount)               [14]
+            content += f"{abs(line.tax_base_amount):014.2f}"
+
+            # Fecha Emision Retencion (move line date)        [10] (dd/mm/yyyy)
+            content += fields.Date.from_string(issue_date).strftime("%d/%m/%Y")
+
+            # Codigo de Condicion (condition code)           [ 2]
+            content += "01"
+
+            # Retención Pract. a Suj. ..     [ 1]
+            content += "0"
+
+            # Importe de Retencion (withholding amount)          [14]
+            content += f"{abs(line.balance):014.2f}"
+
+            # Porcentaje de Exclusion (exclusion percentage)       [ 6]
+            content += "000.00"
+
+            # Fecha Emision Boletin          [10] (dd/mm/yyyy)
+            content += fields.Date.from_string(issue_date).strftime("%d/%m/%Y")
+
+            # Tipo Documento Retenido (document type code)       [ 2]
+            content += f"{int(partner.l10n_latam_identification_type_id.l10n_ar_afip_code):02d}"
+
+            # Numero Documento Retenido (vat)     [20]
+            content += partner.vat.ljust(20)
+
+            # Numero Certificado Original    [14]
+            content += f"{0:014d}"
+
+            content += "\r\n"
+
+            lines.append(content)
+        return lines


### PR DESCRIPTION
Task Adhoc side: 56583

Al generar los asientos de liquidación de manera nativa se establece la fecha de bloqueo de impuestos automáticamente. En Argentina no queremos que esto suceda.