### PR TITLE
[FIX] l10n_ar_account_tax_settlement: _l10n_ar_get_amounts method doen't receive company_currency parameter

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -357,7 +357,7 @@ class AccountJournal(models.Model):
 
             # 17 - Importe IVA (solo si factura)
             if line.move_id.is_invoice():
-                amounts = line.move_id._l10n_ar_get_amounts(company_currency=True)
+                amounts = line.move_id._l10n_ar_get_amounts()
                 vat_amount = amounts["vat_amount"]
                 base_amount = amounts["vat_taxable_amount"]
             else:
@@ -616,7 +616,7 @@ class AccountJournal(models.Model):
                 # lo sacamos por diferencia
                 other_taxes_amount = company_currency.round(total_amount - taxable_amount - vat_amount)
             elif line.move_id.is_invoice():
-                amounts = line.move_id._l10n_ar_get_amounts(company_currency=True)
+                amounts = line.move_id._l10n_ar_get_amounts()
                 # segun especificacion el iva solo se reporta para estos
                 if line.l10n_latam_document_type_id.l10n_ar_letter in ["A", "M"]:
                     vat_amount = amounts["vat_amount"]


### PR DESCRIPTION
Odoo mezcló este cambio https://github.com/odoo/odoo/commit/114cae88b0bb8e9ad9e89acd81410ba817bc11dd#diff-37cd2146d6cb28293f87a3d641350de1f21239e8b31df6c4246aff3ed95502c3R282 y _l10n_ar_get_amounts de account.move no recibe el parámetro company_currency, por lo que se rompe la función de liquidación de impuestos. Se corrige eliminando el parámetro.
Ticket: 116813