### PR TITLE
[IMP] _reports: use simple for vat and remove net vat line

### DIFF
--- a/l10n_ar_account_reports/__init__.py
+++ b/l10n_ar_account_reports/__init__.py
@@ -13,3 +13,4 @@ def _post_init_hook_configure_ar_account_tags(env):
     companies = env["res.company"].search([("account_fiscal_country_id.code", "=", "AR")])
     # Apply tags to accounts
     env["account.chart.template"]._l10n_ar_account_reports_setup_account_tags(companies)
+    env["account.chart.template"]._l10n_ar_setup_return_type_accounts(companies)

--- a/l10n_ar_account_reports/__manifest__.py
+++ b/l10n_ar_account_reports/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Accounting Reports Customized for Argentina",
-    "version": "19.0.1.6.0",
+    "version": "19.0.1.7.0",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",
@@ -41,6 +41,7 @@
         "account_payment_pro_receiptbook",
     ],
     "data": [
+        "views/account_return_type_views.xml",
         "data/tags_data.xml",
         "data/estado_resultados.xml",
         "data/balance_sheet.xml",

--- a/l10n_ar_account_reports/data/l10n_ar_vat_ret_perc_sufrido.xml
+++ b/l10n_ar_account_reports/data/l10n_ar_vat_ret_perc_sufrido.xml
@@ -77,17 +77,6 @@
                     </record>
                 </field>
             </record>
-            <record id="l10n_ar_iva_report_total" model="account.report.line">
-                <field name="name">Monto a Pagar O Saldo Libre Disponibilidad</field>
-                <field name="code">L10N_AR_IVA_TOTAL</field>
-                <field name="expression_ids">
-                    <record id="l10n_ar_iva_report_total_balance" model="account.report.expression">
-                        <field name="label">balance</field>
-                        <field name="engine">aggregation</field>
-                        <field name="formula">L10N_AR_IVA_SALDO_TECNICO.balance + L10N_AR_IVA_RETENCIONES.balance + L10N_AR_IVA_PERCEPCIONES.balance</field>
-                    </record>
-                </field>
-            </record>
         </field>
     </record>
 

--- a/l10n_ar_account_reports/demo/account_demo.py
+++ b/l10n_ar_account_reports/demo/account_demo.py
@@ -15,6 +15,9 @@ class AccountChartTemplate(models.AbstractModel):
     def _install_l10n_ar_account_reports_demo(self, companies):
         for company in companies:
             self = self.with_company(company)
+            # seteamos multilateral a los fines de demo. si luego queremos manejar otros casos podemos hacer esto
+            # SOLO sobre RI
+            company.l10n_ar_gross_income_type = "multilateral"
             demo_data = {
                 "account.fiscal.position": self._l10n_ar_get_demo_data_fiscal_position(),
                 "account.move": self._l10n_ar_get_demo_data_move(),

--- a/l10n_ar_account_reports/models/account_chart_template.py
+++ b/l10n_ar_account_reports/models/account_chart_template.py
@@ -22,6 +22,7 @@ class AccountChartTemplate(models.AbstractModel):
         # Check if applicable to "ar_ex", "ar_base"
         if company.account_fiscal_country_id.code == "AR":
             self._l10n_ar_account_reports_setup_account_tags([company])
+            self._l10n_ar_setup_return_type_accounts(company)
 
         return res
 
@@ -29,6 +30,52 @@ class AccountChartTemplate(models.AbstractModel):
         super()._post_load_data(template_code, company, template_data)
         if company.account_fiscal_country_id.code == "AR":
             self._l10n_ar_account_reports_setup_account_tags([company])
+            self._l10n_ar_setup_return_type_accounts(company)
+
+    def _l10n_ar_setup_return_type_accounts(self, companies):
+        """Configure l10n_ar_account_id for AR return types when installing chart of accounts.
+
+        Account mapping (account template code):
+        - sicore: ri_retencion_sicore_a_pagar
+        - IVA: ri_iva_saldo_a_pagar
+        - iibb agents (provincial): ri_retencion_iibb_a_pagar
+        - iibb sufrido (Sifere): base_iibb_a_pagar
+        """
+        # Mapping: return_type xml_id -> account template code
+        # Note: Some accounts only exist in ar_ri or ar_ex templates
+        return_type_account_mapping = {
+            # SICORE (ganancias) - exists in ar_ri and ar_ex
+            "l10n_ar_account_reports.sicore_return_type": "ri_retencion_sicore_a_pagar",
+            # IVA - exists in ar_ri
+            "l10n_ar_reports.ar_tax_return_type": "ri_iva_saldo_a_pagar",
+            # SIFERE (iibb sufrido) - exists in all AR templates
+            "l10n_ar_account_reports.ar_sifere_iibb_return_type": "base_iibb_a_pagar",
+            # Provincial IIBB agents - exists in ar_ri and ar_ex
+            "l10n_ar_account_reports.ar_caba_iibb_return_type": "ri_retencion_iibb_a_pagar",
+            "l10n_ar_account_reports.ar_pba_iibb_return_type": "ri_retencion_iibb_a_pagar",
+            "l10n_ar_account_reports.ar_mendoza_iibb_return_type": "ri_retencion_iibb_a_pagar",
+            "l10n_ar_account_reports.ar_santa_fe_iibb_return_type": "ri_retencion_iibb_a_pagar",
+            "l10n_ar_account_reports.ar_tucuman_iibb_return_type": "ri_retencion_iibb_a_pagar",
+            "l10n_ar_account_reports.ar_misiones_iibb_return_type": "ri_retencion_iibb_a_pagar",
+            "l10n_ar_account_reports.ar_sircar_iibb_return_type": "ri_retencion_iibb_a_pagar",
+        }
+        for company in companies:
+            # para que le ref de "chart" funcione bien, necesita tener en el env la company correcta
+            self = self.with_company(company)
+            # TODO mejorar, tal vez estamos iterando demasiado? hace falta? en los de abajo también. Podriamos mejorar
+            # performance probablemente
+            for return_type_xmlid, account_code in return_type_account_mapping.items():
+                return_type = self.env.ref(return_type_xmlid, raise_if_not_found=False)
+                if not return_type:
+                    continue
+
+                # Build the account external id for this company
+                account = self.ref(account_code, raise_if_not_found=False)
+                if not account:
+                    continue
+
+                # Set the account on the return type for this company (company dependent field)
+                return_type.with_company(company).l10n_ar_account_id = account
 
     def _get_ar_account_tags(self):
         """Get all account tags defined in l10n_ar_account_reports

--- a/l10n_ar_account_reports/models/account_return.py
+++ b/l10n_ar_account_reports/models/account_return.py
@@ -174,12 +174,16 @@ class AccountReturn(models.Model):
     def _get_pay_wizard(self):
         # EXTENDS account_reports
         if self.company_id.country_id.code == "AR" and self.is_tax_return and self.type_id.payment_partner_id:
-            line_to_pay = self.closing_move_ids.line_ids.filtered(
+            lines_to_pay = self.closing_move_ids.line_ids.filtered(
                 lambda l: l.partner_id == self.type_id.payment_partner_id
                 and l.account_id.account_type in ("asset_receivable", "liability_payable")
             )
-            if line_to_pay:
-                return line_to_pay.action_register_payment()
+            # si el saldo es a favor (balance >= 0), actualizamos estado y no abrimos wizard
+            if lines_to_pay and sum(lines_to_pay.mapped("balance")) >= 0:
+                self._update_payment_state()
+                return
+            if lines_to_pay:
+                return lines_to_pay.action_register_payment()
         return super()._get_pay_wizard()
 
     def _update_payment_state(self):
@@ -191,7 +195,8 @@ class AccountReturn(models.Model):
                     and l.account_id.account_type in ("asset_receivable", "liability_payable")
                 )
                 if lines_to_pay:
-                    is_paid = all(lines_to_pay.mapped("reconciled"))
+                    # Si el saldo es "a favor" (balance >= 0) o está conciliado, lo pasamos a pagado
+                    is_paid = sum(lines_to_pay.mapped("balance")) >= 0 or all(lines_to_pay.mapped("reconciled"))
                     workflow_field = record.type_id.states_workflow
                     if is_paid and record.state != "paid":
                         record.state = "paid"

--- a/l10n_ar_account_reports/models/account_return.py
+++ b/l10n_ar_account_reports/models/account_return.py
@@ -35,10 +35,11 @@ class AccountReturn(models.Model):
         return domain
 
     def _is_ar_simple_closing_return(self):
-        """Check if this return should use simple closing (no carryover, no tax_lock_date)."""
-        return self.company_id.country_id.code == "AR" and self.type_id != self.env.ref(
-            "l10n_ar_reports.ar_tax_return_type"
-        )
+        """Check if this return should use simple closing (no carryover, no tax_lock_date).
+        Al libro de IVA también lo hacemos tipo "simple" porque los carryvoer confunden, mezclan libre disponibilidad y
+        saldo a favor, además crean líneas de neto que confunden.
+        """
+        return self.company_id.country_id.code == "AR"
 
     def _ensure_tax_group_configuration_for_tax_closing(self):
         """
@@ -152,11 +153,6 @@ class AccountReturn(models.Model):
 
         # si no posteamos devolvemos acción
         if self.closing_move_ids.filtered(lambda m: m.state == "draft"):
-            # para el libro de IVA asignamos también el partner si está definido
-            if self.type_id == self.env.ref("l10n_ar_reports.ar_tax_return_type") and self.type_id.payment_partner_id:
-                self.closing_move_ids.line_ids.filtered(
-                    lambda l: l.account_id.account_type in ("asset_receivable", "liability_payable")
-                ).partner_id = self.type_id.payment_partner_id.id
             return self.closing_move_ids._get_records_action()
         return res
 

--- a/l10n_ar_account_reports/models/account_return.py
+++ b/l10n_ar_account_reports/models/account_return.py
@@ -1,4 +1,4 @@
-from odoo import Command, _, fields, models
+from odoo import Command, _, api, fields, models
 from odoo.exceptions import UserError
 
 
@@ -45,14 +45,37 @@ class AccountReturn(models.Model):
             return
         return super()._ensure_tax_group_configuration_for_tax_closing()
 
-    def _get_tax_closing_payable_and_receivable_accounts(self):
-        """Eso es necesario para que los importes total_amount_to_pay y period_amount_to_pay se calcule bien"""
-        if self.type_id.l10n_ar_is_simple_closing_return:
-            partner = self.type_id.payment_partner_id
-            return partner.with_company(self.company_id).property_account_payable_id, partner.with_company(
-                self.company_id
-            ).property_account_receivable_id
-        return super()._get_tax_closing_payable_and_receivable_accounts()
+    # ver en _compute_show_amount_to_pay
+    # def _get_tax_closing_payable_and_receivable_accounts(self):
+    #     """Eso es necesario para que los importes total_amount_to_pay y period_amount_to_pay se calcule bien"""
+    #     if self._is_ar_simple_closing_return():
+    #         partner = self.type_id.payment_partner_id
+    #         return partner.with_company(self.company_id).property_account_payable_id, partner.with_company(
+    #             self.company_id
+    #         ).property_account_receivable_id
+    #     return super()._get_tax_closing_payable_and_receivable_accounts()
+
+    @api.depends(
+        "type_id.l10n_ar_is_simple_closing_return",
+    )
+    def _compute_show_amount_to_pay(self):
+        """
+        Para liquidaciones simples de Argentina, los importes calculados por Odoo al bloquear el informe
+        pueden no ser representativos si el asiento fue modificado manualmente o si no se utiliza
+        la configuración estándar de grupos de impuestos. Ocultamos el bloque si los importes son cero
+        para evitar mostrar información irrelevante o confusa.
+        TODO mas adelante podriamos:
+        a) borrar el partche en "_proceed_with_locking"
+        b) dejar que los montos se muestren para los asientos que se publicana automáticamente y/o mejorar para que
+        cambiar asiento manualmente actualice los montos
+        c) agregar en condición de abajo "and not record.total_amount_to_pay and not record.period_amount_to_pay"
+
+        Por ahora vamos por lo simple
+        """
+        super()._compute_show_amount_to_pay()
+        for record in self:
+            if record.type_id.l10n_ar_is_simple_closing_return:
+                record.show_amount_to_pay = False
 
     def _on_post_submission_event(self):
         """No queremos que luego de submit dispare directamente pago, prefiero que se haga click en en boton,
@@ -145,6 +168,9 @@ class AccountReturn(models.Model):
         # por ahora no queremos ningun informe argentino que haga lock porque, IVA, que es el principal lo estamos
         # dejando editable para que el usuario termine de acomodarlo, luego deberá hacer lock manualmente
         if self.type_id.l10n_ar_is_simple_closing_return:
+            # ver notas en _compute_show_amount_to_pay
+            self.write({"total_amount_to_pay": False, "period_amount_to_pay": False})
+
             # Restore tax_lock_date to prevent it from being modified by provincial returns
             for company, original_date in tax_lock_dates.items():
                 if company.tax_lock_date != original_date:

--- a/l10n_ar_account_reports/models/account_return.py
+++ b/l10n_ar_account_reports/models/account_return.py
@@ -34,13 +34,6 @@ class AccountReturn(models.Model):
             domain += l10n_ar_domain
         return domain
 
-    def _is_ar_simple_closing_return(self):
-        """Check if this return should use simple closing (no carryover, no tax_lock_date).
-        Al libro de IVA también lo hacemos tipo "simple" porque los carryvoer confunden, mezclan libre disponibilidad y
-        saldo a favor, además crean líneas de neto que confunden.
-        """
-        return self.company_id.country_id.code == "AR"
-
     def _ensure_tax_group_configuration_for_tax_closing(self):
         """
         Skip tax group account validation for AR simple closing returns,
@@ -48,13 +41,13 @@ class AccountReturn(models.Model):
         NOTA: esto de acá no suma tanto porque si se quiere liquidar el informde "vat" u otro igual se van a chequear
         todas las cuentas
         """
-        if self._is_ar_simple_closing_return():
+        if self.type_id.l10n_ar_is_simple_closing_return:
             return
         return super()._ensure_tax_group_configuration_for_tax_closing()
 
     def _get_tax_closing_payable_and_receivable_accounts(self):
         """Eso es necesario para que los importes total_amount_to_pay y period_amount_to_pay se calcule bien"""
-        if self._is_ar_simple_closing_return():
+        if self.type_id.l10n_ar_is_simple_closing_return:
             partner = self.type_id.payment_partner_id
             return partner.with_company(self.company_id).property_account_payable_id, partner.with_company(
                 self.company_id
@@ -65,7 +58,7 @@ class AccountReturn(models.Model):
         """No queremos que luego de submit dispare directamente pago, prefiero que se haga click en en boton,
         mas adelante se puede implementar un wizard de submit o similar como hacen otros heredando método action_submit
         """
-        if self._is_ar_simple_closing_return():
+        if self.type_id.l10n_ar_is_simple_closing_return:
             if self.type_id.states_workflow == "generic_state_review_submit":
                 return self._mark_completed()
             return
@@ -77,7 +70,7 @@ class AccountReturn(models.Model):
         For AR simple closing returns, create a simple counterpart line using the partner's AP/AR account.
         This avoids the carryover mechanism (no "Balance tax current account" lines).
         """
-        if not self._is_ar_simple_closing_return():
+        if not self.type_id.l10n_ar_is_simple_closing_return:
             return super()._add_tax_group_closing_items(tax_group_subtotal)
 
         # Sum all tax group subtotals to get the total amount
@@ -97,15 +90,21 @@ class AccountReturn(models.Model):
                 )
             )
 
