### PR TITLE
[ADD] l10n_ar_wsmtxca_ws: new module to support WSMTXCA webservice

### DIFF
--- a/l10n_ar_wsmtxca_ws/README.rst
+++ b/l10n_ar_wsmtxca_ws/README.rst
@@ -1,0 +1,105 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+=====================================================
+Argentinean Electronic Invoicing - WSMTXCA Webservice
+=====================================================
+
+Extends the Argentinean Electronic Invoicing (l10n_ar_edi) to add support for the WSMTXCA webservice (RG2904 - Codificación de producto).
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Install the module from the Apps menu.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Configure your AFIP certificate in *Accounting > Configuration > Settings* (inherited from l10n_ar_edi).
+#. Create or edit a Sales Journal and set **AFIP POS System** to ``Codificación de producto - Web Service (WSMTXCAWS)``.
+#. Set the **AFIP POS Number** according to your AFIP portal configuration.
+#. Set the **MTXCA product code** (``codigoMtx``) on each product used in invoices issued through this webservice.
+   This code is company-specific and must be loaded in the **Barcode** field of the product.
+   Each company must register its own product codes with AFIP.
+
+   For testing purposes or lines without a specific product, the following generic codes provided by ARCA are available:
+
+   ========================  =====================================================
+   Código (codigoMtx)        Descripción
+   ========================  =====================================================
+   7790001001030             Descuentos y bonificaciones comerciales
+   7790001001078             Servicios prestados
+   7790001001054             Ventas varias *(usado por defecto cuando la línea no tiene producto)*
+   7790001001047             Conceptos financieros
+   7790001001061             Bienes de uso
+   7790001001085             Fletes
+   7790001001092             Alquileres
+   7790001001115             Depósito y servicios de logística
+   7790001001122             Repuestos y accesorios
+   7790001001139             Ajustes impositivos
+   7790001001146             Actividades comerciales no codificadas
+   7790001001153             Venta de material de rezago
+   ========================  =====================================================
+
+Usage
+=====
+
+Once configured, the module handles WSMTXCA electronic invoicing automatically when validating invoices
+from a journal with the ``WSMTXCAWS`` POS system:
+
+#. Create an invoice in a journal configured with the WSMTXCAWS POS system.
+#. Validate the invoice. The module will contact the WSMTXCA webservice and request a CAE.
+#. To consult a previously authorized invoice, use *Accounting > Reporting > AFIP WS Consult*.
+#. To check available AFIP POS numbers for the webservice, use the **Check Available AFIP PoS** button on the journal (production mode only).
+#. To consult the exchange rate for a currency via WSMTXCA, use the currency rate consultation feature on the currency record.
+
+Technical
+=========
+
+The module implements the following model extensions:
+
+* ``account.move``: overrides ``_l10n_ar_do_afip_ws_request_cae`` to handle WSMTXCA-specific CAE requests (``autorizarComprobante``), response parsing, and tribute/tax formatting.
+* ``account.journal``: adds the ``WSMTXCAWS`` POS system option, maps it to the ``wsmtxca`` webservice, implements ``_wsmtxca_convert_auth`` for WSMTXCA authentication, and overrides ``l10n_ar_check_afip_pos_number`` and ``_l10n_ar_get_afip_last_invoice_number`` for WSMTXCA.
+* ``res.currency``: overrides ``_l10n_ar_get_afip_ws_currency_rate`` to query exchange rates via the WSMTXCA ``consultarCotizacionMoneda`` service.
+* ``l10n_ar.afipws.connection``: overrides ``_l10n_ar_get_afip_ws_url`` to register the WSMTXCA WSDL endpoints for production and testing environments.
+* ``l10n_ar_afip.ws.consult`` (wizard): extends the invoice consultation wizard to support the ``WSMTXCAWS`` POS system, delegating to ``consultarComprobante`` on the WSMTXCA service.
+
+WSMTXCA endpoints:
+
+* Production: ``https://serviciosjava.afip.gob.ar/wsmtxca/services/MTXCAService?wsdl``
+* Testing: ``https://fwshomo.afip.gov.ar/wsmtxca/services/MTXCAService?wsdl``
+
+For official AFIP documentation see: https://www.afip.gob.ar/ws/documentacion/ws-mtxca.asp
+
+Credits
+=======
+
+Images
+------
+
+* |company| |icon|
+
+Contributors
+------------
+
+Maintainer
+----------
+
+|company_logo|
+
+This module is maintained by the |company|.
+
+To contribute to this module, please visit https://www.adhoc.com.ar.

--- a/l10n_ar_wsmtxca_ws/__init__.py
+++ b/l10n_ar_wsmtxca_ws/__init__.py
@@ -1,0 +1,6 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import models
+from . import wizards

--- a/l10n_ar_wsmtxca_ws/__manifest__.py
+++ b/l10n_ar_wsmtxca_ws/__manifest__.py
@@ -1,0 +1,36 @@
+##############################################################################
+#
+#    Copyright (C) 2015  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Argentinean Electronic Invoicing - WSMTXCA Webservice",
+    "version": "18.0.1.0.0",
+    "category": "Localization/Argentina",
+    "sequence": 14,
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "summary": "",
+    "depends": [
+        "l10n_ar_edi",
+    ],
+    "data": [],
+    "installable": True,
+    "auto_install": False,
+    "application": False,
+}

