### PR TITLE
[REF] l10n_ar_account_reports, l10n_ar_currency_update: make user messages translatable

### DIFF
--- a/l10n_ar_account_reports/data/account_report_settlement.xml
+++ b/l10n_ar_account_reports/data/account_report_settlement.xml
@@ -3,13 +3,13 @@
 
     <record id="account_financial_report_l10n_ar_estado_resultados" model="account.report">
         <field name="allow_settlement" eval="True"/>
-        <field name="settlement_title">Asiento de refundición</field>
+        <field name="settlement_title">Refunding Entry</field>
         <field name="settlement_allow_unbalanced" eval="True"/>
     </record>
 
     <record id="account_financial_report_l10n_ar_estado_patrimonial" model="account.report">
         <field name="allow_settlement" eval="True"/>
-        <field name="settlement_title">Generar asiento de cierre</field>
+        <field name="settlement_title">Generate Closing Entry</field>
     </record>
 
 </odoo>

--- a/l10n_ar_account_reports/data/balance_sheet.xml
+++ b/l10n_ar_account_reports/data/balance_sheet.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="account_financial_report_l10n_ar_estado_patrimonial" model="account.report">
-        <field name="name">Estado Patrimonial</field>
+        <field name="name">Balance Sheet</field>
         <field name="root_report_id" ref="account_reports.balance_sheet"/>
         <field name="filter_analytic_groupby" eval="True"/>
         <field name="filter_unfold_all" eval="True"/>
@@ -17,12 +17,12 @@
         <field name="line_ids">
             <!-- Activo -->
             <record id="account_financial_report_l10n_ar_estado_patrimonial_line_activo" model="account.report.line">
-                <field name="name">Activo</field>
+                <field name="name">Assets</field>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <!-- Caja y Bancos -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_bank_cash" model="account.report.line">
-                        <field name="name">Caja y Bancos</field>
+                        <field name="name">Cash and Banks</field>
                         <field name="code">bank_cash</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -39,7 +39,7 @@
 
                     <!-- Inversiones temporarias -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_temp_investments" model="account.report.line">
-                        <field name="name">Inversiones temporarias</field>
+                        <field name="name">Short-term Investments</field>
                         <field name="code">temp_investments</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -56,7 +56,7 @@
 
                     <!-- Créditos por ventas -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_sales_rec" model="account.report.line">
-                        <field name="name">Créditos por ventas</field>
+                        <field name="name">Accounts Receivable</field>
                         <field name="code">sales_rec</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -73,7 +73,7 @@
 
                     <!-- Otros créditos -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_other_rec" model="account.report.line">
-                        <field name="name">Otros créditos</field>
+                        <field name="name">Other Receivables</field>
                         <field name="code">other_rec</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -90,7 +90,7 @@
 
                     <!-- Bienes de cambio -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_inventory" model="account.report.line">
-                        <field name="name">Bienes de cambio</field>
+                        <field name="name">Inventories</field>
                         <field name="code">inventory</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -107,7 +107,7 @@
 
                     <!-- Otros activos -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_other_current_assets" model="account.report.line">
-                        <field name="name">Otros activos</field>
+                        <field name="name">Other Current Assets</field>
                         <field name="code">other_current_assets</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -124,7 +124,7 @@
 
                     <!-- Total del activo corriente -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_total_current_assets" model="account.report.line">
-                        <field name="name">Total del activo corriente</field>
+                        <field name="name">Total Current Assets</field>
                         <field name="code">total_current_assets</field>
                         <field name="hierarchy_level">1</field>
                         <field name="expression_ids">
@@ -138,7 +138,7 @@
 
                     <!-- Créditos por ventas (No corriente) -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_sales_rec_noncurrent" model="account.report.line">
-                        <field name="name">Créditos por ventas (No corriente)</field>
+                        <field name="name">Accounts Receivable (Non-current)</field>
                         <field name="code">sales_rec_noncurrent</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -155,7 +155,7 @@
 
                     <!-- Otros créditos (No corriente) -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_other_rec_noncurrent" model="account.report.line">
-                        <field name="name">Otros créditos (No corriente)</field>
+                        <field name="name">Other Receivables (Non-current)</field>
                         <field name="code">other_rec_noncurrent</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -172,7 +172,7 @@
 
                     <!-- Bienes de cambio (No corriente) -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_inventory_noncurrent" model="account.report.line">
-                        <field name="name">Bienes de cambio (No corriente)</field>
+                        <field name="name">Inventories (Non-current)</field>
                         <field name="code">inventory_noncurrent</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -189,7 +189,7 @@
 
                     <!-- Bienes de uso -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_fixed_assets" model="account.report.line">
-                        <field name="name">Bienes de uso</field>
+                        <field name="name">Fixed Assets</field>
                         <field name="code">fixed_assets</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -206,7 +206,7 @@
 
                     <!-- Participaciones permanentes en sociedades -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_long_term_investments" model="account.report.line">
-                        <field name="name">Participaciones permanentes en sociedades</field>
+                        <field name="name">Long-term Investments in Subsidiaries</field>
                         <field name="code">long_term_investments</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -223,7 +223,7 @@
 
                     <!-- Otras inversiones -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_other_long_term_investments" model="account.report.line">
-                        <field name="name">Otras inversiones</field>
+                        <field name="name">Other Long-term Investments</field>
                         <field name="code">other_long_term_investments</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -240,7 +240,7 @@
 
                     <!-- Activos intangibles -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_intangible_assets" model="account.report.line">
-                        <field name="name">Activos intangibles</field>
+                        <field name="name">Intangible Assets</field>
                         <field name="code">intangible_assets</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -257,7 +257,7 @@
 
                     <!-- Otros activos (No corriente) -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_other_noncurrent_assets" model="account.report.line">
-                        <field name="name">Otros activos (No corriente)</field>
+                        <field name="name">Other Non-current Assets</field>
                         <field name="code">other_noncurrent_assets</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -274,7 +274,7 @@
 
                     <!-- Subtotal del activo no corriente -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_subtotal_noncurrent_assets" model="account.report.line">
-                        <field name="name">Subtotal del activo no corriente</field>
+                        <field name="name">Subtotal Non-current Assets</field>
                         <field name="code">subtotal_noncurrent_assets</field>
                         <field name="hierarchy_level">1</field>
                         <field name="expression_ids">
@@ -288,7 +288,7 @@
 
                     <!-- Llave de negocio -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_goodwill" model="account.report.line">
-                        <field name="name">Llave de negocio</field>
+                        <field name="name">Goodwill</field>
                         <field name="code">goodwill</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -305,7 +305,7 @@
 
                     <!-- Total del activo no corriente -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_total_noncurrent_assets" model="account.report.line">
-                        <field name="name">Total del activo no corriente</field>
+                        <field name="name">Total Non-current Assets</field>
                         <field name="code">total_noncurrent_assets</field>
                         <field name="hierarchy_level">1</field>
                         <field name="expression_ids">
@@ -319,7 +319,7 @@
 
                     <!-- Total del activo -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_total_assets" model="account.report.line">
-                        <field name="name">Total del activo</field>
+                        <field name="name">Total Assets</field>
                         <field name="code">total_assets</field>
                         <field name="hierarchy_level">0</field>
                         <field name="expression_ids">
@@ -335,12 +335,12 @@
 
             <!-- Pasivo -->
             <record id="account_financial_report_l10n_ar_estado_patrimonial_line_pasivo" model="account.report.line">
-                <field name="name">Pasivo</field>
+                <field name="name">Liabilities</field>
                 <field name="hierarchy_level">0</field>
                 <field name="children_ids">
                     <!-- Deudas Comerciales -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_accounts_payable" model="account.report.line">
-                        <field name="name">Deudas Comerciales</field>
+                        <field name="name">Accounts Payable</field>
                         <field name="code">accounts_payable</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -357,7 +357,7 @@
 
                     <!-- Préstamos -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_loans_payable" model="account.report.line">
-                        <field name="name">Préstamos</field>
+                        <field name="name">Loans Payable</field>
                         <field name="code">loans_payable</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -374,7 +374,7 @@
 
                     <!-- Remuneraciones y cargas sociales -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_payroll_liabilities" model="account.report.line">
-                        <field name="name">Remuneraciones y cargas sociales</field>
+                        <field name="name">Payroll Liabilities</field>
                         <field name="code">payroll_liabilities</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -391,7 +391,7 @@
 
                     <!-- Cargas fiscales -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_tax_liabilities" model="account.report.line">
-                        <field name="name">Cargas fiscales</field>
+                        <field name="name">Tax Liabilities</field>
                         <field name="code">tax_liabilities</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -408,7 +408,7 @@
 
                     <!-- Anticipos de clientes -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_advances_from_customers" model="account.report.line">
-                        <field name="name">Anticipos de clientes</field>
+                        <field name="name">Customer Advances</field>
                         <field name="code">advances_from_customers</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -425,7 +425,7 @@
 
                     <!-- Dividendos a pagar -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_dividends_payable" model="account.report.line">
-                        <field name="name">Dividendos a pagar</field>
+                        <field name="name">Dividends Payable</field>
                         <field name="code">dividends_payable</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -442,7 +442,7 @@
 
                     <!-- Otras -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_other_liabilities" model="account.report.line">
-                        <field name="name">Otras</field>
+                        <field name="name">Other</field>
                         <field name="code">other_liabilities</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -459,7 +459,7 @@
 
                     <!-- Total deudas -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_total_debts" model="account.report.line">
-                        <field name="name">Total deudas</field>
+                        <field name="name">Total Debts</field>
                         <field name="code">total_debts</field>
                         <field name="hierarchy_level">1</field>
                         <field name="expression_ids">
@@ -473,7 +473,7 @@
 
                     <!-- Previsiones -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_provisions" model="account.report.line">
-                        <field name="name">Previsiones</field>
+                        <field name="name">Provisions</field>
                         <field name="code">provisions</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -490,7 +490,7 @@
 
                     <!-- Total pasivo corriente -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_total_current_liabilities" model="account.report.line">
-                        <field name="name">Total pasivo corriente</field>
+                        <field name="name">Total Current Liabilities</field>
                         <field name="code">total_current_liabilities</field>
                         <field name="hierarchy_level">1</field>
                         <field name="expression_ids">
@@ -504,7 +504,7 @@
 
                     <!-- Deudas no corrientes -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_long_term_liabilities" model="account.report.line">
-                        <field name="name">Deudas no corrientes</field>
+                        <field name="name">Non-current Liabilities</field>
                         <field name="code">long_term_liabilities</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -521,7 +521,7 @@
 
                     <!-- Previsiones no corrientes -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_long_term_provisions" model="account.report.line">
-                        <field name="name">Previsiones no corrientes</field>
+                        <field name="name">Non-current Provisions</field>
                         <field name="code">long_term_provisions</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -538,7 +538,7 @@
 
                     <!-- Total pasivo no corriente -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_total_noncurrent_liabilities" model="account.report.line">
-                        <field name="name">Total pasivo no corriente</field>
+                        <field name="name">Total Non-current Liabilities</field>
                         <field name="code">total_noncurrent_liabilities</field>
                         <field name="hierarchy_level">1</field>
                         <field name="expression_ids">
@@ -552,7 +552,7 @@
 
                     <!-- Total del pasivo -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_total_liabilities_combined" model="account.report.line">
-                        <field name="name">Total del pasivo</field>
+                        <field name="name">Total Liabilities</field>
                         <field name="code">total_liabilities_combined</field>
                         <field name="hierarchy_level">0</field>
                         <field name="expression_ids">
@@ -568,7 +568,7 @@
 
             <!-- Participación de terceros en sociedades controladas -->
             <record id="account_financial_report_l10n_ar_estado_patrimonial_line_minority_interest" model="account.report.line">
-                <field name="name">Participación de terceros en sociedades controladas</field>
+                <field name="name">Minority Interest in Controlled Companies</field>
                 <field name="code">minority_interest</field>
                 <field name="hierarchy_level">0</field>
                 <field name="user_groupby">account_id</field>
@@ -585,7 +585,7 @@
 
             <!-- Patrimonio neto -->
             <record id="account_financial_report_l10n_ar_estado_patrimonial_line_equity" model="account.report.line">
-                <field name="name">Patrimonio neto</field>
+                <field name="name">Net Equity</field>
                 <field name="code">equity</field>
                 <field name="hierarchy_level">0</field>
                 <field name="expression_ids">
@@ -620,7 +620,7 @@
                     </record>
                     <!-- Reservas -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_equity_reserves" model="account.report.line">
-                        <field name="name">Reservas</field>
+                        <field name="name">Reserves</field>
                         <field name="code">equity_reserves</field>
                         <field name="hierarchy_level">3</field>
                         <field name="user_groupby">account_id</field>
@@ -636,7 +636,7 @@
                     </record>
                     <!-- Resultados -->
                     <record id="account_financial_report_l10n_ar_estado_patrimonial_line_equity_results" model="account.report.line">
-                        <field name="name">Resultados</field>
+                        <field name="name">Results</field>
                         <field name="code">equity_results</field>
                         <field name="hierarchy_level">2</field>
                         <field name="expression_ids">
@@ -649,7 +649,7 @@
                         <field name="children_ids">
                             <!-- Resultado del Ejercicio -->
                             <record id="account_financial_report_l10n_ar_estado_patrimonial_line_ar_curr_year_earnings" model="account.report.line">
-                                <field name="name">Resultado del Ejercicio</field>
+                                <field name="name">Current Year Earnings</field>
                                 <field name="code">ar_curr_year_earnings</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="action_id" ref="action_account_report_l10n_ar_estado_resultados"/>
@@ -677,7 +677,7 @@
                             </record>
                             <!-- Resultados sin asignar de años anteriores -->
                             <record id="account_financial_report_l10n_ar_estado_patrimonial_line_ar_prev_year_earnings" model="account.report.line">
-                                <field name="name">Resultados sin asignar de años anteriores</field>
+                                <field name="name">Unallocated Earnings from Previous Years</field>
                                 <field name="code">ar_prev_year_earnings</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="expression_ids">
@@ -704,7 +704,7 @@
                             </record>
                             <!-- Resultados Acumulados -->
                             <record id="account_financial_report_l10n_ar_estado_patrimonial_line_equity_results_detail" model="account.report.line">
-                                <field name="name">Resultados Acumulados</field>
+                                <field name="name">Accumulated Earnings</field>
                                 <field name="code">equity_results_detail</field>
                                 <field name="hierarchy_level">3</field>
                                 <field name="user_groupby">account_id</field>
@@ -725,7 +725,7 @@
 
             <!-- Total del pasivo, participación de terceros y patrimonio neto -->
             <record id="account_financial_report_l10n_ar_estado_patrimonial_line_total_liabilities_equity" model="account.report.line">
-                <field name="name">Total del pasivo, participación de terceros y patrimonio neto</field>
+                <field name="name">Total Liabilities, Minority Interest and Net Equity</field>
                 <field name="code">total_liabilities_equity</field>
                 <field name="hierarchy_level">0</field>
                 <field name="expression_ids">

--- a/l10n_ar_account_reports/data/estado_resultados.xml
+++ b/l10n_ar_account_reports/data/estado_resultados.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="account_financial_report_l10n_ar_estado_resultados" model="account.report">
-        <field name="name">Estado de Resultados</field>
+        <field name="name">Income Statement</field>
         <field name="root_report_id" ref="account_reports.profit_and_loss"/>
         <field name="filter_analytic_groupby" eval="True"/>
         <field name="filter_unfold_all" eval="True"/>
@@ -17,7 +17,7 @@
         <field name="line_ids">
             <!-- Ventas netas de bienes y servicios -->
             <record id="account_financial_report_l10n_ar_estado_resultados_line_sales" model="account.report.line">
-                <field name="name">Ventas netas de bienes y servicios</field>
+                <field name="name">Net Sales of Goods and Services</field>
                 <field name="code">sales</field>
                 <field name="hierarchy_level">1</field>
                 <field name="user_groupby">account_id</field>
@@ -34,7 +34,7 @@
 
             <!-- Costo de venta de bienes y servicios -->
             <record id="account_financial_report_l10n_ar_estado_resultados_line_cogs" model="account.report.line">
-                <field name="name">Costo de venta de bienes y servicios</field>
+                <field name="name">Cost of Goods and Services Sold</field>
                 <field name="code">cogs</field>
                 <field name="hierarchy_level">1</field>
                 <field name="user_groupby">account_id</field>
@@ -51,7 +51,7 @@
 
             <!-- Ganancia (Pérdida) bruta -->
             <record id="account_financial_report_l10n_ar_estado_resultados_line_gross_inc" model="account.report.line">
-                <field name="name">Ganancia (Pérdida) bruta</field>
+                <field name="name">Gross Profit (Loss)</field>
                 <field name="code">gross_inc</field>
                 <field name="hierarchy_level">0</field>
                 <field name="expression_ids">
@@ -65,7 +65,7 @@
 
             <!-- Gastos de comercialización -->
             <record id="account_financial_report_l10n_ar_estado_resultados_line_com_exp" model="account.report.line">
-                <field name="name">Gastos de comercialización</field>
+                <field name="name">Selling Expenses</field>
                 <field name="code">com_exp</field>
                 <field name="hierarchy_level">1</field>
                 <field name="user_groupby">account_id</field>
@@ -82,7 +82,7 @@
 
             <!-- Gastos de administración -->
             <record id="account_financial_report_l10n_ar_estado_resultados_line_adm_exp" model="account.report.line">
-                <field name="name">Gastos de administración</field>
+                <field name="name">Administrative Expenses</field>
                 <field name="code">adm_exp</field>
                 <field name="hierarchy_level">1</field>
                 <field name="user_groupby">account_id</field>
@@ -99,7 +99,7 @@
 
             <!-- Otros gastos -->
             <record id="account_financial_report_l10n_ar_estado_resultados_line_other_exp" model="account.report.line">
-                <field name="name">Otros gastos</field>
+                <field name="name">Other Expenses</field>
                 <field name="code">other_exp</field>
                 <field name="hierarchy_level">1</field>
                 <field name="user_groupby">account_id</field>
@@ -116,7 +116,7 @@
 
             <!-- Resultados financieros y por tenencia (incluye RECPAM) -->
             <record id="account_financial_report_l10n_ar_estado_resultados_line_fin_exp" model="account.report.line">
-                <field name="name">Resultados financieros y por tenencia (incluye RECPAM)</field>
+                <field name="name">Financial Results and Holding Gains/Losses (includes RECPAM)</field>
                 <field name="code">fin_exp</field>
                 <field name="hierarchy_level">1</field>
                 <field name="user_groupby">account_id</field>
@@ -133,7 +133,7 @@
 
             <!-- Otros ingresos y egresos -->
             <record id="account_financial_report_l10n_ar_estado_resultados_line_other_inc_exp" model="account.report.line">
-                <field name="name">Otros ingresos y egresos</field>
+                <field name="name">Other Income and Expenses</field>
                 <field name="code">other_inc_exp</field>
                 <field name="hierarchy_level">1</field>
                 <field name="user_groupby">account_id</field>
