### PR TITLE
[ADD] l10n_ar_edi_ux: required fields

### DIFF
--- a/l10n_ar_edi_ux/__manifest__.py
+++ b/l10n_ar_edi_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Argentinian Electronic Invoicing UX",
-    "version": "19.0.1.2.0",
+    "version": "19.0.1.3.0",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",

--- a/l10n_ar_edi_ux/views/account_move_view.xml
+++ b/l10n_ar_edi_ux/views/account_move_view.xml
@@ -34,6 +34,13 @@
                 <button name="l10n_ar_verify_on_afip" position="move"/>
             </div>
 
+            <!-- Solo hacemos requeridos estos campo cuando validamos la factura, no antes-->
+            <field name="l10n_latam_document_number" position="attributes">
+                <attribute name="modifiers">{"required": [["state", "=", "posted"], ["l10n_latam_use_documents", "=", true]]}</attribute>
+            </field>
+            <field name="l10n_latam_document_type_id" position="attributes">
+                <attribute name="modifiers">{"required": [["state", "=", "posted"], ["l10n_latam_use_documents", "=", true]]}</attribute>
+            </field>
 
         </field>
     </record>


### PR DESCRIPTION
only require document type and number when validating the invoice