### PR TITLE
[FIX] account_tax_settlement: vista kanban del menu "Liquidación de impuestos".

### DIFF
--- a/account_tax_settlement/__manifest__.py
+++ b/account_tax_settlement/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Tax Settlement",
-    "version": "18.0.1.3.0",
+    "version": "18.0.1.4.0",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",

--- a/account_tax_settlement/models/account_move_line.py
+++ b/account_tax_settlement/models/account_move_line.py
@@ -54,6 +54,7 @@ class AccountMoveLine(models.Model):
         self.ensure_one()
         return self.env["account.journal"].search(
             [
+                ("active", "=", True),
                 ("company_id", "parent_of", self.company_id.id),
                 ("settlement_account_tag_ids", "in", self.tax_repartition_line_id.tag_ids.ids),
             ],

--- a/account_tax_settlement/views/account_journal_view.xml
+++ b/account_tax_settlement/views/account_journal_view.xml
@@ -61,7 +61,7 @@
         <field name="view_mode">kanban,form</field>
         <field name="view_id" ref="account.account_journal_dashboard_kanban_view"/>
         <field name="usage">menu</field>
-        <field name="domain">[('tax_settlement', '!=', False)]</field>
+        <field name="domain">[('tax_settlement', '!=', False), ('active', '=', True)]</field>
     </record>
 
     <menuitem id="menu_board_journal_10" name="Tax Settlement" action="open_account_tax_settlement_kanban" parent="account.menu_finance_entries" sequence="20" groups="account.group_account_user"/>


### PR DESCRIPTION
Ticket: 107702
En la vista kanban del menú de "Liquidación de impuestos" se ven diarios que están archivados y no queremos que eso suceda porque puede prestar a confusión.