@@ -150,7 +150,7 @@
 
             <!-- Resultado antes del impuesto a las ganancias -->
             <record id="account_financial_report_l10n_ar_estado_resultados_line_inc_before_tax" model="account.report.line">
-                <field name="name">Resultado antes del impuesto a las ganancias</field>
+                <field name="name">Result Before Income Tax</field>
                 <field name="code">inc_before_tax</field>
                 <field name="hierarchy_level">0</field>
                 <field name="expression_ids">
@@ -164,7 +164,7 @@
 
             <!-- Impuesto a las ganancias -->
             <record id="account_financial_report_l10n_ar_estado_resultados_line_tax_inc" model="account.report.line">
-                <field name="name">Impuesto a las ganancias</field>
+                <field name="name">Income Tax</field>
                 <field name="code">tax_inc</field>
                 <field name="hierarchy_level">1</field>
                 <field name="user_groupby">account_id</field>
@@ -181,7 +181,7 @@
 
             <!-- Resultado Final del ejercicio -->
             <record id="account_financial_report_l10n_ar_estado_resultados_line_net_inc" model="account.report.line">
-                <field name="name">Resultado Final del ejercicio</field>
+                <field name="name">Net Result for the Period</field>
                 <field name="code">net_inc</field>
                 <field name="hierarchy_level">0</field>
                 <field name="expression_ids">
@@ -197,7 +197,7 @@
 
     <!-- Action para abrir el Estado de Resultados -->
     <record id="action_account_report_l10n_ar_estado_resultados" model="ir.actions.client">
-        <field name="name">Estado de Resultados</field>
+        <field name="name">Income Statement</field>
         <field name="tag">account_report</field>
         <field name="context" eval="{'report_id': ref('account_financial_report_l10n_ar_estado_resultados')}"/>
     </record>

--- a/l10n_ar_account_reports/data/l10n_ar_vat_ret_perc_sufrido.xml
+++ b/l10n_ar_account_reports/data/l10n_ar_vat_ret_perc_sufrido.xml
@@ -13,13 +13,12 @@
         <field name="column_ids">
             <record id="l10n_ar_iva_report_column_total" model="account.report.column">
                 <field name="name">Balance</field>
-                <field name="name@es_419">Balance</field>
                 <field name="expression_label">balance</field>
             </record>
         </field>
         <field name="line_ids">
             <record id="l10n_ar_iva_report_debito_fiscal" model="account.report.line">
-                <field name="name">(+) Débito Fiscal (Ventas)</field>
+                <field name="name">(+) Fiscal Debit (Sales)</field>
                 <field name="code">L10N_AR_IVA_DEBITO</field>
                 <field name="expression_ids">
                     <record id="l10n_ar_iva_report_debito_fiscal_balance" model="account.report.expression">
@@ -31,7 +30,7 @@
                 </field>
             </record>
             <record id="l10n_ar_iva_report_credito_fiscal" model="account.report.line">
-                <field name="name">(-) Crédito Fiscal (Compras)</field>
+                <field name="name">(-) Input VAT (Purchases)</field>
                 <field name="code">L10N_AR_IVA_CREDITO</field>
                 <field name="expression_ids">
                     <record id="l10n_ar_iva_report_credito_fiscal_balance" model="account.report.expression">
@@ -43,7 +42,7 @@
                 </field>
             </record>
             <record id="l10n_ar_iva_report_saldo_tecnico" model="account.report.line">
-                <field name="name">(=) Saldo Técnico (1er Párrafo)</field>
+                <field name="name">(=) Technical Balance (1st Paragraph)</field>
                 <field name="code">L10N_AR_IVA_SALDO_TECNICO</field>
                 <field name="expression_ids">
                     <record id="l10n_ar_iva_report_saldo_tecnico_balance" model="account.report.expression">
@@ -54,7 +53,7 @@
                 </field>
             </record>
             <record id="l10n_ar_iva_report_iva_withholdings_line" model="account.report.line">
-                <field name="name">(-) Retenciones Sufridas</field>
+                <field name="name">(-) Suffered Withholdings</field>
                 <field name="code">L10N_AR_IVA_RETENCIONES</field>
                 <field name="expression_ids">
                     <record id="l10n_ar_iva_report_iva_withholdings_line_balance" model="account.report.expression">
@@ -66,7 +65,7 @@
                 </field>
             </record>
             <record id="l10n_ar_iva_report_iva_perceptions_line" model="account.report.line">
-                <field name="name">(-) Percepciones Sufridas</field>
+                <field name="name">(-) Suffered Perceptions</field>
                 <field name="code">L10N_AR_IVA_PERCEPCIONES</field>
                 <field name="expression_ids">
                     <record id="l10n_ar_iva_report_iva_perceptions_line_balance" model="account.report.expression">

--- a/l10n_ar_account_reports/data/sicore_report.xml
+++ b/l10n_ar_account_reports/data/sicore_report.xml
@@ -12,7 +12,6 @@
         <field name="column_ids">
             <record id="l10n_ar_sicore_report_column_total" model="account.report.column">
                 <field name="name">Balance</field>
-                <field name="name@es_419">Balance</field>
                 <field name="expression_label">balance</field>
             </record>
         </field>
@@ -25,7 +24,7 @@
     </record>
 
     <record id="sicore_return_type" model="account.return.type">
-        <field name="name">SICORE Ganancias (Agente)</field>
+        <field name="name">SICORE Income Tax (Agent)</field>
         <field name="report_id" ref="l10n_ar_account_reports.l10n_ar_sicore_report"/>
         <field name="default_deadline_periodicity">fortnightly</field>
         <field name="auto_generate" eval="False"/>

--- a/l10n_ar_account_reports/data/sifere_report.xml
+++ b/l10n_ar_account_reports/data/sifere_report.xml
@@ -13,7 +13,6 @@
         <field name="column_ids">
             <record id="l10n_ar_sifere_report_column_total" model="account.report.column">
                 <field name="name">Balance</field>
-                <field name="name@es_419">Balance</field>
                 <field name="expression_label">balance</field>
             </record>
         </field>
@@ -28,7 +27,7 @@
                 <field name="domain_formula">sum([("tax_line_id.l10n_ar_state_id", "!=", False), ("tax_line_id.l10n_ar_state_id.country_id.code", "=", "AR"), ("tax_line_id.type_tax_use", "=", "purchase"), ("l10n_latam_document_type_id.code", "not in", ["66", "67"])])</field>
             </record>
             <record id="l10n_ar_sifere_report_sifere_despachos_line" model="account.report.line">
-                <field name="name">Despachos de importación</field>
+                <field name="name">Import Dispatches</field>
                 <field name="domain_formula">sum([("tax_line_id.l10n_ar_state_id", "!=", False), ("tax_line_id.l10n_ar_state_id.country_id.code", "=", "AR"), ("tax_line_id.type_tax_use", "=", "purchase"), ("l10n_latam_document_type_id.code", "in", ["66", "67"])])</field>
             </record>
         </field>

--- a/l10n_ar_account_reports/data/tags_data.xml
+++ b/l10n_ar_account_reports/data/tags_data.xml
@@ -2,141 +2,141 @@
 <odoo>
     <!-- Estado de Resultados Tags -->
     <record id="ar_eerr_ventas" model="account.account.tag">
-        <field name="name">AR EERR: Ventas</field>
+        <field name="name">AR EERR: Sales</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_eerr_costo_ventas" model="account.account.tag">
-        <field name="name">AR EERR: Costo de Ventas</field>
+        <field name="name">AR EERR: Cost of Sales</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_eerr_gastos_comercializacion" model="account.account.tag">
-        <field name="name">AR EERR: Gastos de Comercialización</field>
+        <field name="name">AR EERR: Selling Expenses</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_eerr_gastos_administracion" model="account.account.tag">
-        <field name="name">AR EERR: Gastos de Administración</field>
+        <field name="name">AR EERR: Administrative Expenses</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_eerr_otros_gastos" model="account.account.tag">
-        <field name="name">AR EERR: Otros Gastos</field>
+        <field name="name">AR EERR: Other Expenses</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_eerr_rxt_resultados_financieros" model="account.account.tag">
-        <field name="name">AR EERR: RxT y Resultados Financieros</field>
+        <field name="name">AR EERR: Financial Results and Holding Gains/Losses</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_eerr_otros_ingresos_egresos" model="account.account.tag">
-        <field name="name">AR EERR: Otros ingresos y egresos</field>
+        <field name="name">AR EERR: Other Income and Expenses</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_eerr_impuesto_ganancias" model="account.account.tag">
-        <field name="name">AR EERR: Impuesto a las ganancias</field>
+        <field name="name">AR EERR: Income Tax</field>
         <field name="applicability">accounts</field>
     </record>
 
     <!-- Estado Patrimonial Tags (Balance Sheet) -->
     <record id="ar_esp_caja_y_bancos" model="account.account.tag">
-        <field name="name">AR ESP: Caja y Bancos</field>
+        <field name="name">AR ESP: Cash and Banks</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_inversiones_temporarias" model="account.account.tag">
-        <field name="name">AR ESP: Inversiones Temporarias</field>
+        <field name="name">AR ESP: Short-term Investments</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_creditos_por_ventas" model="account.account.tag">
-        <field name="name">AR ESP: Créditos por Ventas</field>
+        <field name="name">AR ESP: Accounts Receivable</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_otros_creditos" model="account.account.tag">
-        <field name="name">AR ESP: Otros Créditos</field>
+        <field name="name">AR ESP: Other Receivables</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_bienes_de_cambio" model="account.account.tag">
-        <field name="name">AR ESP: Bienes de Cambio</field>
+        <field name="name">AR ESP: Inventories</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_otros_activos" model="account.account.tag">
-        <field name="name">AR ESP: Otros Activos</field>
+        <field name="name">AR ESP: Other Current Assets</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_creditos_por_ventas_nc" model="account.account.tag">
-        <field name="name">AR ESP: Créditos por Ventas NC</field>
+        <field name="name">AR ESP: Long-term Accounts Receivable</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_otros_creditos_nc" model="account.account.tag">
-        <field name="name">AR ESP: Otros Créditos NC</field>
+        <field name="name">AR ESP: Other Long-term Receivables</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_bienes_de_cambio_nc" model="account.account.tag">
-        <field name="name">AR ESP: Bienes de Cambio NC</field>
+        <field name="name">AR ESP: Long-term Inventories</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_bienes_de_uso" model="account.account.tag">
-        <field name="name">AR ESP: Bienes de Uso</field>
+        <field name="name">AR ESP: Fixed Assets</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_participaciones_en_sociedades" model="account.account.tag">
-        <field name="name">AR ESP: Participaciones en Sociedades</field>
+        <field name="name">AR ESP: Investments in Subsidiaries</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_otras_inversiones_nc" model="account.account.tag">
-        <field name="name">AR ESP: Otras Inversiones NC</field>
+        <field name="name">AR ESP: Other Long-term Investments</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_activos_intangibles" model="account.account.tag">
-        <field name="name">AR ESP: Activos Intangibles</field>
+        <field name="name">AR ESP: Intangible Assets</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_otros_activos_nc" model="account.account.tag">
-        <field name="name">AR ESP: Otros Activos NC</field>
+        <field name="name">AR ESP: Other Non-current Assets</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_llave_de_negocio" model="account.account.tag">
-        <field name="name">AR ESP: Llave de Negocio</field>
+        <field name="name">AR ESP: Goodwill</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_deudas_comerciales" model="account.account.tag">
-        <field name="name">AR ESP: Deudas Comerciales</field>
+        <field name="name">AR ESP: Accounts Payable</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_prestamos" model="account.account.tag">
-        <field name="name">AR ESP: Préstamos</field>
+        <field name="name">AR ESP: Loans Payable</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_remun_y_cargas_sociales" model="account.account.tag">
-        <field name="name">AR ESP: Remun. y Cargas Sociales</field>
+        <field name="name">AR ESP: Payroll Liabilities</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_cargas_fiscales" model="account.account.tag">
-        <field name="name">AR ESP: Cargas Fiscales</field>
+        <field name="name">AR ESP: Tax Liabilities</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_anticipos_de_clientes" model="account.account.tag">
-        <field name="name">AR ESP: Anticipos de Clientes</field>
+        <field name="name">AR ESP: Customer Advances</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_dividendos_a_pagar" model="account.account.tag">
-        <field name="name">AR ESP: Dividendos a Pagar</field>
+        <field name="name">AR ESP: Dividends Payable</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_otras_deudas" model="account.account.tag">
-        <field name="name">AR ESP: Otras Deudas</field>
+        <field name="name">AR ESP: Other Liabilities</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_previsiones" model="account.account.tag">
-        <field name="name">AR ESP: Previsiones</field>
+        <field name="name">AR ESP: Provisions</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_deudas_no_corrientes" model="account.account.tag">
-        <field name="name">AR ESP: Deudas No Corrientes</field>
+        <field name="name">AR ESP: Non-current Liabilities</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_previsiones_no_corrientes" model="account.account.tag">
-        <field name="name">AR ESP: Previsiones No Corrientes</field>
+        <field name="name">AR ESP: Non-current Provisions</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_part_terceros_en_soc" model="account.account.tag">
-        <field name="name">AR ESP: Part. Terceros en Soc.</field>
+        <field name="name">AR ESP: Minority Interests</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_capital" model="account.account.tag">
@@ -144,15 +144,15 @@
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_reservas" model="account.account.tag">
-        <field name="name">AR ESP: Reservas</field>
+        <field name="name">AR ESP: Reserves</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_resultados" model="account.account.tag">
-        <field name="name">AR ESP: Resultados</field>
+        <field name="name">AR ESP: Retained Earnings</field>
         <field name="applicability">accounts</field>
     </record>
     <record id="ar_esp_resultado_del_ejercicio" model="account.account.tag">
-        <field name="name">AR ESP: Resultado del Ejercicio</field>
+        <field name="name">AR ESP: Current Year Earnings</field>
         <field name="applicability">accounts</field>
     </record>
 </odoo>

--- a/l10n_ar_account_reports/i18n/es.po
+++ b/l10n_ar_account_reports/i18n/es.po
@@ -25,32 +25,27 @@ msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_iva_report_debito_fiscal
-#, fuzzy
-msgid "(+) Débito Fiscal (Ventas)"
+msgid "(+) Fiscal Debit (Sales)"
 msgstr "(+) Débito Fiscal (Ventas)"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_iva_report_credito_fiscal
-#, fuzzy
-msgid "(-) Crédito Fiscal (Compras)"
+msgid "(-) Input VAT (Purchases)"
 msgstr "(-) Crédito Fiscal (Compras)"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_iva_report_iva_perceptions_line
-#, fuzzy
-msgid "(-) Percepciones Sufridas"
+msgid "(-) Suffered Perceptions"
 msgstr "(-) Percepciones Sufridas"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_iva_report_iva_withholdings_line
-#, fuzzy
-msgid "(-) Retenciones Sufridas"
+msgid "(-) Suffered Withholdings"
 msgstr "(-) Retenciones Sufridas"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_iva_report_saldo_tecnico
-#, fuzzy
-msgid "(=) Saldo Técnico (1er Párrafo)"
+msgid "(=) Technical Balance (1st Paragraph)"
 msgstr "(=) Saldo Técnico (1er Párrafo)"
 
 #. module: l10n_ar_account_reports
@@ -59,241 +54,202 @@ msgid ""
 "<span>\n"
 "                                    %\n"
 "                                </span>"
-msgstr ""
-"<span>\n"
-"                                    %\n"
-"                                </span>"
+msgstr "<span>\\n                                    %\\n                                </span>"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_account_return_type__l10n_ar_account_id
-#, fuzzy
 msgid "AR Closing Account"
 msgstr "AR Closing Account"
 
 #. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_costo_ventas
-#, fuzzy
-msgid "AR EERR: Costo de Ventas"
-msgstr "AR EERR: Costo de Ventas"
-
-#. module: l10n_ar_account_reports
 #: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_gastos_administracion
-#, fuzzy
-msgid "AR EERR: Gastos de Administración"
+msgid "AR EERR: Administrative Expenses"
 msgstr "AR EERR: Gastos de Administración"
 
 #. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_gastos_comercializacion
-#, fuzzy
-msgid "AR EERR: Gastos de Comercialización"
-msgstr "AR EERR: Gastos de Comercialización"
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_costo_ventas
+msgid "AR EERR: Cost of Sales"
+msgstr "AR EERR: Costo de Ventas"
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_rxt_resultados_financieros
+msgid "AR EERR: Financial Results and Holding Gains/Losses"
+msgstr "AR EERR: RxT y Resultados Financieros"
 
 #. module: l10n_ar_account_reports
 #: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_impuesto_ganancias
-#, fuzzy
-msgid "AR EERR: Impuesto a las ganancias"
+msgid "AR EERR: Income Tax"
 msgstr "AR EERR: Impuesto a las ganancias"
 
 #. module: l10n_ar_account_reports
 #: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_otros_gastos
-#, fuzzy
-msgid "AR EERR: Otros Gastos"
+msgid "AR EERR: Other Expenses"
 msgstr "AR EERR: Otros Gastos"
 
 #. module: l10n_ar_account_reports
 #: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_otros_ingresos_egresos
-#, fuzzy
-msgid "AR EERR: Otros ingresos y egresos"
+msgid "AR EERR: Other Income and Expenses"
 msgstr "AR EERR: Otros ingresos y egresos"
 
 #. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_rxt_resultados_financieros
-#, fuzzy
-msgid "AR EERR: RxT y Resultados Financieros"
-msgstr "AR EERR: RxT y Resultados Financieros"
-
-#. module: l10n_ar_account_reports
 #: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_ventas
-#, fuzzy
-msgid "AR EERR: Ventas"
+msgid "AR EERR: Sales"
 msgstr "AR EERR: Ventas"
 
 #. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_activos_intangibles
-#, fuzzy
-msgid "AR ESP: Activos Intangibles"
-msgstr "AR ESP: Activos Intangibles"
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_gastos_comercializacion
+msgid "AR EERR: Selling Expenses"
+msgstr "AR EERR: Gastos de Comercialización"
 
 #. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_anticipos_de_clientes
-#, fuzzy
-msgid "AR ESP: Anticipos de Clientes"
-msgstr "AR ESP: Anticipos de Clientes"
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_deudas_comerciales
+msgid "AR ESP: Accounts Payable"
+msgstr "AR ESP: Deudas Comerciales"
 
 #. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_bienes_de_cambio
-#, fuzzy
-msgid "AR ESP: Bienes de Cambio"
-msgstr "AR ESP: Bienes de Cambio"
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_bienes_de_cambio_nc
-#, fuzzy
-msgid "AR ESP: Bienes de Cambio NC"
-msgstr "AR ESP: Bienes de Cambio NC"
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_bienes_de_uso
-#, fuzzy
-msgid "AR ESP: Bienes de Uso"
-msgstr "AR ESP: Bienes de Uso"
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_caja_y_bancos
-#, fuzzy
-msgid "AR ESP: Caja y Bancos"
-msgstr "AR ESP: Caja y Bancos"
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_creditos_por_ventas
+msgid "AR ESP: Accounts Receivable"
+msgstr "AR ESP: Créditos por Ventas"
 
 #. module: l10n_ar_account_reports
 #: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_capital