-        # Use partner's payable account for amounts to pay, receivable for credits
-        if total < 0:
-            # Amount to pay (negative balance means we owe taxes)
-            account = partner.with_company(self.company_id).property_account_payable_id
-            line_name = _("Tax to pay")
+        # Check if a specific account is configured on the return type
+        configured_account = self.type_id.l10n_ar_account_id
+
+        line_name = _("Tax to pay") if total < 0 else _("Tax credit")
+        if configured_account:
+            # Use the configured account from the return type
+            account = configured_account
         else:
-            # Credit in favor (positive balance means tax credit)
-            account = partner.with_company(self.company_id).property_account_receivable_id
-            line_name = _("Tax credit")
+            # Fallback: Use partner's payable account for amounts to pay, receivable for credits
+            if total < 0:
+                # Amount to pay (negative balance means we owe taxes)
+                account = partner.with_company(self.company_id).property_account_payable_id
+            else:
+                # Credit in favor (positive balance means tax credit)
+                account = partner.with_company(self.company_id).property_account_receivable_id
 
         if not account:
             raise UserError(
@@ -145,7 +144,7 @@ class AccountReturn(models.Model):
 
         # por ahora no queremos ningun informe argentino que haga lock porque, IVA, que es el principal lo estamos
         # dejando editable para que el usuario termine de acomodarlo, luego deberá hacer lock manualmente
-        if self._is_ar_simple_closing_return():
+        if self.type_id.l10n_ar_is_simple_closing_return:
             # Restore tax_lock_date to prevent it from being modified by provincial returns
             for company, original_date in tax_lock_dates.items():
                 if company.tax_lock_date != original_date:

--- a/l10n_ar_account_reports/models/account_return_type.py
+++ b/l10n_ar_account_reports/models/account_return_type.py
@@ -30,7 +30,33 @@ class AccountReturnType(models.Model):
     )
     # le ponemos store porque en odoo es un campo solo related y si no hay cuenta bancaria no hay partner
     # issue en odoo: https://github.com/odoo/odoo/issues/240322
