### PR TITLE
[IMP] l10n_ar_edi_ux: share ARCA certificates across branches

### DIFF
--- a/l10n_ar_edi_ux/__manifest__.py
+++ b/l10n_ar_edi_ux/__manifest__.py
@@ -18,10 +18,12 @@
         "views/account_move_view.xml",
         "views/account_journal_view.xml",
         "views/l10n_ar_boarding_permission_view.xml",
+        "views/certificate_certificate_view.xml",
         "security/ir.model.access.csv",
     ],
     "demo": [
         "demo/res_partner_demo.xml",
+        "demo/res_company_demo.xml",
     ],
     "installable": True,
     "auto_install": True,

--- a/l10n_ar_edi_ux/demo/res_company_demo.xml
+++ b/l10n_ar_edi_ux/demo/res_company_demo.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!--
+        Demo hierarchy for branch / multi-company ARCA connection sharing.
+        Mirrors the hierarchy documented in tests/test_afip_connection_w_branches.py.
+
+            edi_ux_parent_company      CUIT 20313932975  HAS certificate
+              ├─ edi_ux_child_company      CUIT 20313932975  no certificate
+              │    └─ edi_ux_grandchild_company   no CUIT    no certificate
+              ├─ edi_ux_branch_diff_cuit   CUIT 30711017077  no certificate
+              ├─ edi_ux_branch_no_cuit     no CUIT           no certificate
+              └─ edi_ux_branch_with_cert   CUIT 30500010084  HAS certificate
+
+        The parent and the branch hold their own ARCA certificates (test certs
+        from l10n_ar_edi/tests/).  All companies point to the AFIP testing
+        environment so no real AFIP credentials are needed.
+    -->
+
+    <!-- ═══════════════════════════════════════════════════════════════════
+         Private key — shared, no company restriction
+         Using the test key from l10n_ar_edi/tests/ avoids company-crossover
+         validation errors that arise when key and certificate are created in
+         different company contexts during demo loading.
+         ═══════════════════════════════════════════════════════════════════ -->
+
+    <record id="edi_ux_demo_key" model="certificate.key">
+        <field name="name">ARCA Demo Key – hierarchy</field>
+        <field name="content" type="base64" file="l10n_ar_edi/tests/private_key.pem"/>
+    </record>
+
+    <!-- ═══════════════════════════════════════════════════════════════════
+         Certificates — no company restriction (shared demo certs)
+         test_cert1 / test_cert2 both carry serialNumber = CUIT 20313932975.
+         In production each company would hold a cert matching its own CUIT;
+         here we use test certs only to exercise the code paths:
+           • parent_company  → has cert → generates own token
+           • branch_with_cert → has cert → does NOT delegate to parent
+         ═══════════════════════════════════════════════════════════════════ -->
+
+    <record id="edi_ux_parent_cert" model="certificate.certificate">
+        <field name="name">Demo Cert – parent (CUIT 20313932975)</field>
+        <field name="content" type="base64" file="l10n_ar_edi/tests/test_cert1.crt"/>
+        <field name="private_key_id" ref="edi_ux_demo_key"/>
+    </record>
+
+    <record id="edi_ux_branch_cert" model="certificate.certificate">
+        <field name="name">Demo Cert – branch_with_cert (own cert)</field>
+        <field name="content" type="base64" file="l10n_ar_edi/tests/test_cert2.crt"/>
+        <field name="private_key_id" ref="edi_ux_demo_key"/>
+    </record>
+
+    <!-- ═══════════════════════════════════════════════════════════════════
+         Partners
+         Partners are created first so companies can reference them via
+         partner_id, which lets us set CUIT / fiscal data cleanly.
+         ═══════════════════════════════════════════════════════════════════ -->
+
+    <record id="edi_ux_parent_partner" model="res.partner">
+        <field name="name">AR Parent Company</field>
+        <field name="is_company" eval="True"/>
+        <field name="country_id" ref="base.ar"/>
+        <field name="l10n_latam_identification_type_id" ref="l10n_ar.it_cuit"/>
+        <field name="vat">20313932975</field>
+        <field name="l10n_ar_afip_responsibility_type_id" ref="l10n_ar.res_IVARI"/>
+    </record>
+
+    <record id="edi_ux_child_partner" model="res.partner">
+        <field name="name">Branch 1 (same CUIT no Cert)</field>
+        <field name="is_company" eval="True"/>
+        <field name="country_id" ref="base.ar"/>
+        <field name="l10n_latam_identification_type_id" ref="l10n_ar.it_cuit"/>
+        <field name="vat">20313932975</field>
+        <field name="l10n_ar_afip_responsibility_type_id" ref="l10n_ar.res_IVARI"/>
+    </record>
+
+    <!-- Grandchild intentionally has no CUIT -->
+    <record id="edi_ux_grandchild_partner" model="res.partner">
+        <field name="name">Grandchild Branch (no CUIT)</field>
+        <field name="is_company" eval="True"/>
+        <field name="country_id" ref="base.ar"/>
+    </record>
+
+    <record id="edi_ux_branch_diff_cuit_partner" model="res.partner">
+        <field name="name">Branch 2 (Diff CUIT no Cert)</field>
+        <field name="is_company" eval="True"/>
+        <field name="country_id" ref="base.ar"/>
+        <field name="l10n_latam_identification_type_id" ref="l10n_ar.it_cuit"/>
+        <field name="vat">30711017077</field>
+        <field name="l10n_ar_afip_responsibility_type_id" ref="l10n_ar.res_IVARI"/>
+    </record>
+
+    <!-- Branch sibling intentionally has no CUIT -->
+    <record id="edi_ux_branch_no_cuit_partner" model="res.partner">
+        <field name="name">Branch 3 (No CUIT no Cert)</field>
+        <field name="is_company" eval="True"/>
+        <field name="country_id" ref="base.ar"/>
+    </record>
+
+    <record id="edi_ux_branch_with_cert_partner" model="res.partner">
+        <field name="name">Branch 4 (Diff CUIT Own Cert)</field>
+        <field name="is_company" eval="True"/>
+        <field name="country_id" ref="base.ar"/>
+        <field name="l10n_latam_identification_type_id" ref="l10n_ar.it_cuit"/>
+        <field name="vat">30500010084</field>
+        <field name="l10n_ar_afip_responsibility_type_id" ref="l10n_ar.res_IVARI"/>
+    </record>
+
+    <!-- ═══════════════════════════════════════════════════════════════════
+         Companies (first pass — without certificates)
+         Certificates depend on keys which can only reference existing
+         companies, so we create the companies first and add the certs below.
+         ═══════════════════════════════════════════════════════════════════ -->
+
+    <!-- parent: CUIT 20313932975 — will receive certificate below -->
+    <record id="edi_ux_parent_company" model="res.company">
+        <field name="name">AR Parent Company</field>
+        <field name="partner_id" ref="edi_ux_parent_partner"/>
+        <field name="currency_id" ref="base.ARS"/>
+        <field name="country_id" ref="base.ar"/>
+        <field name="l10n_ar_afip_ws_environment">testing</field>
+        <field name="l10n_ar_afip_ws_crt_id" ref="edi_ux_parent_cert"/>
+    </record>
+
+    <!-- child: same CUIT as parent, no certificate -->
+    <record id="edi_ux_child_company" model="res.company">
+        <field name="name">Branch 1 (same CUIT no Cert)</field>
+        <field name="partner_id" ref="edi_ux_child_partner"/>
+        <field name="parent_id" ref="edi_ux_parent_company"/>
+        <field name="currency_id" ref="base.ARS"/>
+        <field name="country_id" ref="base.ar"/>
+        <field name="l10n_ar_afip_ws_environment">testing</field>
+    </record>
+
+    <!-- grandchild: no CUIT, no certificate -->
+    <record id="edi_ux_grandchild_company" model="res.company">
+        <field name="name">Grandchild Branch (no CUIT)</field>
+        <field name="partner_id" ref="edi_ux_grandchild_partner"/>
+        <field name="parent_id" ref="edi_ux_child_company"/>
+        <field name="currency_id" ref="base.ARS"/>
+        <field name="country_id" ref="base.ar"/>
+        <field name="l10n_ar_afip_ws_environment">testing</field>
+    </record>
+
+    <!-- branch_diff_cuit: CUIT 30711017077, no certificate -->
+    <record id="edi_ux_branch_diff_cuit" model="res.company">
+        <field name="name">Branch 2 (Diff CUIT no Cert)</field>
+        <field name="partner_id" ref="edi_ux_branch_diff_cuit_partner"/>
+        <field name="parent_id" ref="edi_ux_parent_company"/>
+        <field name="currency_id" ref="base.ARS"/>
+        <field name="country_id" ref="base.ar"/>
+        <field name="l10n_ar_afip_ws_environment">testing</field>
+    </record>
+
+    <!-- branch_no_cuit: no CUIT, no certificate -->
+    <record id="edi_ux_branch_no_cuit" model="res.company">
+        <field name="name">Branch 3 (No CUIT no Cert)</field>
+        <field name="partner_id" ref="edi_ux_branch_no_cuit_partner"/>
+        <field name="parent_id" ref="edi_ux_parent_company"/>
+        <field name="currency_id" ref="base.ARS"/>
+        <field name="country_id" ref="base.ar"/>
+        <field name="l10n_ar_afip_ws_environment">testing</field>
+    </record>
+
+    <!-- branch_with_cert: CUIT 30500010084 — will receive certificate below -->
+    <record id="edi_ux_branch_with_cert" model="res.company">
+        <field name="name">Branch 4 (Diff CUIT Own Cert)</field>
+        <field name="partner_id" ref="edi_ux_branch_with_cert_partner"/>
+        <field name="parent_id" ref="edi_ux_parent_company"/>
+        <field name="currency_id" ref="base.ARS"/>
+        <field name="country_id" ref="base.ar"/>
+        <field name="l10n_ar_afip_ws_environment">testing</field>
+        <field name="l10n_ar_afip_ws_crt_id" ref="edi_ux_branch_cert"/>
+    </record>
+
+    <!-- Grant admin access to all demo companies -->
+    <record id="base.user_admin" model="res.users">
+        <field name="company_ids" eval="[(4, ref('edi_ux_parent_company')), (4, ref('edi_ux_child_company')), (4, ref('edi_ux_grandchild_company')), (4, ref('edi_ux_branch_diff_cuit')), (4, ref('edi_ux_branch_no_cuit')), (4, ref('edi_ux_branch_with_cert'))]"/>
+    </record>
+
+</odoo>

