### PR TITLE
[IMP] account_accountant_ux: add Partner Ledger button to partner form

### DIFF
--- a/account_accountant_ux/views/res_partner_view.xml
+++ b/account_accountant_ux/views/res_partner_view.xml
@@ -81,6 +81,15 @@
             <xpath expr="//button[@name='open_follow_up_report']//span[hasclass('o_stat_text')]" position="replace">
                 <span class="o_stat_text">Follow-up Report</span>
             </xpath>
+            <xpath expr="//button[@name='action_open_reconcile']" position="after">
+                <button class="oe_stat_button" type="action" groups="account.group_account_invoice"
+                        name="%(account_accountant_ux.action_partner_ledger)d" icon="fa-book">
+                    <div class="o_stat_info">
+                        <span class="o_stat_text">Partner</span>
+                        <span class="o_stat_text">Ledger</span>
+                    </div>
+                </button>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
- Modify views/res_partner_view.xml to insert an oe_stat_button after the action_open_reconcile button.
- Button calls server action account_accountant_ux.action_partner_ledger (type action), visible for account.group_account_invoice, with icon fa-book.
- UI-only change (adds quick access to partner ledger from partner form).

Change note: Agrega un botón "Partner Ledger" en la ficha de contacto que abre el libro mayor filtrado por el partner seleccionado, permitiendo acceder rápidamente a sus movimientos desde la vista del partner.