### PR TITLE
[IMP] l10n_ar_currency_update: método de redondeo global en compañías argentinas

### DIFF
--- a/l10n_ar_currency_update/tests/test_l10n_ar_currency_update.py
+++ b/l10n_ar_currency_update/tests/test_l10n_ar_currency_update.py
@@ -60,6 +60,7 @@ class TestL10nArCurrencyUpdate(AccountTestInvoicingCommon):
                 "name": "Test Argentine Company 2",
                 "country_id": ar_country.id,
                 "currency_id": self.ARS.id,
+                "tax_calculation_rounding_method": "round_globally",
             }
         )
 


### PR DESCRIPTION
En el test test_currency_rate_with_rate_perc de l10n_ar_currency_update/tests/test_l10n_ar_currency_update.py cuando se crea la compañía "Test Argentine Company 2" tenemos que asignarle el método de redondeo global, ya que en Argentina es obligatorio que tengan dicho método de redondeo.
Tarea: 66134