### PR TITLE
[FIX] l10n_ar_edi_ux: Result ARCA field

### DIFF
--- a/l10n_ar_edi_ux/__manifest__.py
+++ b/l10n_ar_edi_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Argentinian Electronic Invoicing UX",
-    "version": "19.0.1.1.0",
+    "version": "19.0.1.2.0",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/l10n_ar_edi_ux/views/account_move_view.xml
+++ b/l10n_ar_edi_ux/views/account_move_view.xml
@@ -14,6 +14,12 @@
                 <field name='l10n_ar_boarding_permission_ids' widget="many2many_tags" invisible="l10n_ar_afip_ws != 'wsfex'" options="{'no_quick_create': True}"/>
                 <button name="check_valid_boarding_permission" string="Validar permisos de embarque" type="object" invisible="l10n_ar_afip_ws != 'wsfex'" icon="fa-arrow-right" class="oe_link" colspan="2"/>
             </field>
+
+            <!-- Cambiamos comportamiento de Odoo, movemos el campo Resultado ARCA a la pestaña ARCA como estaba previo a este cambio https://github.com/odoo/enterprise/commit/792907aad38ad283f923680222afe2b51ea5f0dd -->
+            <xpath expr="//page[@name='afip']/group/label" position="before">
+                <field name="l10n_ar_afip_result" position="move"/>
+            </xpath>
+
         </field>
     </record>
 


### PR DESCRIPTION
We move it to inside the notebook in the ARCA page as it used to be. This field will be editable only in draft state and will be shown only if it is a electronic journal