### PR TITLE
[FIX] l10n_ar_tax_settlement_backward_comp: backward tax compatibility

### DIFF
--- a/l10n_ar_tax_settlement_backward_comp/models/account_move_line.py
+++ b/l10n_ar_tax_settlement_backward_comp/models/account_move_line.py
@@ -23,7 +23,7 @@ class AccountMoveLine(models.Model):
             lambda x: x.company_id == self.company_id
             and x.tax_id.l10n_ar_state_id == self.tax_line_id.l10n_ar_state_id
             and (x.from_date <= date if x.from_date else not x.from_date)
-            and (x.to_date >= date if x.to_date else not x.from_date)
+            and (x.to_date >= date if x.to_date else not x.to_date)
         ):
             return partner_tax.tax_id
         return self.tax_line_id


### PR DESCRIPTION
Ticket Adhoc: 108632
Cuando migramos por ejemplo de versión 16 a 18 y hay impuestos que toman alícuota del contacto, si dicho impuesto no tenía "fecha hasta" en el contacto entonces cuando hacemos el backward compatibility (que consiste en buscar el impuesto equivalente en la nueva versión) no se estaba detectando el nuevo impuesto en el contacto en la versión 18, detectaba el impuesto viejo de la versión anterior. Este pr arregla eso.
Más info en este video: https://drive.google.com/file/d/1ov9S-TPKjda-HgQBsdzmUrClJDwiI_hj/view