### PR TITLE
[FIX] account_tax_settlement: recalcular tax_state al eliminar liquidaciones

### DIFF
--- a/account_tax_settlement/models/account_move.py
+++ b/account_tax_settlement/models/account_move.py
@@ -20,3 +20,10 @@ class AccountMove(models.Model):
         # para los que se liquidan desde reporte, no se encuentra el diario,
         # pero sabemos que es el diario donde se liquidaron
         return self.settled_line_ids.get_tax_settlement_file(self.journal_id)
+
+    def unlink(self):
+        """Recompute tax_state on settled lines after deleting settlement moves."""
+        settled_lines = self.mapped("settled_line_ids")
+        res = super().unlink()
+        settled_lines._compute_tax_state()
+        return res


### PR DESCRIPTION
Ticket: 118234
Al eliminar un asiento de liquidación, se recalcula el tax_state de los apuntes contables asociados para que vuelvan a estado "to_settle". Antes de este cambio si se eliminaba una liquidación, luego al entrar en las líneas a liquidar, los apuntes contables de impuestos que estaban en la liquidación no se visualizaban en la vista formulario de las líneas a liquidar (el filtro de la vista, por defecto tiene [("tax_state", "=", "to_settle")]). Este commit lo arregla para que si se visualicen.