--- a/l10n_ar_edi_ux/i18n/es.po
+++ b/l10n_ar_edi_ux/i18n/es.po
@@ -78,6 +78,11 @@ msgid "Automatic Update from Padron"
 msgstr "Actualización automática desde Padrón"
 
 #. module: l10n_ar_edi_ux
+#: model:ir.model.fields,field_description:l10n_ar_edi_ux.field_certificate_certificate__l10n_ar_subject_serial_number
+msgid "Belongs to"
+msgstr "Pertenece a"
+
+#. module: l10n_ar_edi_ux
 #: model:ir.model,name:l10n_ar_edi_ux.model_l10n_ar_boarding_permission
 msgid "Boarding Permission"
 msgstr "Permiso de embarque"
@@ -98,6 +103,23 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #. module: l10n_ar_edi_ux
+#: model:ir.model,name:l10n_ar_edi_ux.model_certificate_certificate
+msgid "Certificate"
+msgstr "Certificado"
+
+#. module: l10n_ar_edi_ux
+#. odoo-python
+#: code:addons/l10n_ar_edi_ux/models/res_company.py:0
+msgid ""
+"Certificate CUIT differ from Company's doc type and number. You can only use the ARCA certificate if it matches\n"
+" * certificate %s\n"
+" * company %s %s"
+msgstr ""
+"El CUIT del certificado difiere del tipo y número de documento de la empresa. Solo puede usar el certificado ARCA si coincide\n"
+" * certificado %s\n"
+" * empresa %s %s"
+
+#. module: l10n_ar_edi_ux
 #: model:ir.model.fields,help:l10n_ar_edi_ux.field_res_config_settings__arba_cit
 msgid "Clave de Identificación Tributaria de ARBA"
 msgstr ""
