### PR TITLE
[FIX] l10n_ar_account_tax_settlement: txt agip pagos migrados con más de una retención

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -604,9 +604,11 @@ class AccountJournal(models.Model):
                     # el amount total de los mismos (move_id.amount_total_in_currency_signed) al total_amount de la
                     # retención. Esto lo hacemos porque en la migración de 16 a 18 se migran los pagos y las retenciones
                     # por separado a diferencia de 16 que estaba todo en el mismo asiento.
+                    # Ignoramos sufijos automáticos tipo " (2)" (por ejemplo) al comparar nombres de pago.
+                    payment_name = re.sub(r"\s\(\d+\)$", "", payment.name)
                     related_payments = self.env["account.payment"].search(
                         [
-                            ("name", "=", payment.name),
+                            ("name", "in", list({payment_name, payment.name})),
                             ("company_id", "=", payment.company_id.id),
                             ("partner_id", "=", payment.partner_id.id),
                             ("id", "!=", payment.id),


### PR DESCRIPTION
Ingnoramos sufijos automáticos en nombres de pagos al buscar pagos relacionados. La especificación (https://github.com/ingadhoc/odoo-argentina-ee/blob/18.0/l10n_ar_account_tax_settlement/README.rst?plain=1#L42C32-L42C124) en el campo 16 "Importe otros conceptos" indica que el mínimo es cero pero había un bug que estamos arreglando en este commit que hacía que dicho importe sea negativo y el bug se daba cuando un pago migrado de 16 a 18 tenía más de una retención asociada y/o más de una línea de pago asociada. Esto se debe a que al buscar los pagos relacionados con la retención, no se ignoraban sufijos automáticos tipo " (2)" (por ejemplo) en el nombre del pago, lo que hacía que no se encontraran los pagos relacionados y por lo tanto no se sumara el importe de pagos relacionados para calcular el importe de otros conceptos, quedando este importe negativo. Con este commit se ignoran dichos sufijos automáticos al buscar los pagos relacionados, lo que hace que se encuentren correctamente y se calcule el importe de otros conceptos correctamente.
Ejemplo 1 (2 retenciones en el pago):
<img width="1808" height="297" alt="image" src="https://github.com/user-attachments/assets/86327e96-7334-416c-91a2-54eacb205566" />

<img width="1157" height="640" alt="image" src="https://github.com/user-attachments/assets/663ef373-5d60-4c92-9706-5159a5f9a45b" />


Ejemplo 2 (el pago en la old tenía 2 retenciones y 2 pagos con banco):
<img width="1796" height="355" alt="image" src="https://github.com/user-attachments/assets/e95cf140-7368-474d-9761-e9ed807ccd83" />
<img width="1142" height="648" alt="image" src="https://github.com/user-attachments/assets/4b338169-255f-4486-bd9b-717955e7bdad" />

Ticket: 112302