--- a/l10n_ar_wsmtxca_ws/i18n/es.po
+++ b/l10n_ar_wsmtxca_ws/i18n/es.po
@@ -1,0 +1,136 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_ar_wsmtxca_ws
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-15 00:00+0000\n"
+"PO-Revision-Date: 2026-05-15 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+
+#. module: l10n_ar_wsmtxca_ws
+#. odoo-python
+#: code:addons/l10n_ar_wsmtxca_ws/models/account_move.py:0
+#: code:addons/l10n_ar_wsmtxca_ws/wizards/l10n_ar_afip_ws_consult.py:0
+msgid "\nAdditional Information:\n"
+msgstr "\nInformación adicional:\n"
+
+#. module: l10n_ar_wsmtxca_ws
+#. odoo-python
+#: code:addons/l10n_ar_wsmtxca_ws/models/account_move.py:0
+#: code:addons/l10n_ar_wsmtxca_ws/wizards/l10n_ar_afip_ws_consult.py:0
+msgid "\n* Code %s: %s"
+msgstr "\n* Código %s: %s"
+
+#. module: l10n_ar_wsmtxca_ws
+#. odoo-python
+#: code:addons/l10n_ar_wsmtxca_ws/wizards/l10n_ar_afip_ws_consult.py:0
+msgid "\n* Evento %s: %s"
+msgstr "\n* Evento %s: %s"
+
+#. module: l10n_ar_wsmtxca_ws
+#. odoo-python
+#: code:addons/l10n_ar_wsmtxca_ws/wizards/l10n_ar_afip_ws_consult.py:0
+msgid "\n* Observations %s: %s"
+msgstr "\n* Observaciones %s: %s"
+
+#. module: l10n_ar_wsmtxca_ws
+#. odoo-python
+#: code:addons/l10n_ar_wsmtxca_ws/wizards/l10n_ar_afip_ws_consult.py:0
+#, python-format
+msgid "AFIP Errors: %(error)s"
+msgstr "Errores AFIP: %(error)s"
+
+#. module: l10n_ar_wsmtxca_ws
+#. odoo-python
+#: code:addons/l10n_ar_wsmtxca_ws/models/account_move.py:0
+msgid "AFIP Messages"
+msgstr "Mensajes AFIP"
+
+#. module: l10n_ar_wsmtxca_ws
+#. odoo-python
+#: code:addons/l10n_ar_wsmtxca_ws/models/account_journal.py:0
+msgid "Codificación de producto - RG2904 (WSMTXCA)"
+msgstr ""
+
+#. module: l10n_ar_wsmtxca_ws
+#. odoo-python
+#: code:addons/l10n_ar_wsmtxca_ws/models/account_journal.py:0
+msgid "Codificación de producto - Web Service"
+msgstr ""
+
+#. module: l10n_ar_wsmtxca_ws
+#. odoo-python
+#: code:addons/l10n_ar_wsmtxca_ws/wizards/l10n_ar_afip_ws_consult.py:0
+msgid "Invoice number %s\n"
+msgstr "Número de factura %s\n"
+
+#. module: l10n_ar_wsmtxca_ws
+#. odoo-python
+#: code:addons/l10n_ar_wsmtxca_ws/wizards/l10n_ar_afip_ws_consult.py:0
+msgid "No AFIP WS selected on point of sale %s"
+msgstr "No hay WS de AFIP seleccionado en el punto de venta %s"
+
+#. module: l10n_ar_wsmtxca_ws
+#. odoo-python
+#: code:addons/l10n_ar_wsmtxca_ws/models/res_currency.py:0
+msgid ""
+"No AFIP code for currency %s. Please configure the AFIP code consulting "
+"information in AFIP page"
+msgstr ""
+"No hay código AFIP para la moneda %s. Por favor configure el código AFIP "
+"consultando información en la página de AFIP"
+
+#. module: l10n_ar_wsmtxca_ws
+#. odoo-python
+#: code:addons/l10n_ar_wsmtxca_ws/models/account_move.py:0
+msgid "No AFIP code in %s UOM"
+msgstr "No hay código AFIP en la unidad de medida %s"
+
+#. module: l10n_ar_wsmtxca_ws
+#. odoo-python
+#: code:addons/l10n_ar_wsmtxca_ws/models/res_currency.py:0
+msgid "No rate for ARS (is the base currency for AFIP)"
+msgstr "No hay tipo de cambio para ARS (es la moneda base para AFIP)"
+
+#. module: l10n_ar_wsmtxca_ws
+#. odoo-python
+#: code:addons/l10n_ar_wsmtxca_ws/wizards/l10n_ar_afip_ws_consult.py:0
+msgid "Please set the number you want to consult"
+msgstr "Por favor establezca el número que desea consultar"
+
+#. module: l10n_ar_wsmtxca_ws
+#. odoo-python
+#: code:addons/l10n_ar_wsmtxca_ws/models/account_move.py:0
+msgid ""
+"The product '%s' does not have a valid Codigo MTX for ARCA. "
+"Please set a valid barcode in the product to continue."
+msgstr ""
+"El producto '%s' no tiene un Código MTX válido para ARCA. "
+"Por favor establezca un código de barras válido en el producto para continuar."
+
+#. module: l10n_ar_wsmtxca_ws
+#. odoo-python
+#: code:addons/l10n_ar_wsmtxca_ws/models/account_move.py:0
+msgid "The product %s has an invalid barcode for ARCA (only GS1 o Códigos GTIN 8/12/13)"
+msgstr "El producto %s tiene un código de barras inválido para ARCA (solo GS1 o Códigos GTIN 8/12/13)"
+
+#. module: l10n_ar_wsmtxca_ws
+#. odoo-python
+#: code:addons/l10n_ar_wsmtxca_ws/models/account_journal.py:0
+msgid "\"Check Available AFIP PoS\" is not implemented in testing mode for webservice %s"
+msgstr "\"Consultar Puntos de Venta AFIP\" no está implementado en modo de prueba para el webservice %s"
+
+#. module: l10n_ar_wsmtxca_ws
+#. odoo-python
+#: code:addons/l10n_ar_wsmtxca_ws/models/account_journal.py:0
+msgid "We receive this error trying to consult the last invoice number to AFIP:\n%s"
+msgstr "Recibimos este error al intentar consultar el último número de factura a AFIP:\n%s"

