### PR TITLE
[FIX] l10n_ar_account_tax_settlement: Nro. transacción Agente txt arba ret aplicado por lote A122R

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -1696,7 +1696,7 @@ class AccountJournal(models.Model):
         content = ''
         for line in move_lines:
             # Nro. transacción Agente (numérico 20, desde 1 hasta 20. Formato 99999999999999999999)
-            content += str(line.name).zfill(20)
+            content += re.sub(r'[^0-9]', '', str(line.name))[-20:].zfill(20)
 
             # CUIT contribuyente Retenido (long 11, desde 1 hasta 11. Formato 99999999999)
             content += line.partner_id.ensure_vat()


### PR DESCRIPTION
Ticket: 112047
El Nro. transacción Agente de acuerdo a la especificación ( https://github.com/ingadhoc/odoo-argentina-ee/blob/19.0/l10n_ar_account_reports/doc/ARBA%20(pba)/Dise%C3%B1o%20desde%2001032026/especificacion_arba_lotes_retencion_a122rdesde_01032026.png ) debe ser numérico. Este commit borra todo tipo de caracteres no numéricos para el campo "Nro. transacción Agente" del archivo txt y dichos caracteres son reemplazados por ceros a la izquierda. De esta forma, se asegura que el campo sea numérico y cumpla con la especificación requerida por ARBA.

Video mostrando la descarga del archivo con el bug y la descarga del archivo con el fix en una base local de 1: https://drive.google.com/file/d/1wK09DMoNRIAGIG_dCqF8SM89GPBb4vjT/view