-#, fuzzy
 msgid "AR ESP: Capital"
 msgstr "AR ESP: Capital"
 
 #. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_cargas_fiscales
-#, fuzzy
-msgid "AR ESP: Cargas Fiscales"
-msgstr "AR ESP: Cargas Fiscales"
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_caja_y_bancos
+msgid "AR ESP: Cash and Banks"
+msgstr "AR ESP: Caja y Bancos"
 
 #. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_creditos_por_ventas
-#, fuzzy
-msgid "AR ESP: Créditos por Ventas"
-msgstr "AR ESP: Créditos por Ventas"
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_resultado_del_ejercicio
+msgid "AR ESP: Current Year Earnings"
+msgstr "AR ESP: Resultado del Ejercicio"
 
 #. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_creditos_por_ventas_nc
-#, fuzzy
-msgid "AR ESP: Créditos por Ventas NC"
-msgstr "AR ESP: Créditos por Ventas NC"
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_deudas_comerciales
-#, fuzzy
-msgid "AR ESP: Deudas Comerciales"
-msgstr "AR ESP: Deudas Comerciales"
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_deudas_no_corrientes
-#, fuzzy
-msgid "AR ESP: Deudas No Corrientes"
-msgstr "AR ESP: Deudas No Corrientes"
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_anticipos_de_clientes
+msgid "AR ESP: Customer Advances"
+msgstr "AR ESP: Anticipos de Clientes"
 
 #. module: l10n_ar_account_reports
 #: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_dividendos_a_pagar
-#, fuzzy
-msgid "AR ESP: Dividendos a Pagar"
+msgid "AR ESP: Dividends Payable"
 msgstr "AR ESP: Dividendos a Pagar"
 
 #. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_inversiones_temporarias
-#, fuzzy
-msgid "AR ESP: Inversiones Temporarias"
-msgstr "AR ESP: Inversiones Temporarias"
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_bienes_de_uso
+msgid "AR ESP: Fixed Assets"
+msgstr "AR ESP: Bienes de Uso"
 
 #. module: l10n_ar_account_reports
 #: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_llave_de_negocio
-#, fuzzy
-msgid "AR ESP: Llave de Negocio"
+msgid "AR ESP: Goodwill"
 msgstr "AR ESP: Llave de Negocio"
 
 #. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_activos_intangibles
+msgid "AR ESP: Intangible Assets"
+msgstr "AR ESP: Activos Intangibles"
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_bienes_de_cambio
+msgid "AR ESP: Inventories"
+msgstr "AR ESP: Bienes de Cambio"
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_participaciones_en_sociedades
+msgid "AR ESP: Investments in Subsidiaries"
+msgstr "AR ESP: Participaciones en Sociedades"
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_prestamos
+msgid "AR ESP: Loans Payable"
+msgstr "AR ESP: Préstamos"
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_creditos_por_ventas_nc
+msgid "AR ESP: Long-term Accounts Receivable"
+msgstr "AR ESP: Créditos por Ventas NC"
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_bienes_de_cambio_nc
+msgid "AR ESP: Long-term Inventories"
+msgstr "AR ESP: Bienes de Cambio NC"
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_part_terceros_en_soc
+msgid "AR ESP: Minority Interests"
+msgstr "AR ESP: Part. Terceros en Soc."
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_deudas_no_corrientes
+msgid "AR ESP: Non-current Liabilities"
+msgstr "AR ESP: Deudas No Corrientes"
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_previsiones_no_corrientes
+msgid "AR ESP: Non-current Provisions"
+msgstr "AR ESP: Previsiones No Corrientes"
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_otros_activos
+msgid "AR ESP: Other Current Assets"
+msgstr "AR ESP: Otros Activos"
+
+#. module: l10n_ar_account_reports
 #: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_otras_deudas
-#, fuzzy
-msgid "AR ESP: Otras Deudas"
+msgid "AR ESP: Other Liabilities"
 msgstr "AR ESP: Otras Deudas"
 
 #. module: l10n_ar_account_reports
 #: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_otras_inversiones_nc
-#, fuzzy
-msgid "AR ESP: Otras Inversiones NC"
+msgid "AR ESP: Other Long-term Investments"
 msgstr "AR ESP: Otras Inversiones NC"
 
 #. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_otros_activos
-#, fuzzy
-msgid "AR ESP: Otros Activos"
-msgstr "AR ESP: Otros Activos"
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_otros_creditos_nc
+msgid "AR ESP: Other Long-term Receivables"
+msgstr "AR ESP: Otros Créditos NC"
 
 #. module: l10n_ar_account_reports
 #: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_otros_activos_nc
-#, fuzzy
-msgid "AR ESP: Otros Activos NC"
+msgid "AR ESP: Other Non-current Assets"
 msgstr "AR ESP: Otros Activos NC"
 
 #. module: l10n_ar_account_reports
 #: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_otros_creditos
-#, fuzzy
-msgid "AR ESP: Otros Créditos"
+msgid "AR ESP: Other Receivables"
 msgstr "AR ESP: Otros Créditos"
 
 #. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_otros_creditos_nc
-#, fuzzy
-msgid "AR ESP: Otros Créditos NC"
-msgstr "AR ESP: Otros Créditos NC"
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_part_terceros_en_soc
-#, fuzzy
-msgid "AR ESP: Part. Terceros en Soc."
-msgstr "AR ESP: Part. Terceros en Soc."
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_participaciones_en_sociedades
-#, fuzzy
-msgid "AR ESP: Participaciones en Sociedades"
-msgstr "AR ESP: Participaciones en Sociedades"
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_previsiones
-#, fuzzy
-msgid "AR ESP: Previsiones"
-msgstr "AR ESP: Previsiones"
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_previsiones_no_corrientes
-#, fuzzy
-msgid "AR ESP: Previsiones No Corrientes"
-msgstr "AR ESP: Previsiones No Corrientes"
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_prestamos
-#, fuzzy
-msgid "AR ESP: Préstamos"
-msgstr "AR ESP: Préstamos"
-
-#. module: l10n_ar_account_reports
 #: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_remun_y_cargas_sociales
-#, fuzzy
-msgid "AR ESP: Remun. y Cargas Sociales"
+msgid "AR ESP: Payroll Liabilities"
 msgstr "AR ESP: Remun. y Cargas Sociales"
 
 #. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_reservas
-msgid "AR ESP: Reservas"
-msgstr ""
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_previsiones
+msgid "AR ESP: Provisions"
+msgstr "AR ESP: Previsiones"
 
 #. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_resultado_del_ejercicio
-msgid "AR ESP: Resultado del Ejercicio"
-msgstr ""
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_reservas
+msgid "AR ESP: Reserves"
+msgstr "AR ESP: Reservas"
 
 #. module: l10n_ar_account_reports
 #: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_resultados
-msgid "AR ESP: Resultados"
-msgstr ""
+msgid "AR ESP: Retained Earnings"
+msgstr "AR ESP: Resultados"
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_inversiones_temporarias
+msgid "AR ESP: Short-term Investments"
+msgstr "AR ESP: Inversiones Temporarias"
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_cargas_fiscales
+msgid "AR ESP: Tax Liabilities"
+msgstr "AR ESP: Cargas Fiscales"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_account_return_type__l10n_ar_is_simple_closing_return
@@ -315,10 +271,7 @@ msgstr "Plantilla de plan contable"
 msgid ""
 "Account to use for the closing entry of this return type. If not set, the "
 "partner's payable/receivable account will be used."
-msgstr ""
-"Cuenta que se utilizará para el asiento de cierre de este tipo de "
-"declaración. Si no se configura, se utilizará la cuenta de cuentas por pagar "
-"o por cobrar del socio."
+msgstr "Cuenta que se utilizará para el asiento de cierre de este tipo de declaración. Si no se configura, se utilizará la cuenta de cuentas por pagar o por cobrar del socio."
 
 #. module: l10n_ar_account_reports
 #: model:ir.model,name:l10n_ar_account_reports.model_account_return
@@ -331,86 +284,88 @@ msgid "Accounting Return Type"
 msgstr "Tipo de declaración de impuestos"
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_activo
-#, fuzzy
-msgid "Activo"
-msgstr "Activo"
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_accounts_payable
+msgid "Accounts Payable"
+msgstr "Deudas Comerciales"
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_intangible_assets
-#, fuzzy
-msgid "Activos intangibles"
-msgstr "Activos intangibles"
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_sales_rec
+msgid "Accounts Receivable"
+msgstr "Créditos por ventas"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_sales_rec_noncurrent
+msgid "Accounts Receivable (Non-current)"
+msgstr "Créditos por ventas (No corriente)"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_equity_results_detail
+msgid "Accumulated Earnings"
+msgstr "Resultados Acumulados"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_adm_exp
+msgid "Administrative Expenses"
+msgstr "Gastos de administración"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
-msgid "Inflation Adjustment %s"
+msgid "Ajuste por inflación %s"
 msgstr "Ajuste por inflación %s"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
-msgid "Inflation adjustment %s (%s * %.2f%%)"
-msgstr "Ajuste por inflación %s (%s * %.2f%%)"
+msgid "Ajuste por inflación %s (%s * %.2f%%)"
+msgstr "Ajuste por inflación %s"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
-msgid "Global Inflation Adjustment [%s] / [%s]"
-msgstr "Ajuste por inflación Global [%s] / [%s]"
+msgid "Ajuste por inflación Global [%s] / [%s]"
+msgstr "Ajuste por inflación %s"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
-msgid "Inflation adjustment opening balances (%s * %.2f%%)"
-msgstr "Ajuste por inflación cuentas al inicio (%s * %.2f%%)"
+msgid "Ajuste por inflación cuentas al inicio (%s * %.2f%%)"
+msgstr "Ajuste por inflación %s"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/tucuman_report.py:0
 msgid ""
-"Some documents do not contain information about the street/city/province/"
-"postal code of the contact:\n"
+"Algunos comprobantes no contienen información acerca de la calle/ciudad/provincia/cod postal del contacto:\n"
 " %s"
-msgstr ""
-"Algunos comprobantes no contienen información acerca de la calle/ciudad/"
-"provincia/cod postal del contacto:\n"
-" %s"
+msgstr "Algunos comprobantes no contienen información acerca de la calle/ciudad/provincia/cod postal del contacto:\\n %s"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/tucuman_report.py:0
 msgid ""
-"Some corrective documents do not contain information about which original "
-"document they are reversing:\n"
+"Algunos comprobantes rectificativos no contienen información de que comprobante original están revirtiendo:\n"
 " %s"
-msgstr ""
-"Algunos comprobantes rectificativos no contienen información de que "
-"comprobante original están revirtiendo:\n"
-" %s"
+msgstr "Algunos comprobantes no contienen información acerca de la calle/ciudad/provincia/cod postal del contacto:\\n %s"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/tucuman_report.py:0
 msgid ""
-"Some documents have a 5-digit point of sale but must have a 4-digit one to "
-"generate the Tucuman withholdings and perceptions TXT file:\n"
+"Algunos comprobantes tienen punto de venta de 5 dígitos y deben tener de 4 dígitos para poder generar el archivo txt de retenciones y percepciones de Tucuman:\n"
 " %s"
-msgstr ""
-"Algunos comprobantes tienen punto de venta de 5 dígitos y deben tener de 4 "
-"dígitos para poder generar el archivo txt de retenciones y percepciones de "
-"Tucuman:\n"
-" %s"
+msgstr "Algunos comprobantes no contienen información acerca de la calle/ciudad/provincia/cod postal del contacto:\\n %s"
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_advances_from_customers
-msgid "Anticipos de clientes"
-msgstr "Anticipos de clientes"
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/inflation_adjustment_index.py:0
+msgid ""
+"An index already exists for period %s %s. You can only have one inflation "
+"index per month"
+msgstr "Ya existe un índice para el periodo %s %s. Solo puedes tener un índice de inflación por mes"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model,name:l10n_ar_account_reports.model_l10n_ar_caba_report_handler
-#, fuzzy
 msgid "Argentinian CABA Report Custom Handler"
 msgstr "Gestor personalizado de informes de la CABA argentina"
 
@@ -426,8 +381,6 @@ msgstr "Gestor personalizado de informes Argentinos Misiones"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model,name:l10n_ar_account_reports.model_l10n_ar_pba_report_handler
-#, fuzzy
-#| msgid "Partner Ledger Custom Handler"
 msgid "Argentinian PBA Report Custom Handler"
 msgstr "Gestor personalizado de informes Argentinos PBA"
 
@@ -457,57 +410,31 @@ msgid "Argentinian Tucumán Report Custom Handler"
 msgstr "Gestor personalizado de informes Argentinos Tucumán"
 
 #. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
 #: model:ir.actions.act_window,name:l10n_ar_account_reports.inflation_adjustment_action
 #: model:ir.ui.menu,name:l10n_ar_account_reports.inflation_adjustment_menu
 msgid "Asiento de ajuste por inflación"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#. odoo-python
-#: code:addons/l10n_ar_account_reports/models/account_return.py:0
-msgid "Inflation Adjustment Entry"
-msgstr "Asiento de ajuste por inflación"
-
-#. module: l10n_ar_account_reports
-#: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__open_move_id
-msgid "Opening Entry"
-msgstr "Asiento de apertura"
-
-#. module: l10n_ar_account_reports
-#: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__closure_move_id
-msgid "Closing Entry"
-msgstr "Asiento de cierre"
-
-#. module: l10n_ar_account_reports
-#: model:account.report,settlement_title:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados
-msgid "Asiento de refundición"
-msgstr ""
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_activo
+msgid "Assets"
+msgstr "Activo"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.column,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_column
 #: model:account.report.column,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_column
+#: model:account.report.column,name:l10n_ar_account_reports.l10n_ar_iva_report_column_total
+#: model:account.report.column,name:l10n_ar_account_reports.l10n_ar_sicore_report_column_total
+#: model:account.report.column,name:l10n_ar_account_reports.l10n_ar_sifere_report_column_total
 msgid "Balance"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_inventory
-msgid "Bienes de cambio"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_inventory_noncurrent
-msgid "Bienes de cambio (No corriente)"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_fixed_assets
-msgid "Bienes de uso"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_bank_cash
-msgid "Caja y Bancos"
-msgstr ""
+#: model:account.report,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial
+msgid "Balance Sheet"
+msgstr "Estado Patrimonial"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
@@ -524,9 +451,7 @@ msgstr ""
 msgid ""
 "Can only generate TXT files using posted entries. Please remove Include "
 "unposted entries filter and try again"
-msgstr ""
-"Solo se pueden generar archivos TXT a partir de entradas publicadas. "
-"Desactiva el filtro «Incluir entradas no publicadas» e inténtalo de nuevo"
+msgstr "Solo se pueden generar archivos TXT a partir de entradas publicadas. Desactiva el filtro «Incluir entradas no publicadas» e inténtalo de nuevo"
 
 #. module: l10n_ar_account_reports
 #: model_terms:ir.ui.view,arch_db:l10n_ar_account_reports.inflation_adjustment_form
@@ -539,15 +464,20 @@ msgid "Capital"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_tax_liabilities
-msgid "Cargas fiscales"
-msgstr ""
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_bank_cash
+msgid "Cash and Banks"
+msgstr "Caja y Bancos"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/account_return.py:0
-msgid "Post-dated Checks"
-msgstr "Cheques a fecha"
+msgid "Cheques a fecha"
+msgstr "Asiento de ajuste por inflación"
+
+#. module: l10n_ar_account_reports
+#: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__closure_move_id
+msgid "Closing Entry"
+msgstr "Asiento de cierre"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__company_id
@@ -561,8 +491,17 @@ msgstr "Confirmar"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_cogs
-msgid "Costo de venta de bienes y servicios"
-msgstr ""
+msgid "Cost of Goods and Services Sold"
+msgstr "Costo de venta de bienes y servicios"
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+msgid ""
+"Could not find the original document for %s (id %s). Please verify that in "
+"the credit note \"%s\", the origin field contains the original invoice "
+"number"
+msgstr "No pudimos encontrar el comprobante original para %s (id %s). Verifique que en la nota de crédito \\\"%s\\\", el campo origen es el número de la factura original"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__create_uid
@@ -577,14 +516,14 @@ msgid "Created on"
 msgstr "Creado en"
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_sales_rec
-msgid "Créditos por ventas"
-msgstr ""
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_ar_curr_year_earnings
+msgid "Current Year Earnings"
+msgstr "Resultado del Ejercicio"
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_sales_rec_noncurrent
-msgid "Créditos por ventas (No corriente)"
-msgstr ""
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_advances_from_customers
+msgid "Customer Advances"
+msgstr "Anticipos de clientes"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment_index__date
@@ -605,50 +544,29 @@ msgstr "Fecha Hasta"
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
 msgid ""
-"You must set the IIBB registration type for partner "
-"\"%(partner_name)s\" (id: %(partner_id)s)"
-msgstr ""
 "Debe establecer el tipo de inscripción de IIBB del partner "
 "\"%(partner_name)s\" (id: %(partner_id)s)"
+msgstr "Debe establecer el tipo de inscripción de IIBB del partner \\\"%(partner_name)s\\\" (id: %(partner_id)s)"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
 msgid ""
-"You must set the \"article/section\" information in the configuration of tax "
-"\"%(tax_name)s\" in the \"API\" tab."
-msgstr ""
 "Debe establecer la información de \"artículo/inciso\" en la configuración "
-"del impuesto \"%(tax_name)s\" en la solapa \"API\"."
+"del impuesto \"%(tax_name)s\"en la solapa \"API\"."
+msgstr "Debe establecer el tipo de inscripción de IIBB del partner \\\"%(partner_name)s\\\" (id: %(partner_id)s)"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
 msgid ""
-"You must set the IIBB registration type for contact "
-"\"%(partner_name)s\" (id: %(partner_id)s)"
-msgstr ""
-"Debe setear el tipo de inscripción de IIBB del contacto "
-"\"%(partner_name)s\" (id: %(partner_id)s)"
+"Debe setear el tipo de inscripción de IIBB del contacto \"%(partner_name)s\""
+" (id: %(partner_id)s)"
+msgstr "Debe setear el tipo de inscripción de IIBB del contacto \\\"%(partner_name)s\\\" (id: %(partner_id)s)"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_account_return_type__default_deadline_periodicity
 msgid "Default Periodicity"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_sifere_report_sifere_despachos_line
-msgid "Despachos de importación"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_accounts_payable
-msgid "Deudas Comerciales"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_long_term_liabilities
-msgid "Deudas no corrientes"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -677,8 +595,15 @@ msgstr "Nombre para mostrar"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_dividends_payable
-msgid "Dividendos a pagar"
-msgstr ""
+msgid "Dividends Payable"
+msgstr "Dividendos a pagar"
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+#: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
+msgid "Edit contact"
+msgstr "Editar contacto"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
@@ -692,75 +617,56 @@ msgstr "Editar impuesto"
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
 #: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
-msgid "Edit contact"
+msgid "Editar contacto"
 msgstr "Editar contacto"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
 msgid ""
