### PR TITLE
[FIX] l10n_ar_edi_ux: void duplicating activities across both regimes

### DIFF
--- a/l10n_ar_edi_ux/models/res_partner.py
+++ b/l10n_ar_edi_ux/models/res_partner.py
@@ -184,12 +184,27 @@ class ResPartner(models.Model):
         def check_activity(data_rg, data_mt):
             res = []
             new_activity = {}
-            afip_activities = data_rg.get("actividad", []) + (
+
+            # Evitamos duplicar actividades que puedan venir en ambos regimenes
+            combined_acts = data_rg.get("actividad", []) + (
                 [data_mt.get("actividadMonotributista", [])] if data_mt else []
             )
+            unique_acts = []
+            seen_ids = set()
+            for act in combined_acts:
+                if not isinstance(act, dict):
+                    continue
+                act_id = act.get("idActividad")
+                if act_id is None:
+                    continue
+                if act_id in seen_ids:
+                    continue
+                seen_ids.add(act_id)
+                unique_acts.append(act)
+
             actividades = self.env["afip.activity"].sudo()
             activity_codes = actividades.search([]).mapped("code")
-            for act in afip_activities:
+            for act in unique_acts:
                 if act and str(act.get("idActividad")) not in activity_codes:
                     new_activity.update(
                         {


### PR DESCRIPTION
Estabamos obteniendo este error cada vez que queriamos actualizar un contacto a través del wizard Update from Padron

<img width="1063" height="553" alt="image" src="https://github.com/user-attachments/assets/0fea303a-7c18-4c62-b011-e899cc0a38f4" />

el problema surgia en la definicion de la variable afip_activities

`afip_activities = data_rg.get("actividad", []) + ([data_mt.get("actividadMonotributista", [])] if data_mt else [])`

Acá realizamos la sumatoria de las actividades tanto del régimen general como del régimen monotributo. Y por lo general, se da una duplicidad de actividades, ya que lo que trae data_mt ya está contenido en data_rg. Desconozco si esto es siempre así, con lo cual, a fines de no perder información importante, agregué un filtrado para que las actividades que analicemos sean unicas.