### PR TITLE
[IMP] l10n_ar_account_tax_settlement: improve document number validation with user-friendly error handling

### DIFF
--- a/account_tax_settlement/models/account_move_line.py
+++ b/account_tax_settlement/models/account_move_line.py
@@ -148,6 +148,7 @@ class AccountMoveLine(models.Model):
         """
         if not journal:
             journal = self.get_tax_settlement_journal()
+        self.mapped("move_id").filtered("l10n_latam_document_number")._validate_document_number_parts()
         res = self.env["res.download_files_wizard"].action_get_files(
             journal.get_tax_settlement_files_values(self), journal.settlement_tax
         )

--- a/l10n_ar_account_tax_settlement/i18n/es.po
+++ b/l10n_ar_account_tax_settlement/i18n/es.po
@@ -516,6 +516,18 @@ msgstr "Impuesto"
 
 #. module: l10n_ar_account_tax_settlement
 #. odoo-python
+#: code:addons/l10n_ar_account_tax_settlement/models/account_move.py:0
+msgid ""
+"The following document(s) have an invalid document number format.\n"
+"ARCA requires the format XXXXX-XXXXXXXX (e.g.: 00001-00000001).\n"
+"Please correct them before generating the file:\n%s"
+msgstr ""
+"Los siguientes comprobantes tienen un número de documento con formato inválido.\n"
+"ARCA requiere el formato XXXXX-XXXXXXXX (ej: 00001-00000001).\n"
+"Por favor corrija los siguientes comprobantes antes de generar el archivo:\n%s"
+
+#. module: l10n_ar_account_tax_settlement
+#. odoo-python
 #: code:addons/l10n_ar_account_tax_settlement/models/account_journal.py:0
 msgid "Tipo de comprobante no reconocido"
 msgstr ""

--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -792,9 +792,7 @@ class AccountJournal(models.Model):
                     or "R"
                 )
                 content += line.l10n_latam_document_type_id.l10n_ar_letter
-            document_parts = move._l10n_ar_get_document_number_parts(
-                move.l10n_latam_document_number, move.l10n_latam_document_type_id.code
-            )
+            document_parts = move._get_document_number_parts()
             # si el punto de venta es de 5 digitos no encontramos doc
             # que diga como proceder, tomamos los ultimos 4 digitos
             pto_venta = "{:0>4d}".format(document_parts["point_of_sale"])[-4:]
@@ -1112,9 +1110,7 @@ class AccountJournal(models.Model):
                 content += f"{pos:>04s}"
                 content += f"{number:>016s}"
             else:
-                document_parts = move._l10n_ar_get_document_number_parts(
-                    move.l10n_latam_document_number, move.l10n_latam_document_type_id.code
-                )
+                document_parts = move._get_document_number_parts()
                 pos = document_parts["point_of_sale"]
                 number = document_parts["invoice_number"]
                 # si el punto de venta es de 5 digitos no encontramos doc
@@ -1710,9 +1706,7 @@ class AccountJournal(models.Model):
                 )
                 # Letra Comprobante (long 1, desde 25 hasta 25. Valores A,B,C, o “ ” (blanco)).
                 content += line.l10n_latam_document_type_id.l10n_ar_letter
-            document_parts = move._l10n_ar_get_document_number_parts(
-                move.l10n_latam_document_number, move.l10n_latam_document_type_id.code
-            )
+            document_parts = move._get_document_number_parts()
             pto_venta = "{:0>5d}".format(document_parts["point_of_sale"])[-5:]
             nro_documento = "{:0>8d}".format(document_parts["invoice_number"])[-8:]
             # Numero Sucursal (long 5, desde 26 hasta 30)
@@ -1849,9 +1843,7 @@ class AccountJournal(models.Model):
             content += line.partner_id.ensure_vat()
 
             move = line.move_id
-            document_parts = move._l10n_ar_get_document_number_parts(
-                move.l10n_latam_document_number, move.l10n_latam_document_type_id.code
-            )
+            document_parts = move._get_document_number_parts()
             pto_venta = "{:0>5d}".format(document_parts["point_of_sale"])[-5:]
 
             # Sucursal (long 5, desde 32 hasta 36)

--- a/l10n_ar_account_tax_settlement/models/account_move.py
+++ b/l10n_ar_account_tax_settlement/models/account_move.py
@@ -6,10 +6,45 @@ import csv
 from io import StringIO
 
 from odoo import _, models
+from odoo.exceptions import ValidationError
 
 
 class AccountMove(models.Model):
     _inherit = "account.move"
+
+    def _get_document_number_parts(self):
+        """Wrapper around _l10n_ar_get_document_number_parts for single-record use.
+        Callers should invoke _validate_document_number_parts() on the full recordset
+        first so that all invalid documents are reported at once."""
+        self.ensure_one()
+        return self._l10n_ar_get_document_number_parts(
+            self.l10n_latam_document_number, self.l10n_latam_document_type_id.code
+        )
+
+    def _validate_document_number_parts(self):
+        """Validate document number format for all records in self.
+        Collects every invalid document and raises a single ValidationError
+        listing them all, instead of stopping at the first failure."""
+        invalid = []
+        for move in self:
+            try:
+                move._l10n_ar_get_document_number_parts(
+                    move.l10n_latam_document_number, move.l10n_latam_document_type_id.code
+                )
+            except (ValueError, AttributeError):
+                invalid.append(move)
+        if invalid:
+            doc_list = "\n".join(
+                '- "%s" (id: %d): "%s"' % (m.display_name, m.id, m.l10n_latam_document_number) for m in invalid
+            )
+            raise ValidationError(
+                _(
+                    "The following document(s) have an invalid document number format.\n"
+                    "ARCA requires the format XXXXX-XXXXXXXX (e.g.: 00001-00000001).\n"
+                    "Please correct them before generating the file:\n%s"
+                )
+                % doc_list
+            )
 
     def action_download_vat_differences_csv(self):
         """Acción para descargar CSV con diferencias de IVA"""


### PR DESCRIPTION
La idea de este PR es mejorar la experiencia del usuario en el proceso de generación de archivos de liquidación de impuestos (txt) al centralizar y validar el formato de los números de documento de las facturas electrónicas argentinas. Los cambios garantizan que todos los números de documento no válidos se notifiquen de una sola vez, ayuda a los usuarios a identificar y solucionar rápidamente los problemas y evita tickets por tracebacks que el usuario no puede entender.

**Mejoras en la validación y el manejo de errores:**

* Se agregó un nuevo método `_validate_document_number_parts` a `account_move.py` que verifica todos los registros de un conjunto para detectar formatos de número de documento válidos, recopilando todos los documentos no válidos y generando un único `ValidationError` que los enumera. Esto garantiza que los usuarios vean todos los problemas de una sola vez en lugar de que el proceso falle ante el primer error.
* Se actualizó `get_tax_settlement_file` en `account_move_line.py` para llamar al nuevo método de validación antes de generar archivos, lo que impide la creación de archivos si algún número de documento no es válido (al igual que antes, sólo que explotaba durante la genereación).
* Se agregó un mensaje de error claro y fácil de entender (con traducción) que explica el formato requerido y enumera los documentos no válidos.

**Consistencia y simplificación del código:**

* Se han sustituido múltiples llamadas directas a `_l10n_ar_get_document_number_parts`, de nivel inferior, por un nuevo wrapper `_get_document_number_parts` en `account_move.py`, lo que garantiza el uso de un solo registro y un manejo de errores más consistente en todo el código. [[1]](diffhunk://#diff-bb150bf99f80d598921f8e30252aaef1a306060d63df68bcd6dab8782f8d7f9eR9-R48) [[2]](diffhunk://#diff-18887bee09441a653f07cb985aaf7b6cb399475c13056cf44c259914449bf96dL795-R795) [[3]](diffhunk://#diff-18887bee09441a653f07cb985aaf7b6cb399475c13056cf44c259914449bf96dL1115-R1113) [[4]](diffhunk://#diff-18887bee09441a653f07cb985aaf7b6cb399475c13056cf44c259914449bf96dL1713-R1709) [[5]](diffhunk://#diff-18887bee09441a653f07cb985aaf7b6cb399475c13056cf44c259914449bf96dL1852-R1846)