-"The inflation adjustment entry cannot be generated because the adjustment "
-"index for period %(month)s %(year)s is missing"
-msgstr ""
 "El asiento de ajuste por inflación no puede ser generado ya que hace falta "
 "el indice de ajuste para el periodo %(month)s %(year)s"
+msgstr "Ajuste por inflación %s"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
 msgid ""
-"The contact \"%(partner_name)s\" (id %(partner_id)s) must have the "
-"identification type CUIT, CUIL, or CDI."
-msgstr ""
 "El contacto \"%(partner_name)s\" (id %(partner_id)s), debe tener el tipo de "
 "identificación CUIT, CUIL, CDI."
+msgstr "Debe setear el tipo de inscripción de IIBB del contacto \\\"%(partner_name)s\\\" (id: %(partner_id)s)"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/l10n_ar_vat_ret_perc_sufrido.py:0
 msgid ""
-"The regime code must have 3 digits in the configuration of tax "
-"\"%(tax_name)s\""
-msgstr ""
 "El código de régimen tiene que tener 3 dígitos en la configuración del "
 "impuesto \"%(tax_name)s\""
+msgstr "El código de régimen tiene que tener 3 dígitos en la configuración del impuesto \\\"%(tax_name)s\\\""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
-msgid "The tax is not associated"
-msgstr "El impuesto no está asociado"
+msgid "El impuesto no está asociado"
+msgstr "Debe setear el tipo de inscripción de IIBB del contacto \\\"%(partner_name)s\\\" (id: %(partner_id)s)"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
 msgid ""
-"The partner \"%(partner_name)s\" (id %(partner_id)s) does not have an "
-"identification number set"
-msgstr ""
 "El partner \"%(partner_name)s\" (id %(partner_id)s) no tiene número de "
 "identificación establecido"
+msgstr "Debe setear el tipo de inscripción de IIBB del contacto \\\"%(partner_name)s\\\" (id: %(partner_id)s)"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/inflation_adjustment_index.py:0
-msgid "The index must start on the first day of each month"
+msgid "El índice debe comenzar el primer día de cada mes"
 msgstr "El índice debe comenzar el primer día de cada mes"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__end_index
 msgid "End Index"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial
-msgid "Estado Patrimonial"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados
-#: model:ir.actions.client,name:l10n_ar_account_reports.action_account_report_l10n_ar_estado_resultados
-msgid "Estado de Resultados"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -774,36 +680,53 @@ msgid "External ID"
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_fin_exp
+msgid "Financial Results and Holding Gains/Losses (includes RECPAM)"
+msgstr "Resultados financieros y por tenencia (incluye RECPAM)"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_fixed_assets
+msgid "Fixed Assets"
+msgstr "Bienes de uso"
+
+#. module: l10n_ar_account_reports
 #: model:ir.model.fields.selection,name:l10n_ar_account_reports.selection__account_return_type__deadline_periodicity__fortnightly
 #: model:ir.model.fields.selection,name:l10n_ar_account_reports.selection__account_return_type__default_deadline_periodicity__fortnightly
 msgid "Fortnightly"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_gross_inc
-msgid "Ganancia (Pérdida) bruta"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_adm_exp
-msgid "Gastos de administración"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_com_exp
-msgid "Gastos de comercialización"
-msgstr ""
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
+msgid "Generar el asiento de ajuste por inflación para el período fiscal."
+msgstr "Asiento de ajuste por inflación"
 
 #. module: l10n_ar_account_reports
 #: model:account.report,settlement_title:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial
-msgid "Generar asiento de cierre"
-msgstr ""
+msgid "Generate Closing Entry"
+msgstr "Generar asiento de cierre"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/account_return.py:0
 msgid "Generate the inflation adjustment journal entry for the fiscal period."
 msgstr "Generar el asiento de ajuste por inflación para el período fiscal."
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid "Global Inflation Adjustment [%s] / [%s]"
+msgstr "Ajuste por inflación Global [%s] / [%s]"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_goodwill
+msgid "Goodwill"
+msgstr "Llave de negocio"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_gross_inc
+msgid "Gross Profit (Loss)"
+msgstr "Ganancia (Pérdida) bruta"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__open_cloure_entry
@@ -877,8 +800,6 @@ msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:ir.model,name:l10n_ar_account_reports.model_l10n_ar_iva_report_handler
-#, fuzzy
-#| msgid "Partner Ledger Custom Handler"
 msgid "IVA Sufrido Report Custom Handler"
 msgstr "Gestor personalizado del libro mayor del contacto"
 
@@ -887,15 +808,30 @@ msgstr "Gestor personalizado del libro mayor del contacto"
 msgid ""
 "If enabled, this return type uses simplified closing logic: no carryover "
 "mechanism and no automatic tax_lock_date update."
-msgstr ""
-"Si se habilita, este tipo de declaración utiliza una lógica de cierre "
-"simplificada: sin mecanismo de traspaso y sin actualización automática de la "
-"fecha de bloqueo fiscal."
+msgstr "Si se habilita, este tipo de declaración utiliza una lógica de cierre simplificada: sin mecanismo de traspaso y sin actualización automática de la fecha de bloqueo fiscal."
+
+#. module: l10n_ar_account_reports
+#: model:ir.model.fields,help:l10n_ar_account_reports.field_inflation_adjustment__open_cloure_entry
+msgid ""
+"If you have made the closing/opening entries, please indicate them so they "
+"can be excluded from the calculation."
+msgstr "Si usted ha realizado los asientos de cierre/apertura debe indicarnos cuales son para poder excluir los mismos en el cálculo."
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_sifere_report_sifere_despachos_line
+msgid "Import Dispatches"
+msgstr "Despachos de importación"
+
+#. module: l10n_ar_account_reports
+#: model:account.report,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados
+#: model:ir.actions.client,name:l10n_ar_account_reports.action_account_report_l10n_ar_estado_resultados
+msgid "Income Statement"
+msgstr "Estado de Resultados"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_tax_inc
-msgid "Impuesto a las ganancias"
-msgstr ""
+msgid "Income Tax"
+msgstr "Impuesto a las ganancias"
 
 #. module: l10n_ar_account_reports
 #: model:ir.actions.act_window,name:l10n_ar_account_reports.inflation_adjustment_index_action
@@ -909,6 +845,18 @@ msgid "Inflation Adjustment"
 msgstr "Ajuste por Inflación"
 
 #. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid "Inflation Adjustment %s"
+msgstr "Ajuste por inflación %s"
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
+msgid "Inflation Adjustment Entry"
+msgstr "Asiento de ajuste por inflación"
+
+#. module: l10n_ar_account_reports
 #: model:ir.model,name:l10n_ar_account_reports.model_inflation_adjustment_index
 msgid "Inflation Adjustment Index"
 msgstr "Índice de Ajuste por Inflación"
@@ -919,9 +867,31 @@ msgid "Inflation adjustment"
 msgstr "Ajuste por Inflación"
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_temp_investments
-msgid "Inversiones temporarias"
-msgstr ""
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid "Inflation adjustment %s (%s * %.2f%%)"
+msgstr "Ajuste por inflación %s (%s * %.2f%%)"
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid "Inflation adjustment opening balances (%s * %.2f%%)"
+msgstr "Ajuste por inflación cuentas al inicio (%s * %.2f%%)"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_intangible_assets
+msgid "Intangible Assets"
+msgstr "Activos intangibles"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_inventory
+msgid "Inventories"
+msgstr "Bienes de cambio"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_inventory_noncurrent
+msgid "Inventories (Non-current)"
+msgstr "Bienes de cambio (No corriente)"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__journal_id
@@ -942,29 +912,24 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/sifere_report.py:0
 msgid ""
-"The perception %s (id: %d) of the document \"%s\" (id: %d) has no associated "
-"contact."
-msgstr ""
 "La percepción %s (id: %d) del comprobante \"%s\" (id: %d) no tiene contacto "
 "asociado."
+msgstr "La percepción %s (id: %d) del comprobante \\\"%s\\\" (id: %d) no tiene contacto asociado."
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
 msgid ""
-"The VAT responsibility \"%s\" is not supported for AGIP withholding/perception"
-msgstr ""
 "La responsabilidad frente a IVA \"%s\" no está soportada para ret/perc AGIP"
+msgstr "Debe setear el tipo de inscripción de IIBB del contacto \\\"%(partner_name)s\\\" (id: %(partner_id)s)"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
 msgid ""
-"The VAT responsibility \"%s\" is not supported for Santa Fe "
-"withholding/perception"
-msgstr ""
-"La responsabilidad frente a IVA \"%s\" no está soportada para ret/perc Santa "
-"Fe"
+"La responsabilidad frente a IVA \"%s\" no está soportada para ret/perc Santa"
+" Fe"
+msgstr "Debe establecer el tipo de inscripción de IIBB del partner \\\"%(partner_name)s\\\" (id: %(partner_id)s)"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__write_uid
@@ -979,9 +944,39 @@ msgid "Last Updated on"
 msgstr "Última Actualización en"
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_goodwill
-msgid "Llave de negocio"
-msgstr ""
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_pasivo
+msgid "Liabilities"
+msgstr "Pasivo"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_loans_payable
+msgid "Loans Payable"
+msgstr "Préstamos"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_long_term_investments
+msgid "Long-term Investments in Subsidiaries"
+msgstr "Participaciones permanentes en sociedades"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_minority_interest
+msgid "Minority Interest in Controlled Companies"
+msgstr "Participación de terceros en sociedades controladas"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_equity
+msgid "Net Equity"
+msgstr "Patrimonio neto"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_net_inc
+msgid "Net Result for the Period"
+msgstr "Resultado Final del ejercicio"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_sales
+msgid "Net Sales of Goods and Services"
+msgstr "Ventas netas de bienes y servicios"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields.selection,name:l10n_ar_account_reports.selection__inflation_adjustment__open_cloure_entry__no
@@ -991,40 +986,32 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/l10n_ar_vat_ret_perc_sufrido.py:0
-msgid ""
-"There is no regime code in the configuration of tax \"%(tax_name)s\""
-msgstr ""
-"No hay código de régimen en la configuración del impuesto \"%(tax_name)s\""
+msgid "No hay código de régimen en la configuración del impuesto \"%(tax_name)s\""
+msgstr "El código de régimen tiene que tener 3 dígitos en la configuración del impuesto \\\"%(tax_name)s\\\""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
 msgid ""
-"There is no jurisdiction set in the tax \"%(tax_name)s\" or it does not have "
-"a jurisdiction code."
-msgstr ""
 "No hay jurisdicción establecida en el impuesto \"%(tax_name)s\" o no tiene "
 "código de jurisdicción."
+msgstr "No hay jurisdicción establecida en el impuesto \\\"%(tax_name)s\\\" o no tiene código de jurisdicción."
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
 msgid ""
-"There is no withholding regime (ARCA Code 'l10n_ar_code') configured for tax "
-"'%(tax_name)s' of partner '%(partner_name)s'"
-msgstr ""
 "No hay regimen de retencion (ARCA Code 'l10n_ar_code') configurado para el "
 "impuesto '%(tax_name)s' del partner '%(partner_name)s'"
+msgstr "No hay jurisdicción establecida en el impuesto \\\"%(tax_name)s\\\" o no tiene código de jurisdicción."
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
 msgid ""
-"There is no perception regime (ARCA Code 'l10n_ar_code') configured for tax: "
-"'%(tax_name)s'."
-msgstr ""
 "No hay régimen de percepción (ARCA Code 'l10n_ar_code') configurado para el "
 "impuesto: '%(tax_name)s'."
+msgstr "No hay jurisdicción establecida en el impuesto \\\"%(tax_name)s\\\" o no tiene código de jurisdicción."
 
 #. module: l10n_ar_account_reports
 #: model_terms:ir.actions.act_window,help:l10n_ar_account_reports.inflation_adjustment_index_action
@@ -1035,85 +1022,99 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
 msgid ""
-"No journal entries to adjust were found for the selected period."
-msgstr ""
-"No hemos encontrado ningún asiento contable para ajustar asociado al periodo "
-"seleccionado."
-
-#. module: l10n_ar_account_reports
-#. odoo-python
-#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
-msgid ""
-"Could not find the original document for %s (id %s). Please verify that in "
-"the credit note \"%s\", the origin field contains the original invoice number"
-msgstr ""
-"No pudimos encontrar el comprobante original para %s (id %s). Verifique que "
-"en la nota de crédito \"%s\", el campo origen es el número de la factura "
-"original"
+"No hemos encontrado ningún asiento contable para ajustar asociado al periodo"
+" seleccionado."
+msgstr "Ajuste por inflación %s"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
 msgid ""
-"No inflation adjustment index was found for the previous date (%s). "
-"Please configure the corresponding index."
-msgstr ""
+"No inflation adjustment index was found for the previous date (%s). Please "
+"configure the corresponding index."
+msgstr "No se encontró un índice de ajuste por inflación para la fecha anterior (%s). Por favor, configure el índice correspondiente."
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid "No journal entries to adjust were found for the selected period."
+msgstr "No hemos encontrado ningún asiento contable para ajustar asociado al periodo seleccionado."
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+msgid ""
+"No pudimos encontrar el comprobante original para %s (id %s). Verifique que "
+"en la nota de crédito \"%s\", el campo origen es el número de la factura "
+"original"
+msgstr "Debe setear el tipo de inscripción de IIBB del contacto \\\"%(partner_name)s\\\" (id: %(partner_id)s)"
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid ""
 "No se encontró un índice de ajuste por inflación para la fecha anterior "
 "(%s). Por favor, configure el índice correspondiente."
+msgstr "Ajuste por inflación %s"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_long_term_liabilities
+msgid "Non-current Liabilities"
+msgstr "Deudas no corrientes"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_long_term_provisions
+msgid "Non-current Provisions"
+msgstr "Previsiones no corrientes"
+
+#. module: l10n_ar_account_reports
+#: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__open_move_id
+msgid "Opening Entry"
+msgstr "Asiento de apertura"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_liabilities
-msgid "Otras"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_long_term_investments
-msgid "Otras inversiones"
-msgstr ""
+msgid "Other"
+msgstr "Otras"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_current_assets
-msgid "Otros activos"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_noncurrent_assets
-msgid "Otros activos (No corriente)"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_rec
-msgid "Otros créditos"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_rec_noncurrent
-msgid "Otros créditos (No corriente)"
-msgstr ""
+msgid "Other Current Assets"
+msgstr "Otros activos"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_other_exp
-msgid "Otros gastos"
-msgstr ""
+msgid "Other Expenses"
+msgstr "Otros gastos"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_other_inc_exp
-msgid "Otros ingresos y egresos"
-msgstr ""
+msgid "Other Income and Expenses"
+msgstr "Otros ingresos y egresos"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_long_term_investments
+msgid "Other Long-term Investments"
+msgstr "Otras inversiones"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_noncurrent_assets
+msgid "Other Non-current Assets"
+msgstr "Otros activos (No corriente)"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_rec
+msgid "Other Receivables"
+msgstr "Otros créditos"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_rec_noncurrent
+msgid "Other Receivables (Non-current)"
+msgstr "Otros créditos (No corriente)"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model,name:l10n_ar_account_reports.model_account_partial_reconcile
 msgid "Partial Reconcile"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_long_term_investments
-msgid "Participaciones permanentes en sociedades"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_minority_interest
-msgid "Participación de terceros en sociedades controladas"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -1122,19 +1123,14 @@ msgid "Partner Ledger Custom Handler"
 msgstr "Gestor personalizado del libro mayor del contacto"
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_pasivo
-msgid "Pasivo"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_equity
-msgid "Patrimonio neto"
-msgstr ""
-
-#. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_account_return_type__payment_partner_id
 msgid "Payment Partner"
 msgstr "Contacto del Pago"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_payroll_liabilities
+msgid "Payroll Liabilities"
+msgstr "Remuneraciones y cargas sociales"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_account_return_type__deadline_periodicity
@@ -1148,19 +1144,21 @@ msgid "Please specify the start and end date range"
 msgstr "Por favor indique el rango de fecha de inicio y fin"
 
 #. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid "Por favor indique el rango de fecha de inicio y fin"
+msgstr "Ajuste por inflación %s"
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
+msgid "Post-dated Checks"
+msgstr "Cheques a fecha"
+
+#. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_provisions
-msgid "Previsiones"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_long_term_provisions
-msgid "Previsiones no corrientes"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_loans_payable
-msgid "Préstamos"
-msgstr ""
+msgid "Provisions"
+msgstr "Previsiones"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_sifere_report_sifere_perceptions_line
@@ -1184,49 +1182,24 @@ msgid "Purchase Withholdings"
 msgstr "Retenciones de Compra"
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_payroll_liabilities
-msgid "Remuneraciones y cargas sociales"
-msgstr ""
+#: model:account.report,settlement_title:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados
+msgid "Refunding Entry"
+msgstr "Asiento de refundición"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_equity_reserves
-msgid "Reservas"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_net_inc
-msgid "Resultado Final del ejercicio"
-msgstr ""
+msgid "Reserves"
+msgstr "Reservas"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_inc_before_tax
-msgid "Resultado antes del impuesto a las ganancias"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_ar_curr_year_earnings
-msgid "Resultado del Ejercicio"
-msgstr ""
+msgid "Result Before Income Tax"
+msgstr "Resultado antes del impuesto a las ganancias"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_equity_results
-msgid "Resultados"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_equity_results_detail
-msgid "Resultados Acumulados"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_fin_exp
-msgid "Resultados financieros y por tenencia (incluye RECPAM)"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_ar_prev_year_earnings
-msgid "Resultados sin asignar de años anteriores"
-msgstr ""
+msgid "Results"
+msgstr "Resultados"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model,name:l10n_ar_account_reports.model_account_return_creation_wizard
@@ -1237,16 +1210,22 @@ msgstr "Asistente de creación de Declaración"
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/account_return.py:0
 msgid ""
-"Review and process third-party checks with deferred payment dates "
-"pending at period close."
-msgstr ""
+"Review and process third-party checks with deferred payment dates pending at"
+" period close."
+msgstr "Revisar y procesar los cheques de terceros con fecha de pago diferida pendientes al cierre del período."
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
+msgid ""
 "Revisar y procesar los cheques de terceros con fecha de pago diferida "
 "pendientes al cierre del período."
+msgstr "Asiento de ajuste por inflación"
 
 #. module: l10n_ar_account_reports
 #: model:account.return.type,name:l10n_ar_account_reports.sicore_return_type
-msgid "SICORE Ganancias (Agente)"
-msgstr ""
+msgid "SICORE Income Tax (Agent)"
+msgstr "SICORE Ganancias (Agente)"
 
 #. module: l10n_ar_account_reports
 #: model:account.report,name:l10n_ar_account_reports.l10n_ar_sicore_report
@@ -1292,18 +1271,14 @@ msgid "Search Description"
 msgstr "Buscar Descripción"
 
 #. module: l10n_ar_account_reports
-#: model:ir.model.fields.selection,name:l10n_ar_account_reports.selection__inflation_adjustment__open_cloure_entry__yes
-msgid "Yes"
-msgstr "Sí"
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_com_exp
+msgid "Selling Expenses"
+msgstr "Gastos de comercialización"
 
 #. module: l10n_ar_account_reports
