### PR TITLE
[FIX] l10n_ar_account_tax_settlement: only validate document formats when txt  generation needs it

### DIFF
--- a/account_tax_settlement/models/account_move_line.py
+++ b/account_tax_settlement/models/account_move_line.py
@@ -148,7 +148,6 @@ class AccountMoveLine(models.Model):
         """
         if not journal:
             journal = self.get_tax_settlement_journal()
-        self.mapped("move_id").filtered("l10n_latam_document_number")._validate_document_number_parts()
         res = self.env["res.download_files_wizard"].action_get_files(
             journal.get_tax_settlement_files_values(self), journal.settlement_tax
         )

--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -199,6 +199,15 @@ class AccountJournal(models.Model):
             return template % f"{round(amount, decimals):.2f}".replace(".", ",")
 
         self.ensure_one()
+        moves_to_validate = (
+            move_lines.filtered(
+                lambda line: line.move_id.l10n_latam_document_type_id.internal_type
+                in ("invoice", "credit_note", "debit_note")
+            )
+            .mapped("move_id")
+            .filtered(lambda m: m.l10n_latam_document_type_id and m.l10n_latam_document_number)
+        )
+        moves_to_validate._validate_document_number_parts()
         ret = ""
         perc = ""
 
@@ -1074,6 +1083,13 @@ class AccountJournal(models.Model):
         sifereweb@comisionarbitral.gob.ar
         """
         self.ensure_one()
+        move_lines.filtered(
+            lambda line: (
+                not line.payment_id
+                and line.move_id.l10n_latam_document_type_id
+                and line.move_id.l10n_latam_document_number
+            )
+        ).mapped("move_id")._validate_document_number_parts()
 
         ret = ""
         perc = ""


### PR DESCRIPTION
Modificamos los cambios introducidos acá https://github.com/ingadhoc/odoo-argentina-ee/pull/1003/changes#diff-767b5ff4334f9071cbba84fc670d9e5f62f52163a9cfc8cd2c9e860388eea6a3R151 para evitar que salten errores de validación de formato de documentos en la generación de TXTs que no necesitan un formato específico.