--- a/l10n_ar_wsmtxca_ws/models/__init__.py
+++ b/l10n_ar_wsmtxca_ws/models/__init__.py
@@ -1,0 +1,4 @@
+from . import account_journal
+from . import account_move
+from . import l10n_ar_afipws_connection
+from . import res_currency

--- a/l10n_ar_wsmtxca_ws/models/account_journal.py
+++ b/l10n_ar_wsmtxca_ws/models/account_journal.py
@@ -1,0 +1,101 @@
+from odoo import _, api, models
+from odoo.exceptions import UserError
+
+
+class AccountJournal(models.Model):
+    _inherit = "account.journal"
+
+    def _get_l10n_ar_afip_ws(self):
+        """Return the list of values of the selection field."""
+        res = super()._get_l10n_ar_afip_ws()
+        return res + [
+            ("wsmtxca", _("Codificación de producto - RG2904 (WSMTXCA)")),
+        ]
+
+    def _get_l10n_ar_afip_pos_types_selection(self):
+        """Add more options to the selection field AFIP POS System, re order options by common use"""
+        res = super()._get_l10n_ar_afip_pos_types_selection()
+        res.append(("WSMTXCAWS", _("Codificación de producto - Web Service")))
+        return res
+
+    @api.depends("l10n_ar_afip_pos_system")
+    def _compute_l10n_ar_afip_ws(self):
+        """Depending on AFIP POS System selected set the proper AFIP WS"""
+        super()._compute_l10n_ar_afip_ws()
+        for rec in self:
+            if rec.l10n_ar_afip_pos_system == "WSMTXCAWS":
+                rec.l10n_ar_afip_ws = "wsmtxca"
+
+    def l10n_ar_check_afip_pos_number(self):
+        """Return information about the AFIP POS numbers related to the given AFIP WS"""
+        if self.l10n_ar_afip_ws != "wsmtxca":
+            return super().l10n_ar_check_afip_pos_number()
+        self.ensure_one()
+        connection = self.company_id._l10n_ar_get_connection(self.l10n_ar_afip_ws)
+        client, auth = connection._get_client()
+        if self.company_id._get_environment_type() == "testing":
+            raise UserError(
+                _(
+                    '"Check Available AFIP PoS" is not implemented in testing mode for webservice %s',
+                    self.l10n_ar_afip_ws,
+                )
+            )
+        auth = self._wsmtxca_convert_auth(auth)
+        response = client.service.consultarPuntosVentaCAE(auth)
+        raise UserError(response)
+
+    def _l10n_ar_get_afip_last_invoice_number(self, document_type):
+        """Consult via webservice the number of the last invoice register"""
+        afip_ws = self.l10n_ar_afip_ws
+        if afip_ws != "wsmtxca":
+            return super()._l10n_ar_get_afip_last_invoice_number(document_type)
+        self.ensure_one()
+        if self.env.registry.in_test_mode():
+            return 0
+
+        pos_number = self.l10n_ar_afip_pos_number
+        connection = self.company_id._l10n_ar_get_connection(afip_ws)
+        client, auth = connection._get_client()
+        last = errors = False
+
+        data = self._wsmtxca_convert_auth(auth)
+        response = client.service.consultarUltimoComprobanteAutorizado(
+            data,
+            consultaUltimoComprobanteAutorizadoRequest={
+                "codigoTipoComprobante": document_type.code,
+                "numeroPuntoVenta": pos_number,
+            },
+        )
+        if response.numeroComprobante:
+            last = response.numeroComprobante
+        if response.arrayErrores:
+            errors = "".join(
+                ["\n* Code %s: %s" % (err.codigo, err.descripcion) for err in response.arrayErrores.codigoDescripcion]
+            )
+            error_first_invoice = [1502]
+            if error_first_invoice == [err.codigo for err in response.arrayErrores.codigoDescripcion]:
+                errors = False  # No invoices found for this document type
+                last = 0
+
+        if errors:
+            raise UserError(_("We received this error while consulting the last invoice number from ARCA:\n%s", errors))
+        return last
+
+    @api.model
+    def _get_codes_per_journal_type(self, afip_pos_system):
+        res = super()._get_codes_per_journal_type(afip_pos_system)
+        if afip_pos_system != "WSMTXCAWS":
+            return res
+
+        usual_codes = ["1", "2", "3", "6", "7", "8"]
+        invoice_m_code = ["51", "52", "53"]
+        mipyme_codes = ["201", "202", "203", "206", "207", "208"]
+        codes = usual_codes + invoice_m_code + mipyme_codes
+
+        res[0] = ("code", "in", codes)
+        return res
+
+    @api.model
+    def _wsmtxca_convert_auth(self, auth):
+        res = {"sign": auth.get("Sign"), "token": auth.get("Token"), "cuitRepresentada": auth.get("Cuit")}
+        return res