-#: model:ir.model.fields,help:l10n_ar_account_reports.field_inflation_adjustment__open_cloure_entry
-msgid ""
-"If you have made the closing/opening entries, please indicate them so they "
-"can be excluded from the calculation."
-msgstr ""
-"Si usted ha realizado los asientos de cierre/apertura debe indicarnos cuales "
-"son para poder excluir los mismos en el cálculo."
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_temp_investments
+msgid "Short-term Investments"
+msgstr "Inversiones temporarias"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
@@ -1312,14 +1287,43 @@ msgid "Sicore Profits Withholdings TXT"
 msgstr "TXT SICORE Retenciones Ganancias"
 
 #. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/tucuman_report.py:0
+msgid ""
+"Some corrective documents do not contain information about which original document they are reversing:\n"
+" %s"
+msgstr "Algunos comprobantes rectificativos no contienen información de que comprobante original están revirtiendo:\\n %s"
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/tucuman_report.py:0
+msgid ""
+"Some documents do not contain information about the street/city/province/postal code of the contact:\n"
+" %s"
+msgstr "Algunos comprobantes no contienen información acerca de la calle/ciudad/provincia/cod postal del contacto:\\n %s"
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/tucuman_report.py:0
+msgid ""
+"Some documents have a 5-digit point of sale but must have a 4-digit one to generate the Tucuman withholdings and perceptions TXT file:\n"
+" %s"
+msgstr "Algunos comprobantes tienen punto de venta de 5 dígitos y deben tener de 4 dígitos para poder generar el archivo txt de retenciones y percepciones de Tucuman:\\n %s"
+
+#. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__start_index
 msgid "Start Index"
 msgstr "Índice Inicio"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_subtotal_noncurrent_assets
-msgid "Subtotal del activo no corriente"
-msgstr ""
+msgid "Subtotal Non-current Assets"
+msgstr "Subtotal del activo no corriente"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_tax_liabilities
+msgid "Tax Liabilities"
+msgstr "Cargas fiscales"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
@@ -1335,18 +1339,37 @@ msgstr "Impuesto a pagar"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+msgid ""
+"The VAT responsibility \"%s\" is not supported for AGIP "
+"withholding/perception"
+msgstr "La responsabilidad frente a IVA \\\"%s\\\" no está soportada para ret/perc AGIP"
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
+msgid ""
+"The VAT responsibility \"%s\" is not supported for Santa Fe "
+"withholding/perception"
+msgstr "La responsabilidad frente a IVA \\\"%s\\\" no está soportada para ret/perc Santa Fe"
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+msgid ""
+"The contact \"%(partner_name)s\" (id %(partner_id)s) must have the "
+"identification type CUIT, CUIL, or CDI."
+msgstr "El contacto \\\"%(partner_name)s\\\" (id %(partner_id)s), debe tener el tipo de identificación CUIT, CUIL, CDI."
+
+#. module: l10n_ar_account_reports
+#. odoo-python
 #: code:addons/l10n_ar_account_reports/models/account_move.py:0
 msgid ""
 "The following document(s) have an invalid document number format.\n"
 "ARCA requires the format XXXXX-XXXXXXXX (e.g.: 00001-00000001).\n"
 "Please correct them before generating the file:\n"
 "%s"
-msgstr ""
-"Los siguientes comprobantes tienen un número de documento con formato "
-"inválido.\n"
-"ARCA requiere el formato XXXXX-XXXXXXXX (ej: 00001-00000001).\n"
-"Por favor corrija los siguientes comprobantes antes de generar el archivo:\n"
-"%s"
+msgstr "Los siguientes comprobantes tienen un número de documento con formato inválido.\\nARCA requiere el formato XXXXX-XXXXXXXX (ej: 00001-00000001).\\nPor favor corrija los siguientes comprobantes antes de generar el archivo:\\n%s"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
@@ -1354,9 +1377,29 @@ msgstr ""
 msgid ""
 "The identification type \"%(identification_type)s\" does not have ARCA code "
 "set."
-msgstr ""
-"El tipo de identificación «%(identification_type)s» no tiene asignado ningún "
-"código ARCA."
+msgstr "El tipo de identificación «%(identification_type)s» no tiene asignado ningún código ARCA."
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/inflation_adjustment_index.py:0
+msgid "The index must start on the first day of each month"
+msgstr "El índice debe comenzar el primer día de cada mes"
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid ""
+"The inflation adjustment entry cannot be generated because the adjustment "
+"index for period %(month)s %(year)s is missing"
+msgstr "El asiento de ajuste por inflación no puede ser generado ya que hace falta el indice de ajuste para el periodo %(month)s %(year)s"
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+msgid ""
+"The partner \"%(partner_name)s\" (id %(partner_id)s) does not have an "
+"identification number set"
+msgstr "El partner \\\"%(partner_name)s\\\" (id %(partner_id)s) no tiene número de identificación establecido"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
@@ -1364,25 +1407,130 @@ msgstr ""
 msgid ""
 "The partner \"%(partner_name)s\" (id %(partner_id)s) does not have the vat "
 "set."
-msgstr ""
-"El socio «%(partner_name)s» (id %(partner_id)s) no tiene configurado el IVA."
+msgstr "El socio «%(partner_name)s» (id %(partner_id)s) no tiene configurado el IVA."
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/account_return.py:0
 msgid "The partner '%s' has no %s account configured for company '%s'."
-msgstr ""
-"El socio «%s» no tiene ninguna cuenta %s configurada para la empresa «%s»."
+msgstr "El socio «%s» no tiene ninguna cuenta %s configurada para la empresa «%s»."
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sifere_report.py:0
+msgid ""
+"The perception %s (id: %d) of the document \"%s\" (id: %d) has no associated"
+" contact."
+msgstr "La percepción %s (id: %d) del comprobante \\\"%s\\\" (id: %d) no tiene contacto asociado."
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/l10n_ar_vat_ret_perc_sufrido.py:0
+msgid ""
+"The regime code must have 3 digits in the configuration of tax "
+"\"%(tax_name)s\""
+msgstr "El código de régimen tiene que tener 3 dígitos en la configuración del impuesto \\\"%(tax_name)s\\\""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/account_return.py:0
 msgid ""
-"The return type '%s' has no payment partner configured. Please set a Payment "
-"Partner on the return type."
-msgstr ""
-"El tipo de devolución «%s» no tiene ningún socio de pago configurado. "
-"Configure un socio de pago para el tipo de devolución."
+"The return type '%s' has no payment partner configured. Please set a Payment"
+" Partner on the return type."
+msgstr "El tipo de devolución «%s» no tiene ningún socio de pago configurado. Configure un socio de pago para el tipo de devolución."
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+msgid "The tax is not associated"
+msgstr "El impuesto no está asociado"
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
+msgid ""
+"There is no jurisdiction set in the tax \"%(tax_name)s\" or it does not have"
+" a jurisdiction code."
+msgstr "No hay jurisdicción establecida en el impuesto \\\"%(tax_name)s\\\" o no tiene código de jurisdicción."
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
+msgid ""
+"There is no perception regime (ARCA Code 'l10n_ar_code') configured for tax:"
+" '%(tax_name)s'."
+msgstr "No hay régimen de percepción (ARCA Code 'l10n_ar_code') configurado para el impuesto: '%(tax_name)s'."
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/l10n_ar_vat_ret_perc_sufrido.py:0
+msgid "There is no regime code in the configuration of tax \"%(tax_name)s\""
+msgstr "No hay código de régimen en la configuración del impuesto \\\"%(tax_name)s\\\""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
+msgid ""
+"There is no withholding regime (ARCA Code 'l10n_ar_code') configured for tax"
+" '%(tax_name)s' of partner '%(partner_name)s'"
+msgstr "No hay regimen de retencion (ARCA Code 'l10n_ar_code') configurado para el impuesto '%(tax_name)s' del partner '%(partner_name)s'"
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
+msgid "Tipo de comprobante no reconocido"
+msgstr "No hay jurisdicción establecida en el impuesto \\\"%(tax_name)s\\\" o no tiene código de jurisdicción."
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
+msgid "Tipo de impuesto %s equivocado"
+msgstr "Debe establecer el tipo de inscripción de IIBB del partner \\\"%(partner_name)s\\\" (id: %(partner_id)s)"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_assets
+msgid "Total Assets"
+msgstr "Total del activo"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_current_assets
+msgid "Total Current Assets"
+msgstr "Total del activo corriente"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_current_liabilities
+msgid "Total Current Liabilities"
+msgstr "Total pasivo corriente"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_debts
+msgid "Total Debts"
+msgstr "Total deudas"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_liabilities_combined
+msgid "Total Liabilities"
+msgstr "Total del pasivo"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_liabilities_equity
+msgid "Total Liabilities, Minority Interest and Net Equity"
+msgstr "Total del pasivo, participación de terceros y patrimonio neto"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_noncurrent_assets
+msgid "Total Non-current Assets"
+msgstr "Total del activo no corriente"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_noncurrent_liabilities
+msgid "Total Non-current Liabilities"
+msgstr "Total pasivo no corriente"
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_ar_prev_year_earnings
+msgid "Unallocated Earnings from Previous Years"
+msgstr "Resultados sin asignar de años anteriores"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
@@ -1391,70 +1539,52 @@ msgid "Unrecognized document type"
 msgstr "Tipo de comprobante no reconocido"
 
 #. module: l10n_ar_account_reports
+#: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment_index__value
+msgid "Value"
+msgstr ""
+
+#. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
 msgid "Wrong tax type %s"
 msgstr "Tipo de impuesto %s equivocado"
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_assets
-msgid "Total del activo"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_current_assets
-msgid "Total del activo corriente"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_noncurrent_assets
-msgid "Total del activo no corriente"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_liabilities_combined
-msgid "Total del pasivo"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_liabilities_equity
-msgid "Total del pasivo, participación de terceros y patrimonio neto"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_debts
-msgid "Total deudas"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_current_liabilities
-msgid "Total pasivo corriente"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_noncurrent_liabilities
-msgid "Total pasivo no corriente"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment_index__value
-msgid "Value"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_sales
-msgid "Ventas netas de bienes y servicios"
-msgstr ""
-
-#. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/inflation_adjustment_index.py:0
 msgid ""
-"An index already exists for period %s %s. You can only have one inflation "
-"index per month"
-msgstr ""
 "Ya existe un índice para el periodo %s %s. Solo puedes tener un índice de "
 "inflación por mes"
+msgstr "El índice debe comenzar el primer día de cada mes"
+
+#. module: l10n_ar_account_reports
+#: model:ir.model.fields.selection,name:l10n_ar_account_reports.selection__inflation_adjustment__open_cloure_entry__yes
+msgid "Yes"
+msgstr "Sí"
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
+msgid ""
+"You must set the \"article/section\" information in the configuration of tax"
+" \"%(tax_name)s\" in the \"API\" tab."
+msgstr "Debe establecer la información de \\\"artículo/inciso\\\" en la configuración del impuesto \\\"%(tax_name)s\\\" en la solapa \\\"API\\\"."
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+msgid ""
+"You must set the IIBB registration type for contact \"%(partner_name)s\" "
+"(id: %(partner_id)s)"
+msgstr "Debe setear el tipo de inscripción de IIBB del contacto \\\"%(partner_name)s\\\" (id: %(partner_id)s)"
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
+msgid ""
+"You must set the IIBB registration type for partner \"%(partner_name)s\" "
+"(id: %(partner_id)s)"
+msgstr "Debe establecer el tipo de inscripción de IIBB del partner \\\"%(partner_name)s\\\" (id: %(partner_id)s)"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
@@ -1467,15 +1597,3 @@ msgstr "pagable"
 #: code:addons/l10n_ar_account_reports/models/account_return.py:0
 msgid "receivable"
 msgstr "por cobrar"
-
-#, fuzzy
-#~ msgid "AR ESP: Patrimonio Neto"
-#~ msgstr "AR ESP: Patrimonio Neto"
-
-#, fuzzy
-#~| msgid "Partner Ledger Custom Handler"
-#~ msgid "Argentinian Tax Report Custom Handler"
-#~ msgstr "Gestor personalizado del libro mayor del contacto"
-
-#~ msgid "or"
-#~ msgstr "o"

--- a/l10n_ar_account_reports/i18n/es.po
+++ b/l10n_ar_account_reports/i18n/es.po
@@ -323,12 +323,12 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #: model:ir.model,name:l10n_ar_account_reports.model_account_return
 msgid "Accounting Return"
-msgstr "Declaración contable"
+msgstr "Declaración de impuestos"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model,name:l10n_ar_account_reports.model_account_return_type
 msgid "Accounting Return Type"
-msgstr "Tipo de Declaración contable"
+msgstr "Tipo de declaración de impuestos"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_activo
@@ -345,47 +345,45 @@ msgstr "Activos intangibles"
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
-msgid "Ajuste por inflación %s"
-msgstr ""
+msgid "Inflation Adjustment %s"
+msgstr "Ajuste por inflación %s"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
-msgid "Ajuste por inflación %s (%s * %.2f%%)"
-msgstr ""
+msgid "Inflation adjustment %s (%s * %.2f%%)"
+msgstr "Ajuste por inflación %s (%s * %.2f%%)"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
-msgid "Ajuste por inflación Global [%s] / [%s]"
-msgstr ""
+msgid "Global Inflation Adjustment [%s] / [%s]"
+msgstr "Ajuste por inflación Global [%s] / [%s]"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
-msgid "Ajuste por inflación cuentas al inicio (%s * %.2f%%)"
-msgstr ""
+msgid "Inflation adjustment opening balances (%s * %.2f%%)"
+msgstr "Ajuste por inflación cuentas al inicio (%s * %.2f%%)"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/tucuman_report.py:0
-#, fuzzy
 msgid ""
+"Some documents do not contain information about the street/city/province/"
+"postal code of the contact:\n"
+" %s"
+msgstr ""
 "Algunos comprobantes no contienen información acerca de la calle/ciudad/"
 "provincia/cod postal del contacto:\n"
 " %s"
-msgstr ""
-"Algunos comprobantes no contienen información acerca de la calle/ciudad/"
-"provincia/cod postal del contacto:\n"
-" %s"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/tucuman_report.py:0
-#, fuzzy
 msgid ""
-"Algunos comprobantes rectificativos no contienen información de que "
-"comprobante original están revirtiendo:\n"
+"Some corrective documents do not contain information about which original "
+"document they are reversing:\n"
 " %s"
 msgstr ""
 "Algunos comprobantes rectificativos no contienen información de que "
@@ -395,11 +393,9 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/tucuman_report.py:0
-#, fuzzy
 msgid ""
-"Algunos comprobantes tienen punto de venta de 5 dígitos y deben tener de 4 "
-"dígitos para poder generar el archivo txt de retenciones y percepciones de "
-"Tucuman:\n"
+"Some documents have a 5-digit point of sale but must have a 4-digit one to "
+"generate the Tucuman withholdings and perceptions TXT file:\n"
 " %s"
 msgstr ""
 "Algunos comprobantes tienen punto de venta de 5 dígitos y deben tener de 4 "
@@ -461,22 +457,26 @@ msgid "Argentinian Tucumán Report Custom Handler"
 msgstr "Gestor personalizado de informes Argentinos Tucumán"
 
 #. module: l10n_ar_account_reports
-#. odoo-python
-#: code:addons/l10n_ar_account_reports/models/account_return.py:0
 #: model:ir.actions.act_window,name:l10n_ar_account_reports.inflation_adjustment_action
 #: model:ir.ui.menu,name:l10n_ar_account_reports.inflation_adjustment_menu
 msgid "Asiento de ajuste por inflación"
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
+msgid "Inflation Adjustment Entry"
+msgstr "Asiento de ajuste por inflación"
+
+#. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__open_move_id
-msgid "Asiento de apertura"
-msgstr ""
+msgid "Opening Entry"
+msgstr "Asiento de apertura"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__closure_move_id
-msgid "Asiento de cierre"
-msgstr ""
+msgid "Closing Entry"
+msgstr "Asiento de cierre"
 
 #. module: l10n_ar_account_reports
 #: model:account.report,settlement_title:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados
@@ -546,8 +546,8 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/account_return.py:0
-msgid "Cheques a fecha"
-msgstr ""
+msgid "Post-dated Checks"
+msgstr "Cheques a fecha"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__company_id
@@ -605,25 +605,31 @@ msgstr "Fecha Hasta"
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
 msgid ""
-"Debe establecer el tipo de inscripción de IIBB del partner "
+"You must set the IIBB registration type for partner "
 "\"%(partner_name)s\" (id: %(partner_id)s)"
 msgstr ""
+"Debe establecer el tipo de inscripción de IIBB del partner "
+"\"%(partner_name)s\" (id: %(partner_id)s)"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
 msgid ""
-"Debe establecer la información de \"artículo/inciso\" en la configuración "
-"del impuesto \"%(tax_name)s\"en la solapa \"API\"."
+"You must set the \"article/section\" information in the configuration of tax "
+"\"%(tax_name)s\" in the \"API\" tab."
 msgstr ""
+"Debe establecer la información de \"artículo/inciso\" en la configuración "
+"del impuesto \"%(tax_name)s\" en la solapa \"API\"."
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
 msgid ""
-"Debe setear el tipo de inscripción de IIBB del contacto "
+"You must set the IIBB registration type for contact "
 "\"%(partner_name)s\" (id: %(partner_id)s)"
 msgstr ""
+"Debe setear el tipo de inscripción de IIBB del contacto "
+"\"%(partner_name)s\" (id: %(partner_id)s)"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_account_return_type__default_deadline_periodicity
@@ -680,58 +686,66 @@ msgstr ""
 #: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
 #: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
 msgid "Edit tax"
-msgstr ""
+msgstr "Editar impuesto"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
 #: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
-msgid "Editar contacto"
-msgstr ""
+msgid "Edit contact"
+msgstr "Editar contacto"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
 msgid ""
+"The inflation adjustment entry cannot be generated because the adjustment "
+"index for period %(month)s %(year)s is missing"
+msgstr ""
 "El asiento de ajuste por inflación no puede ser generado ya que hace falta "
 "el indice de ajuste para el periodo %(month)s %(year)s"
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
 msgid ""
+"The contact \"%(partner_name)s\" (id %(partner_id)s) must have the "
+"identification type CUIT, CUIL, or CDI."
+msgstr ""
 "El contacto \"%(partner_name)s\" (id %(partner_id)s), debe tener el tipo de "
 "identificación CUIT, CUIL, CDI."
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/l10n_ar_vat_ret_perc_sufrido.py:0
 msgid ""
+"The regime code must have 3 digits in the configuration of tax "
+"\"%(tax_name)s\""
+msgstr ""
 "El código de régimen tiene que tener 3 dígitos en la configuración del "
 "impuesto \"%(tax_name)s\""
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
-msgid "El impuesto no está asociado"
-msgstr ""
+msgid "The tax is not associated"
+msgstr "El impuesto no está asociado"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
 msgid ""
