### PR TITLE
[ADD] l10n_ar_import_bill: add trash button to remove wizard lines

### DIFF
--- a/l10n_ar_import_bill/security/ir.model.access.csv
+++ b/l10n_ar_import_bill/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 afip_import_wizard,afip.import.wizard,model_afip_import_wizard,account.group_account_invoice,1,1,1,0
-afip_import_wizard_line,afip.import.wizard.line,model_afip_import_wizard_line,account.group_account_invoice,1,1,1,0
+afip_import_wizard_line,afip.import.wizard.line,model_afip_import_wizard_line,account.group_account_invoice,1,1,1,1

--- a/l10n_ar_import_bill/wizards/afip_import_wizard.xml
+++ b/l10n_ar_import_bill/wizards/afip_import_wizard.xml
@@ -65,6 +65,7 @@
                         <field name="date_invoice"/>
                         <field name="currency"/>
                         <field name="amount_total"/>
+                        <button name="action_remove" type="object" icon="fa-trash-o" title="Eliminar" class="oe_inline"/>
                     </list>
 
                 </field>

--- a/l10n_ar_import_bill/wizards/afip_import_wizard_line.py
+++ b/l10n_ar_import_bill/wizards/afip_import_wizard_line.py
@@ -150,3 +150,19 @@ class AfipImportWizardLine(models.TransientModel):
             "partner_id": partner.id,
         }
         return (0, 0, vals)
+
+    def action_remove(self):
+        wizard = self.mapped("wizard_id")
+        self.unlink()
+        # Re-open the same wizard in a modal to refresh only its content (lines)
+        view = self.env.ref("l10n_ar_import_bill.view_afip_import_wizard_form", raise_if_not_found=False)
+        action = {
+            "type": "ir.actions.act_window",
+            "res_model": "afip.import.wizard",
+            "res_id": wizard.id if wizard else False,
+            "view_mode": "form",
+            "target": "new",
+        }
+        if view:
+            action.update({"view_id": view.id, "views": [(view.id, "form")]})
+        return action


### PR DESCRIPTION
Technical description
- Add action_remove() on afip.import.wizard.line to unlink the transient line and reopen the wizard modal so the one2many is refreshed without closing the wizard. (wizards/afip_import_wizard_line.py)
- Add a trash icon button to the wizard list view that calls action_remove. (wizards/afip_import_wizard.xml)
- Ensure ACL allows unlink for the accounting group on the wizard line model (security/ir.model.access.csv).

Why
- Allow users to remove individual imported lines from the wizard before creating invoices, improving UX and avoiding creating unwanted records.

Change note (nota de cambio)
- Se agregó un icono de papelera en el wizard de importación para eliminar líneas individuales y así evitar que se creen facturas no deseadas; la acción refresca el modal del wizard para actualizar sólo las líneas. Se ajustaron los permisos de acceso para permitir la eliminación por el grupo de Accounting/Billing.