@@ -116,6 +138,26 @@ msgstr "Compañías"
 #: model:ir.model.fields,field_description:l10n_ar_edi_ux.field_l10n_ar_boarding_permission__company_id
 msgid "Company"
 msgstr "Empresa"
+
+#. module: l10n_ar_edi_ux
+#. odoo-python
+#: code:addons/l10n_ar_edi_ux/models/res_company.py:0
+msgid ""
+"Company \"%s\" has no ARCA certificate and no ancestor sharing the same CUIT"
+" was found. Please configure a certificate in the accounting settings."
+msgstr ""
+"La empresa \"%s\" no tiene certificado ARCA y no se encontró ningún padre"
+" con el mismo CUIT. Por favor configure un certificado en los ajustes de contabilidad."
+
+#. module: l10n_ar_edi_ux
+#. odoo-python
+#: code:addons/l10n_ar_edi_ux/models/res_company.py:0
+msgid ""
+"Company \"%s\" has no CUIT configured. A CUIT is required to get "
+"an ARCA connection."
+msgstr ""
+"La empresa \"%s\" no tiene CUIT configurado. Se requiere un CUIT para"
+" obtener una conexión ARCA."
 
 #. module: l10n_ar_edi_ux
 #: model:ir.model,name:l10n_ar_edi_ux.model_res_config_settings
@@ -415,6 +457,11 @@ msgstr "Campo"
 #: model_terms:ir.ui.view,arch_db:l10n_ar_edi_ux.view_base_partner_update_from_padron_form
 msgid "There are no more partners to update for this request..."
 msgstr "No hay más contactos para actualizar para esta solicitud..."
+
+#. module: l10n_ar_edi_ux
+#: model:ir.model.fields,help:l10n_ar_edi_ux.field_certificate_certificate__l10n_ar_subject_serial_number
+msgid "This is the CUIT information of the related ARCA Certificate."
+msgstr "Es el CUIT del certificado ARCA asociado."
 
 #. module: l10n_ar_edi_ux
 #. odoo-python

--- a/l10n_ar_edi_ux/models/__init__.py
+++ b/l10n_ar_edi_ux/models/__init__.py
@@ -2,6 +2,7 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
+from . import certificate_certificate
 from . import l10n_ar_afipws_connection
 from . import res_partner
 from . import account_move

--- a/l10n_ar_edi_ux/models/account_move.py
+++ b/l10n_ar_edi_ux/models/account_move.py
@@ -37,11 +37,13 @@ class AccountMove(models.Model):
             original_entry = (
                 self.mapped("invoice_line_ids.sale_line_ids.invoice_lines")
                 .filtered(
-                    lambda x: x.move_id.l10n_latam_document_type_id.country_id.code == "AR"
-                    and x.move_id.l10n_latam_document_type_id.internal_type
-                    != self.l10n_latam_document_type_id.internal_type
-                    and x.move_id.l10n_ar_afip_result in ["A", "O"]
-                    and x.move_id.l10n_ar_afip_auth_code
+                    lambda x: (
+                        x.move_id.l10n_latam_document_type_id.country_id.code == "AR"
+                        and x.move_id.l10n_latam_document_type_id.internal_type
+                        != self.l10n_latam_document_type_id.internal_type
+                        and x.move_id.l10n_ar_afip_result in ["A", "O"]
+                        and x.move_id.l10n_ar_afip_auth_code
+                    )
                 )
                 .mapped("move_id")
             )
@@ -197,3 +199,20 @@ class AccountMove(models.Model):
         )
         self.message_post(body=msg)
         return invalid_permissions