+"The partner \"%(partner_name)s\" (id %(partner_id)s) does not have an "
+"identification number set"
+msgstr ""
 "El partner \"%(partner_name)s\" (id %(partner_id)s) no tiene número de "
 "identificación establecido"
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/inflation_adjustment_index.py:0
-msgid "El índice debe comenzar el primer día de cada mes"
-msgstr ""
+msgid "The index must start on the first day of each month"
+msgstr "El índice debe comenzar el primer día de cada mes"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__end_index
@@ -788,13 +802,13 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/account_return.py:0
-msgid "Generar el asiento de ajuste por inflación para el período fiscal."
-msgstr ""
+msgid "Generate the inflation adjustment journal entry for the fiscal period."
+msgstr "Generar el asiento de ajuste por inflación para el período fiscal."
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__open_cloure_entry
-msgid "Ha realizado asientos de cierre/apertura?"
-msgstr ""
+msgid "Has Closing/Opening Entries?"
+msgstr "¿Ha realizado asientos de cierre/apertura?"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_account_chart_template__id
@@ -928,24 +942,29 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/sifere_report.py:0
 msgid ""
+"The perception %s (id: %d) of the document \"%s\" (id: %d) has no associated "
+"contact."
+msgstr ""
 "La percepción %s (id: %d) del comprobante \"%s\" (id: %d) no tiene contacto "
 "asociado."
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
 msgid ""
-"La responsabilidad frente a IVA \"%s\" no está soportada para ret/perc AGIP"
+"The VAT responsibility \"%s\" is not supported for AGIP withholding/perception"
 msgstr ""
+"La responsabilidad frente a IVA \"%s\" no está soportada para ret/perc AGIP"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
 msgid ""
+"The VAT responsibility \"%s\" is not supported for Santa Fe "
+"withholding/perception"
+msgstr ""
 "La responsabilidad frente a IVA \"%s\" no está soportada para ret/perc Santa "
 "Fe"
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__write_uid
@@ -973,32 +992,39 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/l10n_ar_vat_ret_perc_sufrido.py:0
 msgid ""
-"No hay código de régimen en la configuración del impuesto \"%(tax_name)s\""
+"There is no regime code in the configuration of tax \"%(tax_name)s\""
 msgstr ""
+"No hay código de régimen en la configuración del impuesto \"%(tax_name)s\""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
 msgid ""
+"There is no jurisdiction set in the tax \"%(tax_name)s\" or it does not have "
+"a jurisdiction code."
+msgstr ""
 "No hay jurisdicción establecida en el impuesto \"%(tax_name)s\" o no tiene "
 "código de jurisdicción."
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
 msgid ""
+"There is no withholding regime (ARCA Code 'l10n_ar_code') configured for tax "
+"'%(tax_name)s' of partner '%(partner_name)s'"
+msgstr ""
 "No hay regimen de retencion (ARCA Code 'l10n_ar_code') configurado para el "
 "impuesto '%(tax_name)s' del partner '%(partner_name)s'"
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
 msgid ""
+"There is no perception regime (ARCA Code 'l10n_ar_code') configured for tax: "
+"'%(tax_name)s'."
+msgstr ""
 "No hay régimen de percepción (ARCA Code 'l10n_ar_code') configurado para el "
 "impuesto: '%(tax_name)s'."
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model_terms:ir.actions.act_window,help:l10n_ar_account_reports.inflation_adjustment_index_action
@@ -1009,26 +1035,31 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
 msgid ""
+"No journal entries to adjust were found for the selected period."
+msgstr ""
 "No hemos encontrado ningún asiento contable para ajustar asociado al periodo "
 "seleccionado."
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
 msgid ""
+"Could not find the original document for %s (id %s). Please verify that in "
+"the credit note \"%s\", the origin field contains the original invoice number"
+msgstr ""
 "No pudimos encontrar el comprobante original para %s (id %s). Verifique que "
 "en la nota de crédito \"%s\", el campo origen es el número de la factura "
 "original"
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
 msgid ""
+"No inflation adjustment index was found for the previous date (%s). "
+"Please configure the corresponding index."
+msgstr ""
 "No se encontró un índice de ajuste por inflación para la fecha anterior "
 "(%s). Por favor, configure el índice correspondiente."
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_liabilities
@@ -1113,8 +1144,8 @@ msgstr "Periodicidad"
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
-msgid "Por favor indique el rango de fecha de inicio y fin"
-msgstr ""
+msgid "Please specify the start and end date range"
+msgstr "Por favor indique el rango de fecha de inicio y fin"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_provisions
@@ -1206,9 +1237,11 @@ msgstr "Asistente de creación de Declaración"
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/account_return.py:0
 msgid ""
+"Review and process third-party checks with deferred payment dates "
+"pending at period close."
+msgstr ""
 "Revisar y procesar los cheques de terceros con fecha de pago diferida "
 "pendientes al cierre del período."
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.return.type,name:l10n_ar_account_reports.sicore_return_type
@@ -1260,15 +1293,17 @@ msgstr "Buscar Descripción"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields.selection,name:l10n_ar_account_reports.selection__inflation_adjustment__open_cloure_entry__yes
-msgid "Si"
-msgstr ""
+msgid "Yes"
+msgstr "Sí"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,help:l10n_ar_account_reports.field_inflation_adjustment__open_cloure_entry
 msgid ""
+"If you have made the closing/opening entries, please indicate them so they "
+"can be excluded from the calculation."
+msgstr ""
 "Si usted ha realizado los asientos de cierre/apertura debe indicarnos cuales "
 "son para poder excluir los mismos en el cálculo."
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
@@ -1352,14 +1387,14 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
-msgid "Tipo de comprobante no reconocido"
-msgstr ""
+msgid "Unrecognized document type"
+msgstr "Tipo de comprobante no reconocido"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
-msgid "Tipo de impuesto %s equivocado"
-msgstr ""
+msgid "Wrong tax type %s"
+msgstr "Tipo de impuesto %s equivocado"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_assets
@@ -1415,9 +1450,11 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/inflation_adjustment_index.py:0
 msgid ""
+"An index already exists for period %s %s. You can only have one inflation "
+"index per month"
+msgstr ""
 "Ya existe un índice para el periodo %s %s. Solo puedes tener un índice de "
 "inflación por mes"
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python

--- a/l10n_ar_account_reports/i18n/l10n_ar_account_reports.pot
+++ b/l10n_ar_account_reports/i18n/l10n_ar_account_reports.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-15 18:57+0000\n"
-"PO-Revision-Date: 2026-05-15 18:57+0000\n"
+"POT-Creation-Date: 2026-05-28 11:55+0000\n"
+"PO-Revision-Date: 2026-05-28 11:55+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -334,6 +334,14 @@ msgid ""
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/inflation_adjustment_index.py:0
+msgid ""
+"An index already exists for period %s %s. You can only have one inflation "
+"index per month"
+msgstr ""
+
+#. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_advances_from_customers
 msgid "Anticipos de clientes"
 msgstr ""
@@ -389,16 +397,6 @@ msgstr ""
 #: model:ir.actions.act_window,name:l10n_ar_account_reports.inflation_adjustment_action
 #: model:ir.ui.menu,name:l10n_ar_account_reports.inflation_adjustment_menu
 msgid "Asiento de ajuste por inflación"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__open_move_id
-msgid "Asiento de apertura"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__closure_move_id
-msgid "Asiento de cierre"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -471,6 +469,11 @@ msgid "Cheques a fecha"
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__closure_move_id
+msgid "Closing Entry"
+msgstr ""
+
+#. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__company_id
 msgid "Company"
 msgstr ""
@@ -483,6 +486,15 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_cogs
 msgid "Costo de venta de bienes y servicios"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+msgid ""
+"Could not find the original document for %s (id %s). Please verify that in "
+"the credit note \"%s\", the origin field contains the original invoice "
+"number"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -593,6 +605,13 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_dividends_payable
 msgid "Dividendos a pagar"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+#: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
+msgid "Edit contact"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -713,8 +732,20 @@ msgid "Generar el asiento de ajuste por inflación para el período fiscal."
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
+msgid "Generate the inflation adjustment journal entry for the fiscal period."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid "Global Inflation Adjustment [%s] / [%s]"
+msgstr ""
+
+#. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__open_cloure_entry
-msgid "Ha realizado asientos de cierre/apertura?"
+msgid "Has Closing/Opening Entries?"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -795,6 +826,13 @@ msgid ""
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#: model:ir.model.fields,help:l10n_ar_account_reports.field_inflation_adjustment__open_cloure_entry
+msgid ""
+"If you have made the closing/opening entries, please indicate them so they "
+"can be excluded from the calculation."
+msgstr ""
+
+#. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_tax_inc
 msgid "Impuesto a las ganancias"
 msgstr ""
@@ -811,6 +849,18 @@ msgid "Inflation Adjustment"
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid "Inflation Adjustment %s"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
+msgid "Inflation Adjustment Entry"
+msgstr ""
+
+#. module: l10n_ar_account_reports
 #: model:ir.model,name:l10n_ar_account_reports.model_inflation_adjustment_index
 msgid "Inflation Adjustment Index"
 msgstr ""
@@ -818,6 +868,18 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #: model:ir.model,name:l10n_ar_account_reports.model_inflation_adjustment
 msgid "Inflation adjustment"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid "Inflation adjustment %s (%s * %.2f%%)"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid "Inflation adjustment opening balances (%s * %.2f%%)"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -930,6 +992,20 @@ msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid ""
+"No inflation adjustment index was found for the previous date (%s). Please "
+"configure the corresponding index."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid "No journal entries to adjust were found for the selected period."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
 msgid ""
 "No pudimos encontrar el comprobante original para %s (id %s). Verifique que "
@@ -943,6 +1019,11 @@ msgstr ""
 msgid ""
 "No se encontró un índice de ajuste por inflación para la fecha anterior "
 "(%s). Por favor, configure el índice correspondiente."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__open_move_id
+msgid "Opening Entry"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -1028,7 +1109,19 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid "Please specify the start and end date range"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
 msgid "Por favor indique el rango de fecha de inicio y fin"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
+msgid "Post-dated Checks"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -1121,6 +1214,14 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/account_return.py:0
 msgid ""
+"Review and process third-party checks with deferred payment dates pending at"
+" period close."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
+msgid ""
 "Revisar y procesar los cheques de terceros con fecha de pago diferida "
 "pendientes al cierre del período."
 msgstr ""
@@ -1174,21 +1275,33 @@ msgid "Search Description"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:ir.model.fields.selection,name:l10n_ar_account_reports.selection__inflation_adjustment__open_cloure_entry__yes
-msgid "Si"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:ir.model.fields,help:l10n_ar_account_reports.field_inflation_adjustment__open_cloure_entry
-msgid ""
-"Si usted ha realizado los asientos de cierre/apertura debe indicarnos cuales"
-" son para poder excluir los mismos en el cálculo."
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sicore_report.py:0
+msgid "Sicore Profits Withholdings TXT"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
-#: code:addons/l10n_ar_account_reports/models/sicore_report.py:0
-msgid "Sicore Profits Withholdings TXT"
+#: code:addons/l10n_ar_account_reports/models/tucuman_report.py:0
+msgid ""
+"Some corrective documents do not contain information about which original document they are reversing:\n"
+" %s"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/tucuman_report.py:0
+msgid ""
+"Some documents do not contain information about the street/city/province/postal code of the contact:\n"
+" %s"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/tucuman_report.py:0
+msgid ""
+"Some documents have a 5-digit point of sale but must have a 4-digit one to generate the Tucuman withholdings and perceptions TXT file:\n"
+" %s"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -1215,6 +1328,30 @@ msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+msgid ""
+"The VAT responsibility \"%s\" is not supported for AGIP "
+"withholding/perception"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
+msgid ""
+"The VAT responsibility \"%s\" is not supported for Santa Fe "
+"withholding/perception"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+msgid ""
+"The contact \"%(partner_name)s\" (id %(partner_id)s) must have the "
+"identification type CUIT, CUIL, or CDI."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
 #: code:addons/l10n_ar_account_reports/models/account_move.py:0
 msgid ""
 "The following document(s) have an invalid document number format.\n"
@@ -1233,6 +1370,28 @@ msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
+#: code:addons/l10n_ar_account_reports/models/inflation_adjustment_index.py:0
+msgid "The index must start on the first day of each month"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid ""
+"The inflation adjustment entry cannot be generated because the adjustment "
+"index for period %(month)s %(year)s is missing"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+msgid ""
+"The partner \"%(partner_name)s\" (id %(partner_id)s) does not have an "
+"identification number set"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
 #: code:addons/l10n_ar_account_reports/models/sicore_report.py:0
 msgid ""
 "The partner \"%(partner_name)s\" (id %(partner_id)s) does not have the vat "
@@ -1247,10 +1406,62 @@ msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sifere_report.py:0
+msgid ""
+"The perception %s (id: %d) of the document \"%s\" (id: %d) has no associated"
+" contact."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/l10n_ar_vat_ret_perc_sufrido.py:0
+msgid ""
+"The regime code must have 3 digits in the configuration of tax "
+"\"%(tax_name)s\""
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
 #: code:addons/l10n_ar_account_reports/models/account_return.py:0
 msgid ""
 "The return type '%s' has no payment partner configured. Please set a Payment"
 " Partner on the return type."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+msgid "The tax is not associated"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
+msgid ""
+"There is no jurisdiction set in the tax \"%(tax_name)s\" or it does not have"
+" a jurisdiction code."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
+msgid ""
+"There is no perception regime (ARCA Code 'l10n_ar_code') configured for tax:"
+" '%(tax_name)s'."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/l10n_ar_vat_ret_perc_sufrido.py:0
+msgid "There is no regime code in the configuration of tax \"%(tax_name)s\""
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
+msgid ""
+"There is no withholding regime (ARCA Code 'l10n_ar_code') configured for tax"
+" '%(tax_name)s' of partner '%(partner_name)s'"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -1306,6 +1517,12 @@ msgid "Total pasivo no corriente"
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
+msgid "Unrecognized document type"
+msgstr ""
+
+#. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment_index__value
 msgid "Value"
 msgstr ""
@@ -1317,10 +1534,45 @@ msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
+#: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
+msgid "Wrong tax type %s"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
 #: code:addons/l10n_ar_account_reports/models/inflation_adjustment_index.py:0
 msgid ""
 "Ya existe un índice para el periodo %s %s. Solo puedes tener un índice de "
 "inflación por mes"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:ir.model.fields.selection,name:l10n_ar_account_reports.selection__inflation_adjustment__open_cloure_entry__yes
+msgid "Yes"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
+msgid ""
+"You must set the \"article/section\" information in the configuration of tax"
+" \"%(tax_name)s\" in the \"API\" tab."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+msgid ""
+"You must set the IIBB registration type for contact \"%(partner_name)s\" "
+"(id: %(partner_id)s)"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
+msgid ""
+"You must set the IIBB registration type for partner \"%(partner_name)s\" "
+"(id: %(partner_id)s)"
 msgstr ""
 
 #. module: l10n_ar_account_reports

--- a/l10n_ar_account_reports/i18n/l10n_ar_account_reports.pot
+++ b/l10n_ar_account_reports/i18n/l10n_ar_account_reports.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-28 11:55+0000\n"
-"PO-Revision-Date: 2026-05-28 11:55+0000\n"
+"POT-Creation-Date: 2026-05-28 17:51+0000\n"
+"PO-Revision-Date: 2026-05-28 17:51+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -17,27 +17,27 @@ msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_iva_report_debito_fiscal
-msgid "(+) Débito Fiscal (Ventas)"
+msgid "(+) Fiscal Debit (Sales)"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_iva_report_credito_fiscal
-msgid "(-) Crédito Fiscal (Compras)"
+msgid "(-) Input VAT (Purchases)"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_iva_report_iva_perceptions_line
-msgid "(-) Percepciones Sufridas"
+msgid "(-) Suffered Perceptions"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_iva_report_iva_withholdings_line
-msgid "(-) Retenciones Sufridas"
+msgid "(-) Suffered Withholdings"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_iva_report_saldo_tecnico
-msgid "(=) Saldo Técnico (1er Párrafo)"
+msgid "(=) Technical Balance (1st Paragraph)"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -54,73 +54,53 @@ msgid "AR Closing Account"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_costo_ventas
-msgid "AR EERR: Costo de Ventas"
-msgstr ""
-
-#. module: l10n_ar_account_reports
 #: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_gastos_administracion