-    payment_partner_id = fields.Many2one(store=True)
+    # al final le sacamos también el related porque si no en el create no se guarda. Podria implementarse como compute
+    # pero no vemos necesidad por el momento
+    payment_partner_id = fields.Many2one(store=True, related=False)
+
+    l10n_ar_account_id = fields.Many2one(
+        comodel_name="account.account",
+        string="AR Closing Account",
+        company_dependent=True,
+        domain="[('account_type', 'in', ('liability_payable', 'asset_receivable'))]",
+        help="Account to use for the closing entry of this return type. "
+        "If not set, the partner's payable/receivable account will be used.",
+    )
+    l10n_ar_is_simple_closing_return = fields.Boolean(
+        string="AR Simple Closing",
+        compute="_compute_l10n_ar_is_simple_closing_return",
+        help="If enabled, this return type uses simplified closing logic: "
+        "no carryover mechanism and no automatic tax_lock_date update.",
+    )
+
+    @api.depends("country_id")
+    def _compute_l10n_ar_is_simple_closing_return(self):
+        """Compute if this return type should use simple closing (no carryover, no tax_lock_date).
+        Al libro de IVA también lo hacemos tipo 'simple' porque los carryover confunden,
+        mezclan libre disponibilidad y saldo a favor, además crean líneas de neto que confunden.
+        """
+        for record in self:
+            record.l10n_ar_is_simple_closing_return = record.country_id.code == "AR"
 
     def _get_periodicity_months_delay(self, company):
         """Returns the number of months separating two returns.

--- a/l10n_ar_account_reports/models/account_return_type.py
+++ b/l10n_ar_account_reports/models/account_return_type.py
@@ -333,6 +333,37 @@ class AccountReturnType(models.Model):
             if not return_type:
                 continue
 
+            if not return_type._can_return_exist(main_company, tax_unit):
+                continue
+
+            gi_type = main_company.l10n_ar_gross_income_type
+
+            # Lógica de selección de reportes de IIBB según régimen
+            # SIFERE y SIRCAR solo si es multilateral
+            if (
+                xml_id
+                in [
+                    "l10n_ar_account_reports.ar_sircar_iibb_return_type",
+                    "l10n_ar_account_reports.ar_sifere_iibb_return_type",
+                ]
+                and gi_type != "multilateral"
+            ):
+                continue
+
+            # Mendoza, Misiones y Santa Fe NO van si es multilateral (usan SIRCAR)
+            sircar_provinces = [
+                "l10n_ar_account_reports.ar_mendoza_iibb_return_type",
+                "l10n_ar_account_reports.ar_misiones_iibb_return_type",
+                "l10n_ar_account_reports.ar_santa_fe_iibb_return_type",
+            ]
+            if gi_type == "multilateral" and xml_id in sircar_provinces:
+                continue
+
+            # Caso SIFERE: se genera siempre que sea multilateral, incluso sin operaciones
+            if xml_id == "l10n_ar_account_reports.ar_sifere_iibb_return_type":
+                return_type._try_create_returns_for_fiscal_year(main_company, tax_unit, bypass_period_check=True)
+                continue
+
             domain = return_type._get_l10n_ar_activity_domain()
             if not domain:
                 continue

--- a/l10n_ar_account_reports/views/account_return_type_views.xml
+++ b/l10n_ar_account_reports/views/account_return_type_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="account_return_type_form_view" model="ir.ui.view">
+        <field name="name">account.return.type.form.l10n_ar</field>
+        <field name="model">account.return.type</field>
+        <field name="inherit_id" ref="account_reports.account_return_type_form_view"/>
+        <field name="arch" type="xml">
+            <field name="payment_partner_id" position="after">
+                <field name="l10n_ar_is_simple_closing_return" invisible="1"/>
+                <field name="l10n_ar_account_id"
+                    invisible="not l10n_ar_is_simple_closing_return"
+                    options="{'no_create': True}"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
1. Usamos liquidación simple para IVA para evitar dolores con carryover y demás
2. borarmos la línea de subtotal porque no es facil de implementar y no es lo que más suma valor