### PR TITLE
[IMP] l10n_ar_account_reports: make it auto install with l10n_ar

### DIFF
--- a/l10n_ar_account_reports/__manifest__.py
+++ b/l10n_ar_account_reports/__manifest__.py
@@ -31,6 +31,7 @@
         "accountant",  # en si este modulo no es necesario pero de alguna manera este modulo solo tiene sentido para
         # bases que usan contabilida (tienen accountant)
         "account_reports",
+        "l10n_ar",
         "l10n_ar_tax",
         "l10n_ar_withholding",
         "l10n_latam_check",
@@ -72,7 +73,7 @@
     },
     "test": [],
     "installable": True,
-    "auto_install": True,
+    "auto_install": ["l10n_ar"],
     "application": False,
     "post_init_hook": "_post_init_hook_configure_ar_account_tags",
 }


### PR DESCRIPTION
Hoy l10n_ar_account_reports se auto-instala solo cuando ya está account_payment_pro_receiptbook, por eso muchas bases de localización argentina en 19 quedan sin este módulo. Para alinear el comportamiento con 18.0 (https://github.com/ingadhoc/odoo-argentina-ee/blob/18.0/l10n_ar_account_tax_settlement/__manifest__.py#L49) y mejorar cobertura, se cambia la condición de auto instalación a auto_install = ["l10n_ar"]. De esta forma, las bases con localización argentina instalan automáticamente l10n_ar_account_reports y sus dependencias, evitando instalaciones manuales y reduciendo desvíos entre bases. Ticket: 116556