### PR TITLE
[FIX] l10n_ar_account_tax_settlement: ARBA TXT Exclude lines with DDJJ

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -1836,8 +1836,10 @@ class AccountJournal(models.Model):
 
         # Si el módulo de WS ARBA A122R está instalado, debemos filtrar para no informar en el TXT
         # las retenciones que ya fueron informadas via webservice.
-        if self.env["ir.module.module"].search(
-            [("name", "=", "l10n_ar_arba_ws"), ("state", "in", ["installed", "to upgrade"])]
+        if (
+            self.env["ir.module.module"]
+            .sudo()
+            .search([("name", "=", "l10n_ar_arba_ws"), ("state", "in", ["installed", "to upgrade"])])
         ):
             move_lines = move_lines.filtered(lambda x: not x.withholding_id.l10n_ar_dj_arba_id)
 

--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -1839,7 +1839,7 @@ class AccountJournal(models.Model):
         if self.env["ir.module.module"].search(
             [("name", "=", "l10n_ar_arba_ws"), ("state", "in", ["installed", "to upgrade"])]
         ):
-            move_lines = move_lines.filtered(lambda x: not x.withholding_id.l10n_ar_cert_number)
+            move_lines = move_lines.filtered(lambda x: not x.withholding_id.l10n_ar_dj_arba_id)
 
         for line in move_lines:
             # Nro. transacción Agente (numérico 20, desde 1 hasta 20. Formato 99999999999999999999)


### PR DESCRIPTION
## Summary

Fix the filter condition used when generating the ARBA TXT file to correctly exclude lines associated with a DDJJ (`l10n_ar_dj_arba_id`), instead of incorrectly filtering by `l10n_ar_cert_number`.

## Changes

- `l10n_ar_account_tax_settlement/models/account_journal.py`: Replace `withholding_id.l10n_ar_cert_number` with `withholding_id.l10n_ar_dj_arba_id` in the `move_lines` filter when the `l10n_ar_arba_ws` module is installed.