### PR TITLE
[FIX] Bump manual version: 16.0.1.24.0

### DIFF
--- a/l10n_ar_account_tax_settlement/__manifest__.py
+++ b/l10n_ar_account_tax_settlement/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Tax Settlements For Argentina',
-    'version': "16.0.1.23.0",
+    'version': "16.0.1.24.0",
     'category': 'Accounting',
     'website': 'www.adhoc.com.ar',
     'license': 'LGPL-3',


### PR DESCRIPTION
Tarea: 64444
Hago este pr con bump manual de versión porque se mezcló este pr https://github.com/ingadhoc/odoo-argentina-ee/pull/913 con nobump pero en realidad correspondía mezclar con bump, entonces hago este pr para arreglarlo.