+
+    def _is_dummy_afip_validation(self):
+        # EXTENDS l10n_ar_edi
+        """Original method was not compatible with the new branch approarch.
+
+        With this extension we modify that logic: if we have not certificate, but have an ancestor
+        (parent, grandparent, …) that has certificate and shares the same CUIT, we skip the dummy
+        and force to continue with afip validation.  This supports multi-level branch hierarchies."""
+        self.ensure_one()
+        company = self.company_id
+        if (
+            company._get_environment_type() == "testing"
+            and not company.sudo().l10n_ar_afip_ws_crt_id
+            and company._l10n_ar_get_cert_ancestor()
+        ):
+            return False
+        return super()._is_dummy_afip_validation()

--- a/l10n_ar_edi_ux/models/certificate_certificate.py
+++ b/l10n_ar_edi_ux/models/certificate_certificate.py
@@ -1,0 +1,26 @@
+import base64
+
+from cryptography import x509
+from odoo import api, fields, models
+
+
+class CertificateCertificate(models.Model):
+    _inherit = "certificate.certificate"
+
+    l10n_ar_subject_serial_number = fields.Char(
+        compute="_compute_l10n_ar_subject_serial_number",
+        string="Belongs to",
+        help="This is the CUIT information of the related ARCA Certificate.",
+    )
+
+    @api.depends("pem_certificate")
+    def _compute_l10n_ar_subject_serial_number(self):
+        """Compute the subject serial number needed to then check if the afip connection can be
+        re use for multiple branches if they share the same certificate CUIT."""
+        for certificate in self:
+            pem_certificate = certificate.with_context(bin_size=False).pem_certificate
+            if not certificate.l10n_ar_subject_serial_number and pem_certificate:
+                cert = x509.load_pem_x509_certificate(base64.b64decode(pem_certificate))
+                l10n_ar_subject_serial_number = cert.subject.get_attributes_for_oid(x509.oid.NameOID.SERIAL_NUMBER)
+                if l10n_ar_subject_serial_number:
+                    certificate.l10n_ar_subject_serial_number = l10n_ar_subject_serial_number[0].value

--- a/l10n_ar_edi_ux/models/l10n_ar_afipws_connection.py
+++ b/l10n_ar_edi_ux/models/l10n_ar_afipws_connection.py
@@ -26,3 +26,9 @@ class L10nArAfipwsConnection(models.Model):
             }
         }
         return ws_data.get(afip_ws, {}).get(environment_type)
+
+    def _l10n_ar_get_token_data(self, company, afip_ws):
+        # EXTEND l10n_ar_edi
+        """We want to check first if the certificate match with the company CUIT before trying to get token data"""
+        company._check_match_between_certificate_and_company()
+        return super()._l10n_ar_get_token_data(company, afip_ws)

--- a/l10n_ar_edi_ux/models/res_company.py
+++ b/l10n_ar_edi_ux/models/res_company.py
@@ -1,4 +1,5 @@
-from odoo import api, models
+from odoo import _, api, models
+from odoo.exceptions import UserError
 
 
 class ResCompany(models.Model):
