### PR TITLE
[FIX] l10n_ar_currency_update: actualización de moneda.

### DIFF
--- a/l10n_ar_currency_update/models/res_company.py
+++ b/l10n_ar_currency_update/models/res_company.py
@@ -159,7 +159,7 @@ class ResCompany(models.Model):
                         ("company_id", "=", company.id),
                     ]
                 )
-                if currency == "ARS":
+                if currency == company.currency_id.name:
                     continue
                 if already_existing_rate:
                     new_parsed_data.pop(currency)


### PR DESCRIPTION
Ticket: 110979
Cuando la moneda de la compañía es ARS pero el usuario le cambió el nombre por ejemplo a "PES" entonces no se logra hacer la actualización de las tasas de cambio si la primera vez que se sincronizaron monedas con ARCA no se logró hacer la actualización de las tasas (en ese caso solo se actualiza la moneda de la compañía --> tasa 1.0). Cuando reintentamos sincronizar las tasas y se logra la conexión con arca y se obtienen las tasas entonces no se logra actualizar las mismas en odoo porque no estamos actualizando la moneda de la compañía (porque ya existe) y odoo lo requiere (por más de que el tipo de cambio sea el mismo todos los días).
Más información en este video: https://drive.google.com/file/d/1NkR8rcBES0vGoYE23x6IlYiMkO_vYNIp/view