### PR TITLE
[FIX] l10n_ar_import_bill: rename user_currency_rate to invoice_currency_rate for v19

### DIFF
--- a/l10n_ar_import_bill/wizards/afip_import_wizard.py
+++ b/l10n_ar_import_bill/wizards/afip_import_wizard.py
@@ -231,7 +231,7 @@ class AfipImportWizard(models.TransientModel):
 
             # Agregamos el rate despues de crear la factura, para que Odoo no lo recalcule
             if line.currency_rate and line.currency_rate != 1:
-                move.user_currency_rate = line.currency_rate
+                move.invoice_currency_rate = line.currency_rate
 
             # Si tiene otros tributos, modificamos el valor por defecto con el wizard
             if line.otros_tributos > 0:


### PR DESCRIPTION
## Summary

`account.move.user_currency_rate` was removed in Odoo v19. The native field is now `invoice_currency_rate` (defined at [`addons/account/models/account_move.py`](https://github.com/odoo/odoo/blob/19.0/addons/account/models/account_move.py), computed with `store=True, precompute=True` and manually settable — which is exactly the override pattern this wizard needs).

## Repro

1. Export "Mis Comprobantes Recibidos" from ARCA portal as XLSX with at least one row in non-ARS currency (column **Tipo Cambio** != 1).
2. In Accounting, upload the XLSX on a Vendor Bills journal to trigger `afip.import.wizard`.
3. Review lines in the wizard and click **Crear Facturas**.

## Crash

```
File "/opt/.../l10n_ar_import_bill/wizards/afip_import_wizard.py", line 234, in action_confirm
    move.user_currency_rate = line.currency_rate
    ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'account.move' object has no attribute 'user_currency_rate'
```

Grepping the whole Odoo codebase (core + enterprise + OCA + ingadhoc) for `user_currency_rate` returned a single match: this line. The field simply doesn't exist anywhere in v19.

## Fix

One-line rename:

```diff
-                move.user_currency_rate = line.currency_rate
+                move.invoice_currency_rate = line.currency_rate
```

## Test plan

- [x] Grep confirms `user_currency_rate` has no definition in v19 (core, enterprise, OCA, ingadhoc).
- [x] `invoice_currency_rate` is settable: `account_move.py` uses `env.protecting` to preserve manual writes — the very use case this line targets.
- [x] Smoke test: re-import an XLSX with Tipo Cambio = 1 and Tipo Cambio != 1. Both create invoices without error; non-ARS invoice keeps the XLSX rate.