-msgid "AR EERR: Gastos de Administración"
+msgid "AR EERR: Administrative Expenses"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_gastos_comercializacion
-msgid "AR EERR: Gastos de Comercialización"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_impuesto_ganancias
-msgid "AR EERR: Impuesto a las ganancias"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_otros_gastos
-msgid "AR EERR: Otros Gastos"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_otros_ingresos_egresos
-msgid "AR EERR: Otros ingresos y egresos"
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_costo_ventas
+msgid "AR EERR: Cost of Sales"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_rxt_resultados_financieros
-msgid "AR EERR: RxT y Resultados Financieros"
+msgid "AR EERR: Financial Results and Holding Gains/Losses"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_impuesto_ganancias
+msgid "AR EERR: Income Tax"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_otros_gastos
+msgid "AR EERR: Other Expenses"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_otros_ingresos_egresos
+msgid "AR EERR: Other Income and Expenses"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_ventas
-msgid "AR EERR: Ventas"
+msgid "AR EERR: Sales"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_activos_intangibles
-msgid "AR ESP: Activos Intangibles"
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_eerr_gastos_comercializacion
+msgid "AR EERR: Selling Expenses"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_anticipos_de_clientes
-msgid "AR ESP: Anticipos de Clientes"
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_deudas_comerciales
+msgid "AR ESP: Accounts Payable"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_bienes_de_cambio
-msgid "AR ESP: Bienes de Cambio"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_bienes_de_cambio_nc
-msgid "AR ESP: Bienes de Cambio NC"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_bienes_de_uso
-msgid "AR ESP: Bienes de Uso"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_caja_y_bancos
-msgid "AR ESP: Caja y Bancos"
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_creditos_por_ventas
+msgid "AR ESP: Accounts Receivable"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -129,118 +109,138 @@ msgid "AR ESP: Capital"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_cargas_fiscales
-msgid "AR ESP: Cargas Fiscales"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_creditos_por_ventas
-msgid "AR ESP: Créditos por Ventas"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_creditos_por_ventas_nc
-msgid "AR ESP: Créditos por Ventas NC"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_deudas_comerciales
-msgid "AR ESP: Deudas Comerciales"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_deudas_no_corrientes
-msgid "AR ESP: Deudas No Corrientes"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_dividendos_a_pagar
-msgid "AR ESP: Dividendos a Pagar"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_inversiones_temporarias
-msgid "AR ESP: Inversiones Temporarias"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_llave_de_negocio
-msgid "AR ESP: Llave de Negocio"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_otras_deudas
-msgid "AR ESP: Otras Deudas"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_otras_inversiones_nc
-msgid "AR ESP: Otras Inversiones NC"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_otros_activos
-msgid "AR ESP: Otros Activos"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_otros_activos_nc
-msgid "AR ESP: Otros Activos NC"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_otros_creditos
-msgid "AR ESP: Otros Créditos"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_otros_creditos_nc
-msgid "AR ESP: Otros Créditos NC"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_part_terceros_en_soc
-msgid "AR ESP: Part. Terceros en Soc."
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_participaciones_en_sociedades
-msgid "AR ESP: Participaciones en Sociedades"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_previsiones
-msgid "AR ESP: Previsiones"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_previsiones_no_corrientes
-msgid "AR ESP: Previsiones No Corrientes"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_prestamos
-msgid "AR ESP: Préstamos"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_remun_y_cargas_sociales
-msgid "AR ESP: Remun. y Cargas Sociales"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_reservas
-msgid "AR ESP: Reservas"
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_caja_y_bancos
+msgid "AR ESP: Cash and Banks"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_resultado_del_ejercicio
-msgid "AR ESP: Resultado del Ejercicio"
+msgid "AR ESP: Current Year Earnings"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_anticipos_de_clientes
+msgid "AR ESP: Customer Advances"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_dividendos_a_pagar
+msgid "AR ESP: Dividends Payable"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_bienes_de_uso
+msgid "AR ESP: Fixed Assets"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_llave_de_negocio
+msgid "AR ESP: Goodwill"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_activos_intangibles
+msgid "AR ESP: Intangible Assets"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_bienes_de_cambio
+msgid "AR ESP: Inventories"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_participaciones_en_sociedades
+msgid "AR ESP: Investments in Subsidiaries"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_prestamos
+msgid "AR ESP: Loans Payable"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_creditos_por_ventas_nc
+msgid "AR ESP: Long-term Accounts Receivable"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_bienes_de_cambio_nc
+msgid "AR ESP: Long-term Inventories"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_part_terceros_en_soc
+msgid "AR ESP: Minority Interests"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_deudas_no_corrientes
+msgid "AR ESP: Non-current Liabilities"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_previsiones_no_corrientes
+msgid "AR ESP: Non-current Provisions"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_otros_activos
+msgid "AR ESP: Other Current Assets"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_otras_deudas
+msgid "AR ESP: Other Liabilities"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_otras_inversiones_nc
+msgid "AR ESP: Other Long-term Investments"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_otros_creditos_nc
+msgid "AR ESP: Other Long-term Receivables"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_otros_activos_nc
+msgid "AR ESP: Other Non-current Assets"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_otros_creditos
+msgid "AR ESP: Other Receivables"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_remun_y_cargas_sociales
+msgid "AR ESP: Payroll Liabilities"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_previsiones
+msgid "AR ESP: Provisions"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_reservas
+msgid "AR ESP: Reserves"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_resultados
-msgid "AR ESP: Resultados"
+msgid "AR ESP: Retained Earnings"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_inversiones_temporarias
+msgid "AR ESP: Short-term Investments"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.account.tag,name:l10n_ar_account_reports.ar_esp_cargas_fiscales
+msgid "AR ESP: Tax Liabilities"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -276,13 +276,28 @@ msgid "Accounting Return Type"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_activo
-msgid "Activo"
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_accounts_payable
+msgid "Accounts Payable"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_intangible_assets
-msgid "Activos intangibles"
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_sales_rec
+msgid "Accounts Receivable"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_sales_rec_noncurrent
+msgid "Accounts Receivable (Non-current)"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_equity_results_detail
+msgid "Accumulated Earnings"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_adm_exp
+msgid "Administrative Expenses"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -342,11 +357,6 @@ msgid ""
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_advances_from_customers
-msgid "Anticipos de clientes"
-msgstr ""
-
-#. module: l10n_ar_account_reports
 #: model:ir.model,name:l10n_ar_account_reports.model_l10n_ar_caba_report_handler
 msgid "Argentinian CABA Report Custom Handler"
 msgstr ""
@@ -400,34 +410,22 @@ msgid "Asiento de ajuste por inflación"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.report,settlement_title:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados
-msgid "Asiento de refundición"
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_activo
+msgid "Assets"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.column,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_column
 #: model:account.report.column,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_column
+#: model:account.report.column,name:l10n_ar_account_reports.l10n_ar_iva_report_column_total
+#: model:account.report.column,name:l10n_ar_account_reports.l10n_ar_sicore_report_column_total
+#: model:account.report.column,name:l10n_ar_account_reports.l10n_ar_sifere_report_column_total
 msgid "Balance"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_inventory
-msgid "Bienes de cambio"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_inventory_noncurrent
-msgid "Bienes de cambio (No corriente)"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_fixed_assets
-msgid "Bienes de uso"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_bank_cash
-msgid "Caja y Bancos"
+#: model:account.report,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial
+msgid "Balance Sheet"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -458,8 +456,8 @@ msgid "Capital"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_tax_liabilities
-msgid "Cargas fiscales"
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_bank_cash
+msgid "Cash and Banks"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -485,7 +483,7 @@ msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_cogs
-msgid "Costo de venta de bienes y servicios"
+msgid "Cost of Goods and Services Sold"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -510,13 +508,13 @@ msgid "Created on"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_sales_rec
-msgid "Créditos por ventas"
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_ar_curr_year_earnings
+msgid "Current Year Earnings"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_sales_rec_noncurrent
-msgid "Créditos por ventas (No corriente)"
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_advances_from_customers
+msgid "Customer Advances"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -564,21 +562,6 @@ msgid "Default Periodicity"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_sifere_report_sifere_despachos_line
-msgid "Despachos de importación"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_accounts_payable
-msgid "Deudas Comerciales"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_long_term_liabilities
-msgid "Deudas no corrientes"
-msgstr ""
-
-#. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_account_chart_template__display_name
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_account_move__display_name
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_account_move_line__display_name
@@ -604,7 +587,7 @@ msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_dividends_payable
-msgid "Dividendos a pagar"
+msgid "Dividends Payable"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -679,17 +662,6 @@ msgid "End Index"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.report,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial
-msgid "Estado Patrimonial"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados
-#: model:ir.actions.client,name:l10n_ar_account_reports.action_account_report_l10n_ar_estado_resultados
-msgid "Estado de Resultados"
-msgstr ""
-
-#. module: l10n_ar_account_reports
 #: model_terms:ir.actions.act_window,help:l10n_ar_account_reports.inflation_adjustment_index_action
 msgid "Estos son necesarios para generar el asiento de ajuste por inflación."
 msgstr ""
@@ -700,35 +672,30 @@ msgid "External ID"
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_fin_exp
+msgid "Financial Results and Holding Gains/Losses (includes RECPAM)"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_fixed_assets
+msgid "Fixed Assets"
+msgstr ""
+
+#. module: l10n_ar_account_reports
 #: model:ir.model.fields.selection,name:l10n_ar_account_reports.selection__account_return_type__deadline_periodicity__fortnightly
 #: model:ir.model.fields.selection,name:l10n_ar_account_reports.selection__account_return_type__default_deadline_periodicity__fortnightly
 msgid "Fortnightly"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_gross_inc
-msgid "Ganancia (Pérdida) bruta"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_adm_exp
-msgid "Gastos de administración"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_com_exp
-msgid "Gastos de comercialización"
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
+msgid "Generar el asiento de ajuste por inflación para el período fiscal."
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report,settlement_title:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial
-msgid "Generar asiento de cierre"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#. odoo-python
-#: code:addons/l10n_ar_account_reports/models/account_return.py:0
-msgid "Generar el asiento de ajuste por inflación para el período fiscal."
+msgid "Generate Closing Entry"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -741,6 +708,16 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
 msgid "Global Inflation Adjustment [%s] / [%s]"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_goodwill
+msgid "Goodwill"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_gross_inc
+msgid "Gross Profit (Loss)"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -833,8 +810,19 @@ msgid ""
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_sifere_report_sifere_despachos_line
+msgid "Import Dispatches"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados
+#: model:ir.actions.client,name:l10n_ar_account_reports.action_account_report_l10n_ar_estado_resultados
+msgid "Income Statement"
+msgstr ""
+
+#. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_tax_inc
-msgid "Impuesto a las ganancias"
+msgid "Income Tax"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -883,8 +871,18 @@ msgid "Inflation adjustment opening balances (%s * %.2f%%)"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_temp_investments
-msgid "Inversiones temporarias"
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_intangible_assets
+msgid "Intangible Assets"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_inventory
+msgid "Inventories"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_inventory_noncurrent
+msgid "Inventories (Non-current)"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -938,8 +936,38 @@ msgid "Last Updated on"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_goodwill
-msgid "Llave de negocio"
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_pasivo
+msgid "Liabilities"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_loans_payable
+msgid "Loans Payable"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_long_term_investments
+msgid "Long-term Investments in Subsidiaries"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_minority_interest
+msgid "Minority Interest in Controlled Companies"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_equity
+msgid "Net Equity"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_net_inc
+msgid "Net Result for the Period"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_sales
+msgid "Net Sales of Goods and Services"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -1022,48 +1050,58 @@ msgid ""
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_long_term_liabilities
+msgid "Non-current Liabilities"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_long_term_provisions
+msgid "Non-current Provisions"
+msgstr ""
+
+#. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__open_move_id
 msgid "Opening Entry"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_liabilities
-msgid "Otras"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_long_term_investments
-msgid "Otras inversiones"
+msgid "Other"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_current_assets
-msgid "Otros activos"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_noncurrent_assets
-msgid "Otros activos (No corriente)"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_rec
-msgid "Otros créditos"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_rec_noncurrent
-msgid "Otros créditos (No corriente)"
+msgid "Other Current Assets"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_other_exp
-msgid "Otros gastos"
+msgid "Other Expenses"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_other_inc_exp
-msgid "Otros ingresos y egresos"
+msgid "Other Income and Expenses"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_long_term_investments
+msgid "Other Long-term Investments"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_noncurrent_assets
+msgid "Other Non-current Assets"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_rec
+msgid "Other Receivables"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_rec_noncurrent
+msgid "Other Receivables (Non-current)"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -1072,33 +1110,18 @@ msgid "Partial Reconcile"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_long_term_investments
-msgid "Participaciones permanentes en sociedades"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_minority_interest
-msgid "Participación de terceros en sociedades controladas"
-msgstr ""
-
-#. module: l10n_ar_account_reports
 #: model:ir.model,name:l10n_ar_account_reports.model_account_partner_ledger_report_handler
 msgid "Partner Ledger Custom Handler"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_pasivo
-msgid "Pasivo"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_equity
-msgid "Patrimonio neto"
-msgstr ""
-
-#. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_account_return_type__payment_partner_id
 msgid "Payment Partner"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_payroll_liabilities
+msgid "Payroll Liabilities"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -1126,17 +1149,7 @@ msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_provisions
-msgid "Previsiones"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_long_term_provisions
-msgid "Previsiones no corrientes"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_loans_payable
-msgid "Préstamos"
+msgid "Provisions"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -1161,48 +1174,23 @@ msgid "Purchase Withholdings"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_payroll_liabilities
-msgid "Remuneraciones y cargas sociales"
+#: model:account.report,settlement_title:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados
+msgid "Refunding Entry"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_equity_reserves
-msgid "Reservas"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_net_inc
-msgid "Resultado Final del ejercicio"
+msgid "Reserves"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_inc_before_tax
-msgid "Resultado antes del impuesto a las ganancias"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_ar_curr_year_earnings
-msgid "Resultado del Ejercicio"
+msgid "Result Before Income Tax"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_equity_results
-msgid "Resultados"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_equity_results_detail
-msgid "Resultados Acumulados"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_fin_exp
-msgid "Resultados financieros y por tenencia (incluye RECPAM)"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_ar_prev_year_earnings
-msgid "Resultados sin asignar de años anteriores"
+msgid "Results"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -1228,7 +1216,7 @@ msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.return.type,name:l10n_ar_account_reports.sicore_return_type
-msgid "SICORE Ganancias (Agente)"
+msgid "SICORE Income Tax (Agent)"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -1275,6 +1263,16 @@ msgid "Search Description"
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_com_exp
+msgid "Selling Expenses"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_temp_investments
+msgid "Short-term Investments"
+msgstr ""
+
+#. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/sicore_report.py:0
 msgid "Sicore Profits Withholdings TXT"
@@ -1311,7 +1309,12 @@ msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_subtotal_noncurrent_assets
-msgid "Subtotal del activo no corriente"
+msgid "Subtotal Non-current Assets"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_tax_liabilities
+msgid "Tax Liabilities"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -1478,42 +1481,47 @@ msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_assets
-msgid "Total del activo"
+msgid "Total Assets"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_current_assets
-msgid "Total del activo corriente"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_noncurrent_assets
-msgid "Total del activo no corriente"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_liabilities_combined
-msgid "Total del pasivo"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_liabilities_equity
-msgid "Total del pasivo, participación de terceros y patrimonio neto"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_debts
-msgid "Total deudas"
+msgid "Total Current Assets"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_current_liabilities
-msgid "Total pasivo corriente"
+msgid "Total Current Liabilities"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_debts
+msgid "Total Debts"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_liabilities_combined
+msgid "Total Liabilities"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_liabilities_equity
+msgid "Total Liabilities, Minority Interest and Net Equity"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_noncurrent_assets
+msgid "Total Non-current Assets"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_noncurrent_liabilities
-msgid "Total pasivo no corriente"
+msgid "Total Non-current Liabilities"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_ar_prev_year_earnings
+msgid "Unallocated Earnings from Previous Years"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -1525,11 +1533,6 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment_index__value
 msgid "Value"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_sales
-msgid "Ventas netas de bienes y servicios"
 msgstr ""
 
 #. module: l10n_ar_account_reports