--- a/l10n_ar_wsmtxca_ws/models/account_move.py
+++ b/l10n_ar_wsmtxca_ws/models/account_move.py
@@ -1,0 +1,397 @@
+from markupsafe import Markup
+from odoo import _, models
+from odoo.exceptions import UserError
+from odoo.tools import plaintext2html
+from odoo.tools.float_utils import float_repr, float_round
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def _l10n_ar_do_afip_ws_request_cae(self, client, auth, transport):
+        """Override to handle wsmtxca webservice logic."""
+        non_wsmtxca = self.filtered(lambda x: x.journal_id.l10n_ar_afip_ws != "wsmtxca")
+        if non_wsmtxca:
+            return_info = super(AccountMove, non_wsmtxca)._l10n_ar_do_afip_ws_request_cae(client, auth, transport)
+            if return_info:
+                return return_info
+
+        for inv in self.filtered(lambda x: x.journal_id.l10n_ar_afip_ws == "wsmtxca" and not x.l10n_ar_afip_auth_code):
+            afip_ws = inv.journal_id.l10n_ar_afip_ws
+            errors = obs = events = ""
+            return_codes = []
+            values = {}
+
+            inv.l10n_ar_check_rate()
+
+            ws_method = "autorizarComprobante"
+            request_data = inv.wsmtxca_get_cae_request(client)
+            auth = inv.journal_id._wsmtxca_convert_auth(auth)
+            self._ws_verify_request_data(client, auth, ws_method, request_data)
+
+            response = client.service[ws_method](auth, request_data)
+            if response:
+                if response.resultado in ["A", "O"] and response.comprobanteResponse:
+                    result = response.comprobanteResponse
+                    values = {
+                        "l10n_ar_afip_auth_mode": "CAE",
+                        "l10n_ar_afip_auth_code": result.CAE and str(result.CAE) or "",
+                        "l10n_ar_afip_auth_code_due": result.fechaVencimientoCAE,
+                        "l10n_ar_afip_result": response.resultado,
+                    }
+
+            if response.arrayObservaciones:
+                obs = "".join(
+                    [
+                        _("\n* Code %s: %s", ob.codigo, ob.descripcion)
+                        for ob in response.arrayObservaciones.codigoDescripcion
+                    ]
+                )
+                return_codes += [str(ob.codigo) for ob in response.arrayObservaciones.codigoDescripcion]
+            if response.arrayErrores:
+                errors = "".join(
+                    [
+                        _("\n* Code %s: %s", err.codigo, err.descripcion)
+                        for err in response.arrayErrores.codigoDescripcion
+                    ]
+                )
+                return_codes += [str(err.codigo) for err in response.arrayErrores.codigoDescripcion]
+            if response.evento:
+                events = "".join([_("\n* Code %s: %s", response.evento.codigo, response.evento.descripcion)])
+                return_codes += [str(response.evento.codigo)]
+
+            return_info = inv._prepare_return_msg(afip_ws, errors, obs, events, return_codes)
+            afip_result = values.get("l10n_ar_afip_result")
+            xml_response, xml_request = transport.xml_response, transport.xml_request
+            if afip_result not in ["A", "O"]:
+                if not self.env.context.get("l10n_ar_invoice_skip_commit"):
+                    self.env.cr.rollback()
+                if inv.exists():
+                    # Only save the xml_request/xml_response fields if the invoice exists.
+                    # It is possible that the invoice will rollback as well e.g. when it is automatically created:
+                    #   * creating credit note with full reconcile option
+                    #   * creating/validating an invoice from subscription/sales
+                    inv.sudo().write(
+                        {
+                            "l10n_ar_afip_xml_request": xml_request,
+                            "l10n_ar_afip_xml_response": xml_response,
+                        }
+                    )
+                if not self.env.context.get("l10n_ar_invoice_skip_commit"):
+                    self.env.cr.commit()  # pylint: disable=invalid-commit
+                return return_info
+            values.update(
+                l10n_ar_afip_xml_request=xml_request,
+                l10n_ar_afip_xml_response=xml_response,
+            )
+            inv.sudo().write(values)
+            if return_info:
+                inv.message_post(
+                    body=Markup("<p><b>%s%s</b></p>") % (_("AFIP Messages"), plaintext2html(return_info, "em"))
+                )
+
+    def _get_tributes(self, base_lines=None):
+        """Override to add wsmtxca specific format for tributes."""
+        res = super()._get_tributes(base_lines=base_lines)
+        if self.env.context.get("wsmtxca") and res:
+            new_res = []
+            for item in res:
+                new_res.append(
+                    {
+                        "codigo": item["Id"],
+                        "descripcion": item["Desc"],
+                        "baseImponible": item["BaseImp"],
+                        "importe": item["Importe"],
+                    }
+                )
+            return new_res
+        return res
+
+    def _get_related_invoice_data(self):
+        """Override to add wsmtxca specific keys for related invoice data."""
+        afip_ws = self.journal_id.l10n_ar_afip_ws
+        res = {}
+        if afip_ws != "wsmtxca":
+            return super()._get_related_invoice_data()
+
+        related_inv = self._found_related_invoice()
+        if not related_inv:
+            return res
+
+        # Convert keys to wsmtxca format
+        wsmtxca_keys = {
+            "type": "codigoTipoComprobante",
+            "pos_number": "numeroPuntoVenta",
+            "number": "numeroComprobante",
+            "cuit": "cuit",
+            "date": "fechaEmision",
+        }
+
+        res.update(
+            {
+                wsmtxca_keys["type"]: related_inv.l10n_latam_document_type_id.code,
+                wsmtxca_keys["pos_number"]: related_inv.journal_id.l10n_ar_afip_pos_number,
+                wsmtxca_keys["number"]: self._l10n_ar_get_document_number_parts(
+                    related_inv.l10n_latam_document_number,
+                    related_inv.l10n_latam_document_type_id.code,
+                )["invoice_number"],
+            }
+        )
+
+        return res
+
+    def _get_line_details(self, base_lines=None):
+        """Override to add wsmtxca specific format for line details."""
+        base_lines = base_lines or []
+        details = super()._get_line_details(base_lines=base_lines)
+
+        if (afip_ws := self.journal_id.l10n_ar_afip_ws) and afip_ws != "wsmtxca":
+            return details
+
+        details = []
+        price_precision_digits = min(self.env["decimal.precision"].precision_get("Product Price"), 3)
+
+        for base_line in base_lines:
+            line = base_line["record"]
+
+            if line.display_type in ("line_section", "line_note"):
+                continue
+
+            if line.product_id and not line.product_uom_id.l10n_ar_afip_code:
+                raise UserError(_("No AFIP code in %s UOM", line.product_uom_id.name))
+
+            Pro_umed = line.product_uom_id.l10n_ar_afip_code if line.product_id else "00"
+            quantity = base_line["quantity"]
+
+            if Pro_umed not in ("97", "99", "00"):
+                if line._get_downpayment_lines():
+                    Pro_umed = "97"
+                elif line.price_unit < 0:
+                    Pro_umed = "99"
+
+            is_senia_or_discount = Pro_umed in ("97", "99")
+            is_letter_b = self.l10n_latam_document_type_id.code in ("6", "7", "8")
+
+            unit_price_net = float_repr(line.price_unit, precision_digits=price_precision_digits)
+            vat_tax = line.tax_ids.filtered(lambda x: x.tax_group_id.l10n_ar_vat_afip_code)
+
+            # IVA amount from tax details
+            importeIVA_taxes = sum(
+                td["tax_amount_currency"]
+                for td in base_line["tax_details"]["taxes_data"]
+                if td["tax"].tax_group_id.l10n_ar_vat_afip_code
+            )
+
+            if is_letter_b:
+                # Letter B: precioUnitario includes IVA, importeIVA is not reported separately
+                vat_rate = vat_tax.amount / 100.0 if vat_tax else 0.0
+                precioUnitario = float_repr(
+                    line.price_unit * (1 + vat_rate),
+                    precision_digits=price_precision_digits,
+                )
+                total_with_iva = base_line["tax_details"]["raw_total_included_currency"]
+                discount_amount = base_line["discount"] and (float(precioUnitario) * quantity - total_with_iva) or 0.0
+                importeIVA = 0.0
+                importeItem = (
+                    float(precioUnitario) * quantity - discount_amount if not is_senia_or_discount else total_with_iva
+                )
+            else:
+                # Letter A (and others): precioUnitario is NET (sin IVA), importeIVA reported separately
+                precioUnitario = unit_price_net
+                # Descuento NETO (sin IVA): precio_truncado * qty - base_neta_cruda
+                discount_amount = (
+                    base_line["discount"]
+                    and (float(unit_price_net) * quantity - base_line["tax_details"]["raw_total_excluded_currency"])
+                    or 0.0
+                )
+                importeIVA = importeIVA_taxes
+                # importeItem = base_neta + importeIVA (fórmula AFIP, error 519)
+                base_neta = (
+                    float(unit_price_net) * quantity - discount_amount
+                    if not is_senia_or_discount
+                    else base_line["tax_details"]["raw_total_excluded_currency"]
+                )
+                importeItem = base_neta + importeIVA
+
+            values = {
+                "unidadesMtx": "1",
+                "codigoMtx": self._get_codigoMtx(line),
+                "codigo": line.product_id.default_code or None,
+                "descripcion": line.name,
+                "codigoUnidadMedida": int(Pro_umed) or 7,
+                "cantidad": quantity if not is_senia_or_discount else None,
+                "precioUnitario": precioUnitario if not is_senia_or_discount else None,
+                "codigoCondicionIVA": vat_tax.tax_group_id.l10n_ar_vat_afip_code,
+                "importeItem": float_repr(importeItem, precision_digits=2),
+                "importeIVA": float_repr(importeIVA, precision_digits=2) if importeIVA else None,
+                "importeBonificacion": float_repr(discount_amount, precision_digits=6) if discount_amount else None,
+            }
+            details.append(values)
+
+        return details
+
+    def _get_codigoMtx(self, line):
+        """Return the codigoMtx that applies.
+
+        Could be the barcode of the product or either the  generic code depending on the type of product/service or
+        discounts
+
+        Casos disponibles en ARCA Codigos genericos codigoMtx
+        ** 7790001001030, Descuentos y bonificaciones comerciales
+        ** 7790001001078, Servicios prestados
+        ** 7790001001054, Ventas varias  (lo agregamos  como por defecto cuando no hay producto en linea)
+
+        7790001001047, Conceptos financieros
+        7790001001061, Bienes de uso                        (elif line.product_id.is_asset:)
+        7790001001085, Fletes                                (Posiblemente lo agreguemos en futuro)
+        7790001001092, Alquileres
+        7790001001115, Depósito y servicios de logística
+        7790001001122, Repuestos y accesorios
+        7790001001139, Ajustes impositivos
+        7790001001146, Actividades comerciales no codificadas
+        7790001001153, Venta de material de rezago
+        """
+        cod_mtx = ""
+        if barcode := line.product_id.barcode:
+            if barcode.isdigit() and len(barcode) in (8, 12, 13):
+                cod_mtx = barcode.zfill(13)
+            else:
+                raise UserError(
+                    _(
+                        "The product %s has an invalid barcode for ARCA (only GS1 o Códigos GTIN 8/12/13)",
+                        line.product_id.name,
+                    )
+                )
+
+        if not cod_mtx:
+            if line.product_id.type == "service":
+                cod_mtx = "7790001001078"  # Servicios prestados
+            elif line.price_total < 0.0:
+                cod_mtx = "7790001001030"  # Descuentos y bonificaciones comerciales
+            elif not line.product_id:
+                cod_mtx = "7790001001054"  # Ventas varias
+
+        if not cod_mtx:
+            raise UserError(
+                _(
+                    "The product '%s' does not have a valid Codigo MTX for ARCA. "
+                    "Please set a valid barcode in the product to continue.",
+                    line.product_id.name,
+                )
+            )
+        return cod_mtx
+
+    def _get_optionals_data(self):
+        """Override to add wsmtxca specific format for optional data."""
+        optionals = super()._get_optionals_data()
+        afip_ws = self.journal_id.l10n_ar_afip_ws
+
+        if afip_ws != "wsmtxca" or not optionals:
+            return optionals
+
+        # Convert to wsmtxca format
+        wsmtxca_optionals = []
+        for opt in optionals:
+            wsmtxca_optionals.append({"t": opt.get("Id"), "c1": opt.get("Valor")})
+        return wsmtxca_optionals
+
+    def wsmtxca_get_cae_request(self, client=None):
+        """Generate CAE request data for wsmtxca webservice."""
+        res = {}
+        partner_id_code = self._get_partner_code_id(self.commercial_partner_id)
+        base_lines, _tax_lines = self._get_rounded_base_and_tax_lines()
+        amounts = self._l10n_ar_get_amounts(base_lines=base_lines)
+        related_invoices = self._get_related_invoice_data()
+        due_payment_date = self._due_payment_date()
+        service_start, service_end = self._service_dates()
+        tributes = self.with_context(wsmtxca=True)._get_tributes(base_lines=base_lines)
+        vat_data = self._get_vat(base_lines=base_lines)
+        temp = []
+
+        WS_DATE_FORMAT = {
+            "wsfe": "%Y%m%d",
+            "wsfex": "%Y%m%d",
+            "wsbfe": "%Y%m%d",
+            "wsmtxca": "%Y-%m-%d",
+        }
+
+        # Post process vat_data
+        # Step 1: modify the keys of the dictionary to make it work with wsmtxca
+        vat_needed = ["4", "5", "6"]
+        for item in vat_data:
+            if "Id" in item and "Importe" in item and item.get("Id") in vat_needed:
+                temp.append(
+                    {
+                        "codigo": item["Id"],
+                        "importe": float_repr(item["Importe"], precision_digits=2),
+                    }
+                )
+        vat_data = temp
+        # Step 2: ensure that all vat types are present even if amount is 0
+        vat_data_keys = [item["codigo"] for item in vat_data]
+        vat_code_used = self.line_ids.mapped("tax_ids.tax_group_id.l10n_ar_vat_afip_code")
+        for cod_iva in vat_code_used:
+            if cod_iva in vat_needed and cod_iva not in vat_data_keys:
+                vat_data.append({"codigo": cod_iva, "importe": 0.0})
+
+        ArrayItemsType = client.get_type("ns0:ArrayItemsType")
+        ArraySubtotalesIVA = client.get_type("ns0:ArraySubtotalesIVAType")
+        ComprobanteAsociadoType = client.get_type("ns0:ArrayComprobantesAsociadosType")
+        ArrayOtrosTributosType = client.get_type("ns0:ArrayOtrosTributosType")
+
+        invoice_number = self._l10n_ar_get_document_number_parts(
+            self.l10n_latam_document_number, self.l10n_latam_document_type_id.code
+        )["invoice_number"]
+        vat = partner_id_code and self.commercial_partner_id._get_id_number_sanitize()
+
+        importeGravado = amounts["vat_taxable_amount"]
+        importeNoGravado = amounts["vat_untaxed_base_amount"]
+
+        res = {
+            "codigoTipoComprobante": int(self.l10n_latam_document_type_id.code),
+            "numeroPuntoVenta": int(self.journal_id.l10n_ar_afip_pos_number),
+            "numeroComprobante": invoice_number,
+            "numeroDocumento": vat and int(vat) or 0,
+            "condicionIVAReceptor": int(self.partner_id.l10n_ar_afip_responsibility_type_id.code),
+            "fechaEmision": self.invoice_date.strftime(WS_DATE_FORMAT["wsmtxca"]),
+            "codigoConcepto": int(self.l10n_ar_afip_concept),
+            "codigoTipoDocumento": int(partner_id_code) or 0,
+            "codigoMoneda": self.currency_id.l10n_ar_afip_code,
+            "cotizacionMoneda": float_repr(1 / self.invoice_currency_rate, precision_digits=6),
+            "importeTotal": float_round(self.amount_total, precision_digits=2),
+            "importeSubtotal": float_round(
+                amounts["vat_taxable_amount"] + amounts["vat_untaxed_base_amount"] + amounts["vat_exempt_base_amount"],
+                precision_digits=2,
+            ),
+            "importeGravado": float_round(importeGravado, precision_digits=2),
+            "importeExento": float_round(amounts["vat_exempt_base_amount"], precision_digits=2),
+            "importeNoGravado": float_round(importeNoGravado, precision_digits=2),
+            "importeOtrosTributos": float_round(amounts["not_vat_taxes_amount"], precision_digits=2)
+            if amounts["not_vat_taxes_amount"]
+            else None,
+            "arrayItems": ArrayItemsType(self._get_line_details(base_lines=base_lines)),
+            "arraySubtotalesIVA": ArraySubtotalesIVA(vat_data) if vat_data else None,
+            "arrayComprobantesAsociados": ComprobanteAsociadoType([related_invoices]) if related_invoices else None,
+            "arrayOtrosTributos": ArrayOtrosTributosType(tributes) if tributes else None,
+            "fechaServicioDesde": service_start.strftime(WS_DATE_FORMAT["wsmtxca"]) if service_start else None,
+            "fechaServicioHasta": service_end.strftime(WS_DATE_FORMAT["wsmtxca"]) if service_end else None,
+            "fechaVencimientoPago": due_payment_date.strftime(WS_DATE_FORMAT["wsmtxca"]) if due_payment_date else None,
+        }
+        if self.l10n_latam_document_type_id.code in ["201", "206"]:  # WSMT148
+            res.update({"fechaVencimientoPago": self._due_payment_date().strftime(WS_DATE_FORMAT["wsmtxca"])})
+
+        optionals = self._get_optionals_data()
+        if optionals:
+            ArrayDatosAdicionalesType = client.get_type("ns0:ArrayDatosAdicionalesType")
+            res.update({"arrayDatosAdicionales": ArrayDatosAdicionalesType(optionals) if optionals else None})
+
+        if res.get("codigoMoneda") != "PES" and res["codigoTipoComprobante"] in (
+            1,
+            6,
+            51,
+            201,
+            206,
+        ):
+            res["cancelaEnMismaMonedaExtranjera"] = {"Yes": "S", "No": "N"}.get(self.l10n_ar_payment_foreign_currency)
+
+        return res

