### PR TITLE
[IMP] l10n_ar_account_reports: preserve manual account tag customizations during migration

### DIFF
--- a/l10n_ar_account_reports/migrations/18.0.1.5.0/post-migration.py
+++ b/l10n_ar_account_reports/migrations/18.0.1.5.0/post-migration.py
@@ -8,4 +8,4 @@ def migrate(cr, version):
 
     if companies:
         chart_template = env["account.chart.template"]
-        chart_template._l10n_ar_account_reports_setup_account_tags(companies)
+        chart_template._l10n_ar_account_reports_setup_account_tags(companies, only_missing=True)

--- a/l10n_ar_account_reports/models/account_chart_template.py
+++ b/l10n_ar_account_reports/models/account_chart_template.py
@@ -237,27 +237,34 @@ class AccountChartTemplate(models.AbstractModel):
 
         return None
 
-    def _l10n_ar_account_reports_setup_account_tags(self, ar_companies):
-        """Set up account tags for Argentine chart templates"""
+    def _l10n_ar_account_reports_setup_account_tags(self, ar_companies, only_missing=False):
+        """Set up account tags for Argentine chart templates.
+
+        :param only_missing: When True, preserves manual tag customizations by only
+            assigning tags to accounts that don't already have that specific tag.
+            Use only_missing=False (default) exclusively for fresh chart installations.
+            Always pass only_missing=True from migration scripts to avoid overwriting
+            tags that clients configured manually.
+        """
         tags = self._get_ar_account_tags()
         tag_ids = list(tags.values())
-        tag_ids_list = [tag.id for tag in tag_ids]  # Lista de IDs de todas las etiquetas
+        tag_ids_list = [tag.id for tag in tag_ids]
 
         for company in ar_companies:
-            # En Odoo 18, las cuentas usan company_ids (many2many) en lugar de company_id
-            accounts = self.env["account.account"].search([("company_ids", "in", company.id)])
+            domain = [("company_ids", "in", company.id)]
 
-            # Primero limpiar todas las etiquetas específicas de reportes argentinos
-            for account in accounts:
-                # Quitar todas las etiquetas argentinas existentes
-                for tag_id in tag_ids_list:
-                    account.write({"tag_ids": [(3, tag_id)]})
+            if only_missing:
+                domain.append(("tag_ids", "not in", tag_ids_list))
 
-            # Luego asignar las etiquetas correctas
+            accounts = self.env["account.account"].search(domain)
+
+            if not only_missing:
+                for account in accounts:
+                    account.write({"tag_ids": [(3, tag_id) for tag_id in tag_ids_list]})
+
             for account in accounts:
                 tag_id = None
 
-                # Income statement accounts
                 if account.account_type in [
                     "income",
                     "expense",
@@ -267,7 +274,6 @@ class AccountChartTemplate(models.AbstractModel):
                 ]:
                     tag_id = self._get_tag_for_income_account(account, tags, company)
 
-                # Asset accounts
                 elif account.account_type in [
                     "asset_cash",
                     "asset_receivable",
@@ -277,7 +283,6 @@ class AccountChartTemplate(models.AbstractModel):
                 ]:
                     tag_id = self._get_tag_for_asset_account(account, tags, company)
 
-                # Liability and equity accounts
                 elif account.account_type in [
                     "liability_payable",
                     "liability_current",
@@ -287,6 +292,5 @@ class AccountChartTemplate(models.AbstractModel):
                 ]:
                     tag_id = self._get_tag_for_liability_equity_account(account, tags, company)
 
-                # Assign the tag if one was found
                 if tag_id:
                     account.write({"tag_ids": [(4, tag_id)]})


### PR DESCRIPTION
Add only_missing parameter to _l10n_ar_account_reports_setup_account_tags When only_missing=True, skip accounts that already have any AR module tag, preserving client manual customizations When only_missing=False (default), keep existing behavior: wipe and reassign all AR tags (used only on fresh chart installations) Replace per-account tag_ids.ids loop with filtered_domain() to filter in SQL Post-migration: pass only_missing=True so the migration only assigns tags to accounts left empty by the pre-migration script Change note: Solucionamos un problema donde al actualizar el módulo se pisaban los tags de cuentas que los clientes habían configurado manualmente para ajustar sus reportes contables. A partir de ahora, las personalizaciones manuales de tags se respetan durante las actualizaciones del sistema.