### PR TITLE
[FIX] l10n_ar_account_tax_settlement: sufijos automáticos en nombre de pago txt agip

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -574,8 +574,9 @@ class AccountJournal(models.Model):
                 content += line.l10n_latam_document_type_id.l10n_ar_letter if internal_type == "invoice" else " "
 
             # 6 - Nro de comprobante
-            content += "%016d" % int(re.sub("[^0-9]", "", move.l10n_latam_document_number or ""))
-
+            content += "%016d" % int(
+                re.sub("[^0-9]", "", re.sub(r"\s\(\d+\)$", "", move.l10n_latam_document_number or ""))
+            )
             # 7 - Fecha del comprobante
             content += fields.Date.from_string(move.date).strftime("%d/%m/%Y")
 
@@ -596,11 +597,13 @@ class AccountJournal(models.Model):
                     # el amount total de los mismos (move_id.amount_total_in_currency_signed) al total_amount de la
                     # retención. Esto lo hacemos porque en la migración de 16 a 18 se migran los pagos y las retenciones
                     # por separado a diferencia de 16 que estaba todo en el mismo asiento.
-                    # Ignoramos sufijos automáticos tipo " (2)" (por ejemplo) al comparar nombres de pago.
+                    # Contemplamos que en el nombre puede haber sufijos automáticos tipo " (2)" (por ejemplo)
                     payment_name = re.sub(r"\s\(\d+\)$", "", payment.name)
                     related_payments = self.env["account.payment"].search(
                         [
-                            ("name", "in", list({payment_name, payment.name})),
+                            "|",
+                            ("name", "=", payment_name),
+                            ("name", "=like", payment_name + " (%)"),
                             ("company_id", "=", payment.company_id.id),
                             ("partner_id", "=", payment.partner_id.id),
                             ("id", "!=", payment.id),

--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -584,14 +584,7 @@ class AccountJournal(models.Model):
             if payment:
                 # solo en comprobantes A, M segun especificacion
                 vat_amount = 0.0
-                # es lo mismo que payment_group.matched_amount_untaxed
-                taxable_amount = float_round(line.withholding_id.base_amount, precision_digits=2)
-                rounded_withholding = float_round((taxable_amount * alicuot / 100), precision_digits=2)
-                # TODO en febrero 2026 sacar el if de abajo (más información en tarea 59174).
-                # Hacer revert de https://github.com/ingadhoc/odoo-argentina-ee/pull/743 en febrero 2026
                 total_amount = float_round(payment.move_id.amount_total_in_currency_signed, precision_digits=2)
-                if rounded_withholding != -line.balance:
-                    total_amount = float_round(total_amount + line.balance + rounded_withholding, precision_digits=2)
                 if backward_comp_is_installed and payment.is_backward_withholding_payment:
                     # Buscamos los payments sin retención que vienen migrados de la versión anterior y le sumamos
                     # el amount total de los mismos (move_id.amount_total_in_currency_signed) al total_amount de la
@@ -614,6 +607,8 @@ class AccountJournal(models.Model):
                         total_amount += float_round(
                             sum(related_payments.mapped("move_id.amount_total_in_currency_signed")), precision_digits=2
                         )
+                # es lo mismo que payment_group.matched_amount_untaxed
+                taxable_amount = float_round(line.withholding_id.base_amount, precision_digits=2)
 
                 # lo sacamos por diferencia
                 other_taxes_amount = company_currency.round(total_amount - taxable_amount - vat_amount)
@@ -719,16 +714,8 @@ class AccountJournal(models.Model):
 
             # si la línea tiene moneda diferente de la moneda de la compañía queremos que la ret/perc
             # se calcule aplicando la alícuota sobre la base imponible en la moneda de la compañía
-            # TODO en febrero 2026 sacar lo que está a la derecha del "or" del if de abajo
-            # (más información en tarea 59174).
-            # Hacer revert de esto https://github.com/ingadhoc/odoo-argentina-ee/pull/743 en febrero 2026
-            rounded_ret_perc_applied = float_round((taxable_amount * alicuot / 100), precision_digits=2)
-            if (
-                line.currency_id
-                and line.currency_id != line.company_id.currency_id
-                or rounded_ret_perc_applied != -line.balance
-            ):
-                ret_perc_applied = rounded_ret_perc_applied
+            if line.currency_id and line.currency_id != line.company_id.currency_id:
+                ret_perc_applied = float_round((taxable_amount * alicuot / 100), precision_digits=2)
             content += format_amount((-line.balance if not ret_perc_applied else ret_perc_applied), 16, 2, ",")
 
             # 21 - Monto Total Retenido/Percibido


### PR DESCRIPTION
Hacemos revert de este commit https://github.com/ingadhoc/odoo-argentina-ee/commit/8a4f550f77935d9cefca5fa8d770924562200926 ya que no lo necesitamos más y además mejoramos lo que se había hecho en https://github.com/ingadhoc/odoo-argentina-ee/pull/933 para que no se tengan en cuenta los sufijos de los pagos al momento de descargar el archivo txt de agip.

Ticket: 111810