--- a/l10n_ar_wsmtxca_ws/models/l10n_ar_afipws_connection.py
+++ b/l10n_ar_wsmtxca_ws/models/l10n_ar_afipws_connection.py
@@ -1,0 +1,20 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import api, models
+
+
+class L10nArAfipwsConnection(models.Model):
+    _inherit = "l10n_ar.afipws.connection"
+
+    @api.model
+    def _l10n_ar_get_afip_ws_url(self, afip_ws, environment_type):
+        """Extend to add wsmtxca webservice."""
+        if afip_ws != "wsmtxca":
+            return super()._l10n_ar_get_afip_ws_url(afip_ws, environment_type)
+
+        ws_data = {
+            "wsmtxca": {
+                "production": "https://serviciosjava.afip.gob.ar/wsmtxca/services/MTXCAService?wsdl",
+                "testing": "https://fwshomo.afip.gov.ar/wsmtxca/services/MTXCAService?wsdl",
+            },
+        }
+        return ws_data.get(afip_ws, {}).get(environment_type)

--- a/l10n_ar_wsmtxca_ws/models/res_currency.py
+++ b/l10n_ar_wsmtxca_ws/models/res_currency.py
@@ -1,0 +1,38 @@
+import logging
+
+from odoo import _, models
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+
+class ResCurrency(models.Model):
+    _inherit = "res.currency"
+
+    def _l10n_ar_get_afip_ws_currency_rate(self, afip_ws="wsfe", date_rate=None):
+        """Retrieve the currency exchange rate and date from AFIP web services."""
+        if afip_ws != "wsmtxca":
+            return super()._l10n_ar_get_afip_ws_currency_rate(afip_ws, date_rate)
+        self.ensure_one()
+        if not self.l10n_ar_afip_code:
+            raise UserError(
+                _(
+                    "No AFIP code for currency %s. Please configure the AFIP code consulting information in AFIP page",
+                    self.name,
+                )
+            )
+        if self.l10n_ar_afip_code == "PES":
+            raise UserError(_("No rate for ARS (is the base currency for AFIP)"))
+        connection = self.env.company._l10n_ar_get_connection(afip_ws)
+        client, auth = connection._get_client()
+        auth = self.env["account.journal"]._wsmtxca_convert_auth(auth)
+        req_data = {"codigoMoneda": self.l10n_ar_afip_code}
+        if date_rate:
+            req_data["fechaCotizacion"] = date_rate.strftime("%Y-%m-%d")
+        response = client.service.consultarCotizacionMoneda(auth, **req_data)
+        if response.arrayErrores:
+            _logger.warning("Errors getting currency rate from WSMTXCA: %s", response.arrayErrores)
+            return date_rate, False
+        rate = float(response.cotizacionMoneda)
+        date = date_rate.strftime("%Y-%m-%d") if date_rate else getattr(response, "fechaCotizacion", False)
+        return date, rate

