### PR TITLE
[FIX] l10n_ar_account_tax_settlement: redondeo en percepciones txt ARBA

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -1758,7 +1758,9 @@ class AccountJournal(models.Model):
             if monto_imponible:
                 # por ahora solo hacemos este cálculo para percepciones,
                 # no lo hacemos para retenciones por ahora
-                importe_percepcion_calculado = format_amount(monto_imponible * alicuota / 100, 13, 2, ",")
+                importe_percepcion_calculado = format_amount(
+                    float_round(monto_imponible * alicuota / 100, precision_digits=2), 13, 2, ","
+                )
             # ARBA valida importe = base * alícuota; informar el importe calculado
             # cuando difiere del original por redondeos (calculado por odoo).
             if monto_imponible and importe_percepcion != importe_percepcion_calculado:


### PR DESCRIPTION
Hace un mes aproximadamente habíamos agregado este parche https://github.com/ingadhoc/odoo-argentina-ee/pull/978 (más información: ver descripción de dicho pull request) pero resulta que ese parche informa en el archivo txt de percepciones de arba el monto de percepción truncado en lugar de ser redondeado. En este pull request lo arreglamos para que informe el monto de percepción redondeado.
Ticket: 117233