--- a/l10n_ar_account_reports/models/account_return.py
+++ b/l10n_ar_account_reports/models/account_return.py
@@ -298,10 +298,9 @@ class AccountReturn(models.Model):
             )
             ar_checks.append(
                 {
-                    "name": _("Cheques a fecha"),
+                    "name": _("Post-dated Checks"),
                     "message": _(
-                        "Revisar y procesar los cheques de terceros con fecha de pago diferida "
-                        "pendientes al cierre del período."
+                        "Review and process third-party checks with deferred payment dates " "pending at period close."
                     ),
                     "code": "l10n_ar_cheques_a_fecha",
                     "action": action,
@@ -313,8 +312,8 @@ class AccountReturn(models.Model):
             action = self.env["ir.actions.actions"]._for_xml_id("l10n_ar_account_reports.inflation_adjustment_action")
             ar_checks.append(
                 {
-                    "name": _("Asiento de ajuste por inflación"),
-                    "message": _("Generar el asiento de ajuste por inflación para el período fiscal."),
+                    "name": _("Inflation Adjustment Entry"),
+                    "message": _("Generate the inflation adjustment journal entry for the fiscal period."),
                     "code": "l10n_ar_inflation_adjustment",
                     "action": action,
                     "result": "todo",

--- a/l10n_ar_account_reports/models/caba_report.py
+++ b/l10n_ar_account_reports/models/caba_report.py
@@ -107,12 +107,12 @@ class L10n_ArCabaReportHandler(models.AbstractModel):
             if not partner.vat:
                 raise RedirectWarning(
                     message=_(
-                        'El partner "%(partner_name)s" (id %(partner_id)s) no tiene número de identificación establecido',
+                        'The partner "%(partner_name)s" (id %(partner_id)s) does not have an identification number set',
                         partner_name=partner.name,
                         partner_id=partner.id,
                     ),
                     action=partner.get_formview_action(),
-                    button_text=_("Editar contacto"),
+                    button_text=_("Edit contact"),
                 )
             alicuot = tax.amount
 
@@ -196,7 +196,7 @@ class L10n_ArCabaReportHandler(models.AbstractModel):
                     other_taxes_amount = company_currency.round(total_amount - taxable_amount - vat_amount)
                     # other_taxes_amount = line.move_id.cc_other_taxes_amount
                 else:
-                    raise UserError(_("El impuesto no está asociado"))
+                    raise UserError(_("The tax is not associated"))
 
                 # 8 - Monto del comprobante
                 content += format_amount(total_amount, 16, 2, ",")
@@ -213,13 +213,13 @@ class L10n_ArCabaReportHandler(models.AbstractModel):
                 ]:
                     raise RedirectWarning(
                         message=_(
-                            'El contacto "%(partner_name)s" (id %(partner_id)s), debe tener el tipo de identificación'
-                            " CUIT, CUIL, CDI.",
+                            'The contact "%(partner_name)s" (id %(partner_id)s) must have the identification type'
+                            " CUIT, CUIL, or CDI.",
                             partner_name=partner.name,
                             partner_id=partner.id,
                         ),
                         action=partner.get_formview_action(),
-                        button_text=_("Editar contacto"),
+                        button_text=_("Edit contact"),
                     )
                 doc_type_mapping = {"CUIT": "3", "CUIL": "2", "CDI": "1"}
                 content += doc_type_mapping[partner.l10n_latam_identification_type_id.name]
@@ -233,12 +233,12 @@ class L10n_ArCabaReportHandler(models.AbstractModel):
                 if not partner.l10n_ar_gross_income_type:
                     raise RedirectWarning(
                         message=self.env._(
-                            'Debe setear el tipo de inscripción de IIBB del contacto "%(partner_name)s" (id: %(partner_id)s)',
+                            'You must set the IIBB registration type for contact "%(partner_name)s" (id: %(partner_id)s)',
                             partner_name=partner.name,
                             partner_id=partner.id,
                         ),
                         action=partner.get_formview_action(),
-                        button_text=self.env._("Editar contacto"),
+                        button_text=self.env._("Edit contact"),
                     )
 
                 # ahora se reportaria para cualquier inscripto el numero de cuit
@@ -271,7 +271,7 @@ class L10n_ArCabaReportHandler(models.AbstractModel):
                     content += "4"
                 else:
                     raise UserError(
-                        _('La responsabilidad frente a IVA "%s" no está soportada para ret/perc AGIP') % res_iva.name
+                        _('The VAT responsibility "%s" is not supported for AGIP withholding/perception') % res_iva.name
                     )
 
                 # 15 - Razón Social del Retenido
@@ -345,9 +345,9 @@ class L10n_ArCabaReportHandler(models.AbstractModel):
         if not or_inv:
             raise UserError(
                 _(
-                    "No pudimos encontrar el comprobante original para %s "
-                    '(id %s). Verifique que en la nota de crédito "%s", el'
-                    " campo origen es el número de la factura original"
+                    "Could not find the original document for %s "
+                    '(id %s). Please verify that in the credit note "%s", the'
+                    " origin field contains the original invoice number"
                 )
                 % (
                     line.move_id.display_name,

--- a/l10n_ar_account_reports/models/inflation_adjustment_index.py
+++ b/l10n_ar_account_reports/models/inflation_adjustment_index.py
@@ -43,7 +43,7 @@ class InflationAdjustmentIndex(models.Model):
             if len(repeated) > 1 or repeated.id != rec.id:
                 rec_date = fields.Date.from_string(rec.date)
                 raise ValidationError(
-                    _("Ya existe un índice para el periodo %s %s. Solo puedes tener un índice de inflación por mes")
+                    _("An index already exists for period %s %s. You can only have one inflation index per month")
                     % (rec_date.strftime("%B"), rec_date.year)
                 )
 
@@ -52,7 +52,7 @@ class InflationAdjustmentIndex(models.Model):
         for rec in self:
             date = fields.Date.from_string(rec.date)
             if date.day != 1:
-                raise ValidationError(_("El índice debe comenzar el primer día de cada mes"))
+                raise ValidationError(_("The index must start on the first day of each month"))
 
     @api.constrains("date")
     def check_xml_id(self):

--- a/l10n_ar_account_reports/models/l10n_ar_vat_ret_perc_sufrido.py
+++ b/l10n_ar_account_reports/models/l10n_ar_vat_ret_perc_sufrido.py
@@ -96,7 +96,7 @@ class L10n_ArIvaReportHandler(models.AbstractModel):
                 if not codigo_regimen:
                     raise RedirectWarning(
                         message=_(
-                            'No hay código de régimen en la configuración del impuesto "%(tax_name)s"',
+                            'There is no regime code in the configuration of tax "%(tax_name)s"',
                             tax_name=line_withholding_tax.name,
                         ),
                         action=line_withholding_tax.get_formview_action(),
@@ -105,7 +105,7 @@ class L10n_ArIvaReportHandler(models.AbstractModel):
                 if len(codigo_regimen) < 3:
                     raise RedirectWarning(
                         message=_(
-                            'El código de régimen tiene que tener 3 dígitos en la configuración del impuesto "%(tax_name)s"',
+                            'The regime code must have 3 digits in the configuration of tax "%(tax_name)s"',
                             tax_name=line_withholding_tax.name,
                         ),
                         action=line_withholding_tax.get_formview_action(),
@@ -135,7 +135,7 @@ class L10n_ArIvaReportHandler(models.AbstractModel):
                 if not codigo_regimen:
                     raise RedirectWarning(
                         message=_(
-                            'No hay código de régimen en la configuración del impuesto "%(tax_name)s"',
+                            'There is no regime code in the configuration of tax "%(tax_name)s"',
                             tax_name=tax.name,
                         ),
                         action=tax.get_formview_action(),
@@ -144,7 +144,7 @@ class L10n_ArIvaReportHandler(models.AbstractModel):
                 if len(codigo_regimen) < 3:
                     raise RedirectWarning(
                         message=_(
-                            'El código de régimen tiene que tener 3 dígitos en la configuración del impuesto "%(tax_name)s"',
+                            'The regime code must have 3 digits in the configuration of tax "%(tax_name)s"',
                             tax_name=tax.name,
                         ),
                         action=tax.get_formview_action(),

--- a/l10n_ar_account_reports/models/santa_fe_report.py
+++ b/l10n_ar_account_reports/models/santa_fe_report.py
@@ -100,13 +100,13 @@ class L10n_ArSantaFeReportHandler(models.AbstractModel):
                 articulo_inciso_calculo = tax.api_articulo_inciso_calculo_retencion
                 articulo_inciso_retiene = tax.api_codigo_articulo_retencion
             else:
-                raise UserError(_("Tipo de impuesto %s equivocado") % (tax.tax_group_id.name))
+                raise UserError(_("Wrong tax type %s") % (tax.tax_group_id.name))
 
             if not articulo_inciso_calculo or not articulo_inciso_retiene:
                 raise RedirectWarning(
                     message=_(
-                        'Debe establecer la información de "artículo/inciso" en la configuración del impuesto "%(tax_name)s"'
-                        'en la solapa "API".',
+                        'You must set the "article/section" information in the configuration of tax "%(tax_name)s"'
+                        ' in the "API" tab.',
                         tax_name=tax.name,
                     ),
                     action=tax.get_formview_action(),
@@ -179,12 +179,12 @@ class L10n_ArSantaFeReportHandler(models.AbstractModel):
             if not gross_income_type:
                 raise RedirectWarning(
                     message=_(
-                        'Debe establecer el tipo de inscripción de IIBB del partner "%(partner_name)s" (id: %(partner_id)s)',
+                        'You must set the IIBB registration type for partner "%(partner_name)s" (id: %(partner_id)s)',
                         partner_name=partner.name,
                         partner_id=partner.id,
                     ),
                     action=partner.get_formview_action(),
-                    button_text=_("Editar contacto"),
+                    button_text=_("Edit contact"),
                 )
             if gross_income_type in ["multilateral", "local"]:
                 content += "1"
@@ -211,7 +211,7 @@ class L10n_ArSantaFeReportHandler(models.AbstractModel):
                 content += "4"
             else:
                 raise UserError(
-                    _('La responsabilidad frente a IVA "%s" no está soportada para ret/perc Santa Fe') % res_iva.name
+                    _('The VAT responsibility "%s" is not supported for Santa Fe withholding/perception') % res_iva.name
                 )
 
             # 14 - Marca inscripción Otros Gravámenes

--- a/l10n_ar_account_reports/models/sifere_report.py
+++ b/l10n_ar_account_reports/models/sifere_report.py
@@ -130,7 +130,7 @@ class L10n_ArSifereReportHandler(models.AbstractModel):
 
             if not line.partner_id:
                 raise UserError(
-                    _('La percepción %s (id: %d) del comprobante "%s" (id: %d) no tiene contacto asociado.')
+                    _('The perception %s (id: %d) of the document "%s" (id: %d) has no associated contact.')
                     % (line.withholding_id.name, line.id, line.move_id.name, line.move_id.id)
                 )
             line.partner_id.ensure_vat()

--- a/l10n_ar_account_reports/models/sircar_report.py
+++ b/l10n_ar_account_reports/models/sircar_report.py
@@ -126,7 +126,7 @@ class L10n_ArSircarReportHandler(models.AbstractModel):
                 if not tax.l10n_ar_code:
                     raise RedirectWarning(
                         message=_(
-                            "No hay regimen de retencion (ARCA Code 'l10n_ar_code') configurado para el impuesto '%(tax_name)s' del partner '%(partner_name)s'",
+                            "There is no withholding regime (ARCA Code 'l10n_ar_code') configured for tax '%(tax_name)s' of partner '%(partner_name)s'",
                             tax_name=tax.name,
                             partner_name=line.partner_id.name,
                         ),
@@ -140,7 +140,7 @@ class L10n_ArSircarReportHandler(models.AbstractModel):
                 if not tax.l10n_ar_state_id.jurisdiction_code or not tax.l10n_ar_state_id.jurisdiction_code:
                     raise RedirectWarning(
                         message=_(
-                            'No hay jurisdicción establecida en el impuesto "%(tax_name)s" o no tiene código de jurisdicción.',
+                            'There is no jurisdiction set in the tax "%(tax_name)s" or it does not have a jurisdiction code.',
                             tax_name=tax.name,
                         ),
                         action=tax.get_formview_action(),
@@ -192,7 +192,7 @@ class L10n_ArSircarReportHandler(models.AbstractModel):
                 elif line.move_id.type == "out_refund":
                     tipo_comprobante = 120
                 else:
-                    raise UserError(_("Tipo de comprobante no reconocido"))
+                    raise UserError(_("Unrecognized document type"))
                 content.append("%03d" % tipo_comprobante)
 
                 # 3 Letra del comprobante
@@ -221,7 +221,7 @@ class L10n_ArSircarReportHandler(models.AbstractModel):
                 if not tax.l10n_ar_code:
                     raise RedirectWarning(
                         message=_(
-                            "No hay régimen de percepción (ARCA Code 'l10n_ar_code') configurado para el impuesto: '%(tax_name)s'.",
+                            "There is no perception regime (ARCA Code 'l10n_ar_code') configured for tax: '%(tax_name)s'.",
                             tax_name=tax.name,
                         ),
                         action=tax.get_formview_action(),
@@ -234,7 +234,7 @@ class L10n_ArSircarReportHandler(models.AbstractModel):
                 if not tax.l10n_ar_state_id.jurisdiction_code or not tax.l10n_ar_state_id.jurisdiction_code:
                     raise RedirectWarning(
                         message=_(
-                            'No hay jurisdicción establecida en el impuesto "%(tax_name)s" o no tiene código de jurisdicción.',
+                            'There is no jurisdiction set in the tax "%(tax_name)s" or it does not have a jurisdiction code.',
                             tax_name=tax.name,
                         ),
                         action=tax.get_formview_action(),
@@ -279,7 +279,7 @@ class L10n_ArSircarReportHandler(models.AbstractModel):
         elif related_invoice.move_type == "out_refund":
             document_type = 120
         else:
-            raise UserError(_("Tipo de comprobante no reconocido"))
+            raise UserError(_("Unrecognized document type"))
         res += str(document_type)[:1]
 
         # 3 Letra del comprobante

--- a/l10n_ar_account_reports/models/tucuman_report.py
+++ b/l10n_ar_account_reports/models/tucuman_report.py
@@ -108,8 +108,8 @@ class L10n_ArTucumanReportHandler(models.AbstractModel):
         ):
             raise UserError(
                 _(
-                    "Algunos comprobantes rectificativos no contienen información de que "
-                    "comprobante original están revirtiendo:\n %s"
+                    "Some corrective documents do not contain information about which "
+                    "original document they are reversing:\n %s"
                 )
                 % (", ".join(nc_without_reversed_entry_id.mapped("move_id.name")))
             )
@@ -121,8 +121,8 @@ class L10n_ArTucumanReportHandler(models.AbstractModel):
         ):
             raise UserError(
                 _(
-                    "Algunos comprobantes no contienen información acerca de la calle/ciudad/provincia/cod "
-                    "postal del contacto:\n %s"
+                    "Some documents do not contain information about the street/city/province/postal "
+                    "code of the contact:\n %s"
                 )
                 % (", ".join(moves_without_street_city_state.mapped("move_id.name")))
             )
@@ -135,8 +135,8 @@ class L10n_ArTucumanReportHandler(models.AbstractModel):
         if move_lines_with_five_digits_pos:
             raise UserError(
                 _(
-                    "Algunos comprobantes tienen punto de venta de 5 dígitos y deben tener de 4 dígitos para "
-                    "poder generar el archivo txt de retenciones y percepciones de Tucuman:\n %s"
+                    "Some documents have a 5-digit point of sale but must have a 4-digit one to "
+                    "generate the Tucuman withholdings and perceptions TXT file:\n %s"
                 )
                 % (", ".join(move_lines_with_five_digits_pos.mapped("move_id.name")))
             )

--- a/l10n_ar_account_reports/wizard/inflation_adjustment.py
+++ b/l10n_ar_account_reports/wizard/inflation_adjustment.py
@@ -33,19 +33,19 @@ class InflationAdjustment(models.TransientModel):
         compute="_compute_index",
     )
     open_cloure_entry = fields.Selection(
-        [("yes", "Si"), ("no", "No")],
-        string="Ha realizado asientos de cierre/apertura?",
+        [("yes", "Yes"), ("no", "No")],
+        string="Has Closing/Opening Entries?",
         default="no",
-        help="Si usted ha realizado los asientos de cierre/apertura debe"
-        " indicarnos cuales son para poder excluir los mismos en el cálculo.",
+        help="If you have made the closing/opening entries, please indicate them"
+        " so they can be excluded from the calculation.",
     )
     closure_move_id = fields.Many2one(
         "account.move",
-        string="Asiento de cierre",
+        string="Closing Entry",
     )
     open_move_id = fields.Many2one(
         "account.move",
-        string="Asiento de apertura",
+        string="Opening Entry",
     )
 
     def get_account_id(self, line):
@@ -95,7 +95,7 @@ class InflationAdjustment(models.TransientModel):
             end_index = self.env["inflation.adjustment.index"].find(end_date).value
 
         if not start_date or not end_date:
-            raise UserError(_("Por favor indique el rango de fecha de inicio y fin"))
+            raise UserError(_("Please specify the start and end date range"))
 
         res = []
 
@@ -109,7 +109,7 @@ class InflationAdjustment(models.TransientModel):
             index = indexes.filtered(lambda x: x.date >= start_date and x.date <= date_to)
             if not index:
                 message = _(
-                    "El asiento de ajuste por inflación no puede ser generado ya que hace falta el indice de ajuste para el periodo %(month)s %(year)s"
+                    "The inflation adjustment entry cannot be generated because the adjustment index for period %(month)s %(year)s is missing"
                 ) % {
                     "month": start_date.strftime("%B"),
                     "year": start_date.year,
@@ -167,8 +167,8 @@ class InflationAdjustment(models.TransientModel):
         if not before_index:
             raise UserError(
                 _(
-                    "No se encontró un índice de ajuste por inflación para la fecha anterior (%s). "
-                    "Por favor, configure el índice correspondiente."
+                    "No inflation adjustment index was found for the previous date (%s). "
+                    "Please configure the corresponding index."
                 )
                 % format_date(self.env, before_date_from)
             )
@@ -183,7 +183,7 @@ class InflationAdjustment(models.TransientModel):
             lines.append(
                 {
                     "account_id": self.get_account_id(line),
-                    "name": _("Ajuste por inflación cuentas al inicio (%s * %.2f%%)")
+                    "name": _("Inflation adjustment opening balances (%s * %.2f%%)")
                     % (FormatAmount(line.get("balance")), initial_factor * 100.0),
                     "date_maturity": before_date_from,
                     "debit" if adjustment > 0 else "credit": abs(adjustment),
@@ -209,7 +209,7 @@ class InflationAdjustment(models.TransientModel):
                 lines.append(
                     {
                         "account_id": self.get_account_id(line),
-                        "name": _("Ajuste por inflación %s (%s * %.2f%%)")
+                        "name": _("Inflation adjustment %s (%s * %.2f%%)")
                         % (
                             format_date(self.env, date_from, date_format="MM/Y"),
                             FormatAmount(line.get("balance")),
@@ -222,16 +222,14 @@ class InflationAdjustment(models.TransientModel):
                 adjustment_total["debit" if adjustment > 0 else "credit"] += abs(adjustment)
 
         if not lines:
-            raise UserError(
-                _("No hemos encontrado ningún asiento contable para ajustar asociado al periodo seleccionado.")
-            )
+            raise UserError(_("No journal entries to adjust were found for the selected period."))
 
         # Generate total amount adjustment line
         adj_diff = adjustment_total.get("debit", 0.0) - adjustment_total.get("credit", 0.0)
         lines.append(
             {
                 "account_id": self.account_id.id,
-                "name": _("Ajuste por inflación Global [%s] / [%s]") % (self.date_from, self.date_to),
+                "name": _("Global Inflation Adjustment [%s] / [%s]") % (self.date_from, self.date_to),
                 "debit" if adj_diff < 0 else "credit": abs(adj_diff),
                 "date_maturity": self.date_to,
             }
@@ -245,7 +243,7 @@ class InflationAdjustment(models.TransientModel):
                 {
                     "journal_id": self.journal_id.id,
                     "date": self.date_to,
-                    "ref": _("Ajuste por inflación %s") % (date_to.year),
+                    "ref": _("Inflation Adjustment %s") % (date_to.year),
                     "line_ids": [(0, 0, line_data) for line_data in lines],
                 }
             )

--- a/l10n_ar_currency_update/i18n/es.po
+++ b/l10n_ar_currency_update/i18n/es.po
@@ -70,11 +70,15 @@ msgstr "ID (identificación)"
 #. odoo-python
 #: code:addons/l10n_ar_currency_update/models/res_currency.py:0
 msgid ""
+"Cannot change the name/code of %(currencies)s as it has an ARCA Code "
+"defined.\n"
+"Doing so would affect both the automatic currency rate synchronization "
+"service and the electronic invoicing service."
+msgstr ""
 "No se puede cambiar el nombre/código de %(currencies)s ya que tiene un "
-"Código ARCA definido. \n"
+"Código ARCA definido.\n"
 "Hacerlo repercutiría tanto en el servicio de sincronización automática de "
 "tasa de cambio como en el servicio de facturación electrónica."
-msgstr ""
 
 #. module: l10n_ar_currency_update
 #: model:ir.model.fields,field_description:l10n_ar_currency_update.field_res_company__rate_perc

--- a/l10n_ar_currency_update/i18n/l10n_ar_currency_update.pot
+++ b/l10n_ar_currency_update/i18n/l10n_ar_currency_update.pot
@@ -63,8 +63,10 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_currency_update/models/res_currency.py:0
 msgid ""
-"No se puede cambiar el nombre/código de %(currencies)s ya que tiene un Código ARCA definido. \n"
-"Hacerlo repercutiría tanto en el servicio de sincronización automática de tasa de cambio como en el servicio de facturación electrónica."
+"Cannot change the name/code of %(currencies)s as it has an ARCA Code "
+"defined.\n"
+"Doing so would affect both the automatic currency rate synchronization "
+"service and the electronic invoicing service."
 msgstr ""
 
 #. module: l10n_ar_currency_update

--- a/l10n_ar_currency_update/models/res_currency.py
+++ b/l10n_ar_currency_update/models/res_currency.py
@@ -12,8 +12,8 @@ class ResCurrency(models.Model):
             if renamed_protected:
                 raise UserError(
                     _(
-                        "No se puede cambiar el nombre/código de %(currencies)s ya que tiene un Código ARCA definido. \n"
-                        "Hacerlo repercutiría tanto en el servicio de sincronización automática de tasa de cambio como en el servicio de facturación electrónica.",
+                        "Cannot change the name/code of %(currencies)s as it has an ARCA Code defined.\n"
+                        "Doing so would affect both the automatic currency rate synchronization service and the electronic invoicing service.",
                         currencies=", ".join(renamed_protected.mapped("name")),
                     )
                 )

--- a/l10n_ar_currency_update/tests/test_l10n_ar_currency_update.py
+++ b/l10n_ar_currency_update/tests/test_l10n_ar_currency_update.py
@@ -199,7 +199,7 @@ class TestL10nArCurrencyUpdate(TransactionCase):
         )
 
     def test_protected_currency_name_cannot_be_changed(self):
-        with self.assertRaisesRegex(UserError, "No se puede cambiar el nombre/código"):
+        with self.assertRaisesRegex(UserError, "Cannot change the name/code"):
             self.USD.write({"name": "USX"})
 
     def test_non_protected_currency_name_can_be_changed(self):


### PR DESCRIPTION
## Summary

- Move user-facing strings hardcoded in Spanish inside `_()` calls (and field `string=`/`help=` in Python) to English, following Odoo i18n convention (English `msgid`, Spanish translation in `es.po`).
- Regenerate `.pot` files.
- Add Spanish translations in `es.po` for all converted strings.

Modules affected: `l10n_ar_account_reports` (9 Python files: `sifere_report`, `caba_report`, `santa_fe_report`, `sircar_report`, `l10n_ar_vat_ret_perc_sufrido`, `tucuman_report`, `account_return`, `inflation_adjustment_index`, `wizard/inflation_adjustment`) and `l10n_ar_currency_update` (1 Python file: `models/res_currency`).

## Test plan

- [ ] Verify Spanish translations display correctly with `es` locale active
- [ ] Confirm error messages shown to users appear in Spanish when language is set to Spanish
- [ ] Check that no regressions exist in the TXT export flows (SIFERE, CABA, Santa Fe, SIRCAR, PBA, Mendoza, Misiones, Tucumán, SICORE, IVA sufrido)
- [ ] Verify inflation adjustment wizard works correctly and messages display in Spanish

Task: https://www.adhoc.inc/odoo/project/65994