--- a/l10n_ar_wsmtxca_ws/wizards/__init__.py
+++ b/l10n_ar_wsmtxca_ws/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import l10n_ar_afip_ws_consult

--- a/l10n_ar_wsmtxca_ws/wizards/l10n_ar_afip_ws_consult.py
+++ b/l10n_ar_wsmtxca_ws/wizards/l10n_ar_afip_ws_consult.py
@@ -1,0 +1,75 @@
+import logging
+
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+from odoo.tools.zeep.helpers import serialize_object
+
+_logger = logging.getLogger(__name__)
+
+
+class L10nArAfipWsConsult(models.TransientModel):
+    _inherit = "l10n_ar_afip.ws.consult"
+
+    journal_id = fields.Many2one(
+        domain="[('l10n_ar_afip_pos_system', 'in', ['RAW_MAW', 'BFEWS', 'FEEWS', 'WSMTXCAWS'])]",
+    )
+
+    def button_confirm(self):
+        self.ensure_one()
+        afip_ws = self.journal_id.l10n_ar_afip_ws
+
+        # Si no es wsmtxca, delegar al método padre
+        if afip_ws != "wsmtxca":
+            return super().button_confirm()
+
+        # Lógica específica para wsmtxca
+        pos_number = self.journal_id.l10n_ar_afip_pos_number
+        extra = []
+        error = None
+
+        if not afip_ws:
+            raise UserError(_("No AFIP WS selected on point of sale %s", self.journal_id.name))
+        if not self.number:
+            raise UserError(_("Please set the number you want to consult"))
+
+        connection = self.journal_id.company_id._l10n_ar_get_connection(afip_ws)
+        client, auth = connection._get_client()
+
+        auth = self.journal_id._wsmtxca_convert_auth(auth)
+        response = client.service.consultarComprobante(
+            auth,
+            {
+                "codigoTipoComprobante": self.document_type_id.code,
+                "numeroPuntoVenta": pos_number,
+                "numeroComprobante": self.number,
+            },
+        )
+
+        if response.arrayErrores:
+            error = "".join(
+                [
+                    _("\n* Code %s: %s", item.codigo, item.descripcion)
+                    for item in response.arrayErrores.codigoDescripcion
+                ]
+            )
+        if response.arrayObservaciones:
+            extra += [
+                _("\n* Observations %s: %s", item.codigo, item.descripcion)
+                for item in response.arrayObservaciones.codigoDescripcion
+            ]
+        if response.evento:
+            extra += [_("\n* Evento %s: %s", response.evento.codigo, response.evento.descripcion)]
+        res = response.comprobante
+
+        title = _("Invoice number %s\n", self.number)
+        if error:
+            _logger.warning("%s\n%s" % (title, error))
+            raise UserError(_("AFIP Errors: %(error)s", error=error))
+
+        msg = ""
+        data = serialize_object(res, dict)
+        for key, value in data.items():
+            msg += " * %s: %s\n" % (key, value or "")
+        if extra:
+            msg += _("\nAdditional Information:\n") + "".join(extra)
+        raise UserError(title + msg)