@@ -6,9 +7,97 @@ class ResCompany(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        for vals in vals_list:
+            # When creating new branch, the env should be initializated with the same value
+            # as the parent company to avoid issues
+            if "l10n_ar_afip_ws_environment" not in vals and vals.get("parent_id"):
+                parent = self.browse(vals["parent_id"])
+                if parent.l10n_ar_afip_ws_environment:
+                    vals["l10n_ar_afip_ws_environment"] = parent.l10n_ar_afip_ws_environment
         companies = super().create(vals_list)
         for company in companies:
             if company.country_id.code == "AR":
                 key = f"l10n_ar_edi.{company.id}_foreign_currency_payment"
                 self.env["ir.config_parameter"].sudo().set_param(key, "account")
         return companies
+
+    def _l10n_ar_get_cert_ancestor(self):
+        """Return the nearest ancestor that shares the same CUIT and has an ARCA
+        certificate configured. Walks the full parent chain so that multi-level
+        branch hierarchies are supported (e.g. grandchild → child → parent with
+        cert).  Returns an empty recordset when no such ancestor exists.
+
+        Uses partner_id.l10n_ar_vat (normalized via stdnum.ar.cuit.compact) for
+        comparison so that different VAT formats (with/without dashes) are handled
+        correctly."""
+        self.ensure_one()
+        my_vat = self.partner_id.l10n_ar_vat
+        if not my_vat:
+            return self.env["res.company"]
+        ancestor = self.parent_id
+        while ancestor:
+            if ancestor.partner_id.l10n_ar_vat == my_vat and ancestor.sudo().l10n_ar_afip_ws_crt_id:
+                return ancestor
+            ancestor = ancestor.parent_id
+        return self.env["res.company"]
+
+    def _l10n_ar_get_connection(self, afip_ws):
+        # EXTEND l10n_ar_edi
+        """We adapt this method to be able to share connections between branches
+        and parents that share the same CUIT number.
+
+        Supports multi-level hierarchies: if this company has no certificate it
+        walks up the parent chain (via _l10n_ar_get_cert_ancestor) to find the
+        first ancestor with the same CUIT that owns a certificate, then
+        delegates the connection lookup to that ancestor.
+
+        If no ancestor with a matching cert is found, raises a clear UserError.
+
+        A missing CUIT on a branch that has a parent is detected early and
+        reported with a clear message."""
+        self.ensure_one()
+        if not self.sudo().l10n_ar_afip_ws_crt_id and self.parent_id:
+            if not self.vat:
+                raise UserError(
+                    _(
+                        'Company "%s" has no CUIT configured. A CUIT is required to get an ARCA connection.',
+                        self.name,
+                    )
+                )
+            cert_ancestor = self._l10n_ar_get_cert_ancestor()
+            if cert_ancestor:
+                return super(ResCompany, cert_ancestor)._l10n_ar_get_connection(afip_ws)
+            raise UserError(
+                _(
+                    'Company "%s" has no ARCA certificate and no ancestor sharing the same CUIT '
+                    "was found. Please configure a certificate in the accounting settings.",
+                    self.name,
+                )
+            )
+
+        return super()._l10n_ar_get_connection(afip_ws)
+
+    def _check_match_between_certificate_and_company(self):
+        """Check if the CUIT of the company match with the one in the certificate:
+        - if match, continue with the normal flow to get token data
+        - if not match, raise an error showing the difference between the
+        certificate and company CUIT so the user can fix the configurations.
+
+        Example: certificate.l10n_ar_subject_serial_number store = "CUIT 30111111118" """
+        self.ensure_one()
+        certificate_sudo = self.sudo().l10n_ar_afip_ws_crt_id
+        if certificate_sudo and (
+            not self.partner_id.l10n_ar_vat
+            or certificate_sudo.l10n_ar_subject_serial_number != "CUIT %s" % self.partner_id.vat
+        ):
+            raise UserError(
+                _(
+                    "Certificate CUIT differ from Company's doc type and number. You can only use the ARCA certificate"
+                    " if it matches\n * certificate %s\n * company %s %s"
+                )
+                % (
+                    certificate_sudo.l10n_ar_subject_serial_number,
+                    self.partner_id.l10n_latam_identification_type_id.name,
+                    self.partner_id.vat,
+                )
+            )

--- a/l10n_ar_edi_ux/tests/__init__.py
+++ b/l10n_ar_edi_ux/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_padron_afip
+from . import test_afip_connection_w_branches

--- a/l10n_ar_edi_ux/tests/test_afip_connection_w_branches.py
+++ b/l10n_ar_edi_ux/tests/test_afip_connection_w_branches.py
@@ -1,0 +1,424 @@
+import base64
+from contextlib import contextmanager
+from datetime import timedelta
+from unittest.mock import patch
+
+from odoo import fields
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase, tagged
+from odoo.tools import file_open
+
+
+@tagged("post_install", "-at_install")
+class TestAfipConnection(TransactionCase):
+    """Tests for the ARCA/AFIP connection extensions added by l10n_ar_edi_ux.
+
+    Covers two related features:
+    - _l10n_ar_get_connection: branch companies without a certificate delegate
+      ARCA token generation to the nearest ancestor that shares the same CUIT
+      and holds a certificate.  Multi-level hierarchies are supported.
+    - _check_match_between_certificate_and_company: raises a clear UserError when
+      the CUIT embedded in the certificate subject differs from the company's CUIT.
+
+    Hierarchy under test:
+
+        parent_company          CUIT 20313932975  HAS certificate   (grandparent)
+          ├─ child_company      CUIT 20313932975  no certificate    (child / invoicing company)
+          │    └─ grandchild_company   no CUIT    no certificate    (grandchild)
+          ├─ branch_diff_cuit   CUIT 30711017077  no certificate    (sibling, different CUIT)
+          ├─ branch_no_cuit     no CUIT           no certificate    (sibling, no CUIT)
+          └─ branch_with_cert   CUIT 30500010084  HAS certificate   (sibling, different CUIT, own cert)
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        ar_country = cls.env.ref("base.ar")
+        ar_currency = cls.env.ref("base.ARS")
+        cuit_type = cls.env.ref("l10n_ar.it_cuit")
+        afip_ri = cls.env.ref("l10n_ar.res_IVARI")
+
+        # Shared private key (satisfies the certificate FK)
+        cls.ar_key = cls.env["certificate.key"].create(
+            {
+                "name": "Test RSA Key",
+                "content": base64.b64encode(file_open("l10n_ar_edi/tests/private_key.pem", "rb").read()),
+            }
+        )
+
+        # test_cert1.crt has serialNumber = "CUIT 20313932975"
+        cls.ar_certificate = cls.env["certificate.certificate"].create(
+            {
+                "name": "Test Cert (CUIT 20313932975)",
+                "content": base64.b64encode(file_open("l10n_ar_edi/tests/test_cert1.crt", "rb").read()),
+                "private_key_id": cls.ar_key.id,
+            }
+        )
+
+        # ---------- parent company: has certificate, CUIT 20313932975 ----------
+        cls.parent_company = cls.env["res.company"].create(
+            {"name": "Test Parent Company", "currency_id": ar_currency.id, "country_id": ar_country.id}
+        )
+        cls.parent_company.partner_id.write(
+            {
+                "l10n_latam_identification_type_id": cuit_type.id,
+                "vat": "20313932975",
+                "l10n_ar_afip_responsibility_type_id": afip_ri.id,
+                "country_id": ar_country.id,
+            }
+        )
+        cls.parent_company.write(
+            {
+                "l10n_ar_afip_ws_environment": "testing",
+                "l10n_ar_afip_ws_crt_id": cls.ar_certificate.id,
+            }
+        )
+
+        # ---------- child: same CUIT as parent, no certificate ----------
+        cls.child_company = cls.env["res.company"].create(
+            {
+                "name": "Test Branch 1 (same CUIT no Cert)",
+                "parent_id": cls.parent_company.id,
+                "currency_id": ar_currency.id,
+                "country_id": ar_country.id,
+            }
+        )
+        cls.child_company.partner_id.write(
+            {
+                "l10n_latam_identification_type_id": cuit_type.id,
+                "vat": "20313932975",
+                "l10n_ar_afip_responsibility_type_id": afip_ri.id,
+                "country_id": ar_country.id,
+            }
+        )
+        cls.child_company.write({"l10n_ar_afip_ws_environment": "testing"})
+
+        # ---------- grandchild: no CUIT, no certificate, parent = child ----------
+        cls.grandchild_company = cls.env["res.company"].create(
+            {
+                "name": "Test Grandchild Branch (no CUIT)",
+                "parent_id": cls.child_company.id,
+                "currency_id": ar_currency.id,
+                "country_id": ar_country.id,
+            }
+        )
+        # partner intentionally left without CUIT
+        cls.grandchild_company.write({"l10n_ar_afip_ws_environment": "testing"})
+
+        # ---------- sibling without CUIT: no certificate ----------
+        cls.branch_no_cuit = cls.env["res.company"].create(
+            {
+                "name": "Test Branch 3 (No CUIT no Cert)",
+                "parent_id": cls.parent_company.id,
+                "currency_id": ar_currency.id,
+                "country_id": ar_country.id,
+            }
+        )
+        # partner intentionally left without CUIT
+        cls.branch_no_cuit.write({"l10n_ar_afip_ws_environment": "testing"})
+
+        # ---------- sibling with a different CUIT: no certificate ----------
+        cls.branch_diff_cuit = cls.env["res.company"].create(
+            {
+                "name": "TestBranch 2 (Diff CUIT no Cert)",
+                "parent_id": cls.parent_company.id,
+                "currency_id": ar_currency.id,
+                "country_id": ar_country.id,
+            }
+        )
+        cls.branch_diff_cuit.partner_id.write(
+            {
+                "l10n_latam_identification_type_id": cuit_type.id,
+                "vat": "30711017077",
+                "l10n_ar_afip_responsibility_type_id": afip_ri.id,
+                "country_id": ar_country.id,
+            }
+        )
+        cls.branch_diff_cuit.write({"l10n_ar_afip_ws_environment": "testing"})
+
+        # ---------- sibling with a different CUIT: HAS its own certificate ----------
+        cls.branch_with_cert = cls.env["res.company"].create(
+            {
+                "name": "Test Branch 4 (Diff CUIT Own Cert)",
+                "parent_id": cls.parent_company.id,
+                "currency_id": ar_currency.id,
+                "country_id": ar_country.id,
+            }
+        )
+        cls.branch_with_cert.partner_id.write(
+            {
+                "l10n_latam_identification_type_id": cuit_type.id,
+                "vat": "30500010084",
+                "l10n_ar_afip_responsibility_type_id": afip_ri.id,
+                "country_id": ar_country.id,
+            }
+        )
+        cls.branch_with_cert.write(
+            {
+                "l10n_ar_afip_ws_environment": "testing",
+                "l10n_ar_afip_ws_crt_id": cls.ar_certificate.id,
+            }
+        )
+
+        # ---------- companies for certificate CUIT validation ----------
+        cls.company_matching = cls.env["res.company"].create(
+            {"name": "Company CUIT Matches Cert", "currency_id": ar_currency.id, "country_id": ar_country.id}
+        )
+        cls.company_matching.partner_id.write(
+            {
+                "l10n_latam_identification_type_id": cuit_type.id,
+                "vat": "20313932975",
+                "l10n_ar_afip_responsibility_type_id": afip_ri.id,
+                "country_id": ar_country.id,
+            }
+        )
+        cls.company_matching.write({"l10n_ar_afip_ws_crt_id": cls.ar_certificate.id})
+
+        cls.company_mismatch = cls.env["res.company"].create(
+            {"name": "Company CUIT Mismatches Cert", "currency_id": ar_currency.id, "country_id": ar_country.id}
+        )
+        cls.company_mismatch.partner_id.write(
+            {
+                "l10n_latam_identification_type_id": cuit_type.id,
+                "vat": "30711017077",
+                "l10n_ar_afip_responsibility_type_id": afip_ri.id,
+                "country_id": ar_country.id,
+            }
+        )
+        cls.company_mismatch.write({"l10n_ar_afip_ws_crt_id": cls.ar_certificate.id})
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @contextmanager
+    def _mock_token_generation(self):
+        """Patch _l10n_ar_get_token_data to avoid real AFIP network calls.
+
+        Yields a list that is populated with every ``company`` argument received
+        by the patched method, so tests can assert which company's certificate
+        was used for token generation.
+
+        A regular function (not a Mock) is used as the replacement so that
+        Python's descriptor protocol correctly binds the connection record as
+        ``self`` — ensuring the ``company`` argument is captured at the right
+        position.
+        """
+        now = fields.Datetime.now()
+        fake_token = {
+            "token": "mock-afip-token",
+            "sign": "mock-afip-sign",
+            "generation_time": now,
+            "expiration_time": now + timedelta(hours=12),
+        }
+        companies_used = []
+
+        def _fake_get_token_data(self_conn, company, afip_ws):
+            companies_used.append(company)
+            return fake_token
+
+        AfipwsConnectionCls = type(self.env["l10n_ar.afipws.connection"])
+        with patch.object(AfipwsConnectionCls, "_l10n_ar_get_token_data", _fake_get_token_data):
+            yield companies_used
+
+    def _get_connection(self, company, afip_ws="wsfe"):
+        """Thin wrapper that skips the DB commit injected by the base method."""
+        return company.with_context(l10n_ar_invoice_skip_commit=True)._l10n_ar_get_connection(afip_ws)
+
+    # ------------------------------------------------------------------
+    # _l10n_ar_get_connection tests
+    # ------------------------------------------------------------------
+
+    def test_05_child_generates_token_using_parent_certificate(self):
+        """Invoicing from Child (same CUIT, no cert) must use Parent's certificate.
+
+        When no pre-existing connection exists the base method calls
+        _l10n_ar_get_token_data to create a fresh AFIP token.  The override
+        must route that call to parent_company (the ancestor with the cert),
+        and the resulting connection record must be stored under parent_company.
+
+        Hierarchy:
+          parent_company  (CUIT 20313932975, cert)
+            └─ child_company  (CUIT 20313932975, no cert)   ← invoicing company
+        """
+        with self._mock_token_generation() as companies_used:
+            connection = self._get_connection(self.child_company)
+
+        self.assertEqual(len(companies_used), 1, "Exactly one token request expected")
+        self.assertEqual(
+            companies_used[0],
+            self.parent_company,
+            "Token must be generated using parent_company's certificate, not child's",
+        )
+        self.assertEqual(
+            connection.company_id,
+            self.parent_company,
+            "The created connection must be owned by parent_company",
+        )
+        self.assertEqual(connection.token, "mock-afip-token")
+
+    def test_10_branch_diff_cuit_wo_cert_raise_when_generates_own_token(self):
+        """Branch with a different CUIT and no certificate must raise a UserError.
+
+        branch_diff_cuit has a CUIT that differs from every ancestor's CUIT, so
+        _l10n_ar_get_cert_ancestor() returns empty.  The override must raise
+        early with a descriptive message before any token generation is attempted.
+
+        Hierarchy:
+          parent_company     (CUIT 20313932975, cert)
+            └─ branch_diff_cuit  (CUIT 30711017077, no cert)   ← this company
+        """
+        with self._mock_token_generation() as companies_used:
+            with self.assertRaises(UserError) as ctx:
+                self._get_connection(self.branch_diff_cuit)
+
+        error_message = str(ctx.exception)
+        self.assertIn(self.branch_diff_cuit.name, error_message)
+        self.assertEqual(
+            companies_used,
+            [],
+            "No token must be requested when no cert ancestor exists for the company's CUIT",
+        )
+
+    def test_15_branch_with_own_cert_uses_own_certificate(self):
+        """Branch that holds its own certificate must NOT delegate to the parent.
+
+        The override condition ``not self.sudo().l10n_ar_afip_ws_crt_id`` is False
+        when the branch already has a certificate, so _l10n_ar_get_connection
+        falls straight through to the standard super() path and generates the
+        token for the branch itself — never for parent_company.
+
+        Hierarchy:
+          parent_company       (CUIT 20313932975, cert)
+            └─ branch_with_cert  (CUIT 30711017077, HAS own cert)   ← invoicing company
+        """
+        with self._mock_token_generation() as companies_used:
+            connection = self._get_connection(self.branch_with_cert)
+
+        self.assertEqual(len(companies_used), 1)
+        self.assertEqual(
+            companies_used[0],
+            self.branch_with_cert,
+            "Token must be generated using branch_with_cert's own certificate, " "not delegated to parent_company",
+        )
+        self.assertEqual(connection.company_id, self.branch_with_cert)
+
+    def test_20_branch_no_cuit_raises_before_token_request(self):
+        """Grandchild without CUIT must raise a UserError before any token is requested.
+
+        When a branch has no CUIT it is impossible to find a matching ancestor;
+        _l10n_ar_get_connection must raise early with a message that identifies
+        the company and explains the missing data.
+
+        Hierarchy:
+          parent_company  (CUIT 20313932975, cert)
+            └─ child_company  (CUIT 20313932975, no cert)
+                 └─ grandchild_company  (no CUIT, no cert)   ← this company
+        """
+        with self._mock_token_generation() as companies_used:
+            with self.assertRaises(UserError) as ctx:
+                self._get_connection(self.grandchild_company)
+
+        error_message = str(ctx.exception)
+        self.assertIn(self.grandchild_company.name, error_message)
+        self.assertIn("CUIT", error_message)
+        self.assertEqual(
+            companies_used,
+            [],
+            "No token must be requested when the company has no CUIT",
+        )
+
+    def test_25_branch_sibling_no_cuit_raises_before_token_request(self):
+        """Sibling branch without CUIT must raise a UserError before any token is requested.
+
+        Even though the parent holds a certificate, the branch has no CUIT so
+        _l10n_ar_get_cert_ancestor() cannot find a matching ancestor.
+        _l10n_ar_get_connection must raise early and never attempt token generation.
+
+        Hierarchy:
+          parent_company  (CUIT 20313932975, cert)
+            ├─ child_company   (CUIT 20313932975, no cert)
+            └─ branch_no_cuit  (no CUIT, no cert)   ← this company
+        """
+        with self._mock_token_generation() as companies_used:
+            with self.assertRaises(UserError) as ctx:
+                self._get_connection(self.branch_no_cuit)
+
+        error_message = str(ctx.exception)
+        self.assertIn(self.branch_no_cuit.name, error_message)
+        self.assertIn("CUIT", error_message)
+        self.assertEqual(
+            companies_used,
+            [],
+            "No token must be requested when the sibling branch has no CUIT",
+        )
+
+    def test_30_three_level_hierarchy_token_generated_for_grandparent(self):
+        """3-level hierarchy: grandchild (same CUIT, no cert) skips intermediate
+        (no cert) and generates the token using grandparent's certificate.
+
+        This test validates the _l10n_ar_get_cert_ancestor() helper that walks
+        the full parent chain.  Without it, the delegation to the intermediate
+        would bypass the edi_ux override and the token would be (incorrectly)
+        requested with the intermediate company which has no cert.
+
+        Hierarchy:
+          parent_company          (CUIT A, cert)       <- grandparent with cert
+            └─ child_company      (CUIT A, no cert)    <- intermediate, no cert
+                 └─ grandchild_same_cuit  (CUIT A, no cert)   <- invoicing company
+        """
+        grandchild_same_cuit = self.env["res.company"].create(
+            {
+                "name": "Grandchild Same CUIT",
+                "parent_id": self.child_company.id,
+                "currency_id": self.env.ref("base.ARS").id,
+                "country_id": self.env.ref("base.ar").id,
+            }
+        )
+        grandchild_same_cuit.partner_id.write(
+            {
+                "l10n_latam_identification_type_id": self.env.ref("l10n_ar.it_cuit").id,
+                "vat": "20313932975",
+                "l10n_ar_afip_responsibility_type_id": self.env.ref("l10n_ar.res_IVARI").id,
+                "country_id": self.env.ref("base.ar").id,
+            }
+        )
+        grandchild_same_cuit.write({"l10n_ar_afip_ws_environment": "testing"})
+
+        with self._mock_token_generation() as companies_used:
+            connection = self._get_connection(grandchild_same_cuit)
+
+        self.assertEqual(len(companies_used), 1)
+        self.assertEqual(
+            companies_used[0],
+            self.parent_company,
+            "Token must be generated for grandparent (the ancestor with the cert), "
+            "not the intermediate child which has no cert",
+        )
+        self.assertEqual(
+            connection.company_id,
+            self.parent_company,
+            "Connection must be owned by the grandparent, not the intermediate",
+        )
+
+    # ------------------------------------------------------------------
+    # _check_match_between_certificate_and_company tests
+    # ------------------------------------------------------------------
+
+    def test_35_check_certificate_match_does_not_raise(self):
+        """When company CUIT equals certificate CUIT no UserError is raised."""
+        try:
+            self.company_matching._check_match_between_certificate_and_company()
+        except UserError as exc:
+            self.fail(f"Unexpected UserError for matching CUITs: {exc}")
+
+    def test_40_check_certificate_mismatch_raises_user_error(self):
+        """When company CUIT differs from certificate CUIT a UserError is raised
+        with both CUITs in the message."""
+        with self.assertRaises(UserError) as ctx:
+            self.company_mismatch._check_match_between_certificate_and_company()
+
+        error_message = str(ctx.exception)
+        self.assertIn("CUIT 20313932975", error_message)
+        self.assertIn("30711017077", error_message)

--- a/l10n_ar_edi_ux/views/certificate_certificate_view.xml
+++ b/l10n_ar_edi_ux/views/certificate_certificate_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="certificate_certificate_view_form" model="ir.ui.view">
+        <field name="name">certificate_certificate_view_form.inherit.l10n_cl_edi</field>
+        <field name="model">certificate.certificate</field>
+        <field name="inherit_id" ref="certificate.certificate_certificate_view_form"/>
+        <field name="arch" type="xml">
+
+            <!-- Mostrar el número de serie del sujeto si es un certificado argentino -->
+            <field name="serial_number" position="after">
+                <field name="l10n_ar_subject_serial_number" invisible="country_code != 'AR'"/>
+            </field>
+
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Backport of #1038 to 18.0.

- Allow branch companies without their own certificate to reuse an ancestor's ARCA/AFIP connection when they share the same CUIT
- Expose the certificate subject serial number (CUIT) on certificates to improve traceability and validation
- Support multi-level branch hierarchies when searching for a valid certificate owner
- Validate that the certificate CUIT matches the company's identification data before requesting token data and raise clear UserError messages on mismatch
- Prevent branches without CUIT or without a matching certified ancestor from using ARCA with explicit configuration errors
- Inherit ARCA environment from parent company on branch creation when not explicitly defined
- Adapt dummy AFIP validation in testing to work with delegated branch connections
- Add demo data, translations and automated tests covering branch connections delegation, CUIT mismatch and multi-level scenarios

Resolves Adhoc Ticket 117555