### PR DESCRIPTION
Este PR introduce el nuevo módulo `l10n_ar_wsmtxca_ws`, que amplía la funcionalidad de facturación electrónica argentina para admitir el servicio web WSMTXCA (RG2904 - Codificación de producto). Los principales cambios incluyen la estructura del módulo, la documentación inicial, la compatibilidad con la localización y las ampliaciones del modelo central para integrarse con el servicio web WSMTXCA para la facturación electrónica en Argentina.

**Cambios clave:**

Estructura del módulo y documentación:

* Se ha añadido un archivo `README.rst` completo que detalla la instalación, la configuración, el uso, los detalles técnicos, los puntos finales y los créditos del nuevo módulo de integración WSMTXCA.
* Se ha creado el archivo de manifiesto del módulo `__manifest__.py` con metadatos, dependencias e información sobre licencias.
* Se han añadido los archivos de inicialización del módulo `__init__.py` y `models/__init__.py` para registrar modelos y asistentes. [[1]](diffhunk://#diff-377d149ad0be57670e284ccf5ab6f1a2b7ede3b465bfa837e55291a88a8d67ddR1-R6) [[2]](diffhunk://# diff-75674a5d5ad78164302f9eb8ed5992fbc6f7f8569d1534f2f5696f499d172df3R1-R4)

Localización y traducciones:

* Se ha introducido un archivo de traducción inicial al español `i18n/es.po` con todas las cadenas necesarias para el nuevo módulo, que abarca mensajes de usuario, errores y etiquetas de la interfaz de usuario.

Modelo central y lógica de integración:

* Se ha añadido `account_journal.py` con la lógica para:
  - Registrar el servicio web WSMTXCA como una opción del sistema AFIP WS y POS.
  - Gestionar las comprobaciones de números POS de AFIP y las consultas de números de última factura a través del servicio web WSMTXCA.
  - Asignar datos de autenticación y documentos
