### PR TITLE
[REF] l10n_ar_account_reports, l10n_ar_currency_update: make user messages translatable

### DIFF
--- a/l10n_ar_account_reports/i18n/es.po
+++ b/l10n_ar_account_reports/i18n/es.po
@@ -323,12 +323,12 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #: model:ir.model,name:l10n_ar_account_reports.model_account_return
 msgid "Accounting Return"
-msgstr "Declaración contable"
+msgstr "Declaración de impuestos"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model,name:l10n_ar_account_reports.model_account_return_type
 msgid "Accounting Return Type"
-msgstr "Tipo de Declaración contable"
+msgstr "Tipo de declaración de impuestos"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_activo
@@ -345,47 +345,45 @@ msgstr "Activos intangibles"
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
-msgid "Ajuste por inflación %s"
-msgstr ""
+msgid "Inflation Adjustment %s"
+msgstr "Ajuste por inflación %s"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
-msgid "Ajuste por inflación %s (%s * %.2f%%)"
-msgstr ""
+msgid "Inflation adjustment %s (%s * %.2f%%)"
+msgstr "Ajuste por inflación %s (%s * %.2f%%)"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
-msgid "Ajuste por inflación Global [%s] / [%s]"
-msgstr ""
+msgid "Global Inflation Adjustment [%s] / [%s]"
+msgstr "Ajuste por inflación Global [%s] / [%s]"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
-msgid "Ajuste por inflación cuentas al inicio (%s * %.2f%%)"
-msgstr ""
+msgid "Inflation adjustment opening balances (%s * %.2f%%)"
+msgstr "Ajuste por inflación cuentas al inicio (%s * %.2f%%)"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/tucuman_report.py:0
-#, fuzzy
 msgid ""
+"Some documents do not contain information about the street/city/province/"
+"postal code of the contact:\n"
+" %s"
+msgstr ""
 "Algunos comprobantes no contienen información acerca de la calle/ciudad/"
 "provincia/cod postal del contacto:\n"
 " %s"
-msgstr ""
-"Algunos comprobantes no contienen información acerca de la calle/ciudad/"
-"provincia/cod postal del contacto:\n"
-" %s"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/tucuman_report.py:0
-#, fuzzy
 msgid ""
-"Algunos comprobantes rectificativos no contienen información de que "
-"comprobante original están revirtiendo:\n"
+"Some corrective documents do not contain information about which original "
+"document they are reversing:\n"
 " %s"
 msgstr ""
 "Algunos comprobantes rectificativos no contienen información de que "
@@ -395,11 +393,9 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/tucuman_report.py:0
-#, fuzzy
 msgid ""
-"Algunos comprobantes tienen punto de venta de 5 dígitos y deben tener de 4 "
-"dígitos para poder generar el archivo txt de retenciones y percepciones de "
-"Tucuman:\n"
+"Some documents have a 5-digit point of sale but must have a 4-digit one to "
+"generate the Tucuman withholdings and perceptions TXT file:\n"
 " %s"
 msgstr ""
 "Algunos comprobantes tienen punto de venta de 5 dígitos y deben tener de 4 "
@@ -461,22 +457,26 @@ msgid "Argentinian Tucumán Report Custom Handler"
 msgstr "Gestor personalizado de informes Argentinos Tucumán"
 
 #. module: l10n_ar_account_reports
-#. odoo-python
-#: code:addons/l10n_ar_account_reports/models/account_return.py:0
 #: model:ir.actions.act_window,name:l10n_ar_account_reports.inflation_adjustment_action
 #: model:ir.ui.menu,name:l10n_ar_account_reports.inflation_adjustment_menu
 msgid "Asiento de ajuste por inflación"
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
+msgid "Inflation Adjustment Entry"
+msgstr "Asiento de ajuste por inflación"
+
+#. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__open_move_id
-msgid "Asiento de apertura"
-msgstr ""
+msgid "Opening Entry"
+msgstr "Asiento de apertura"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__closure_move_id
-msgid "Asiento de cierre"
-msgstr ""
+msgid "Closing Entry"
+msgstr "Asiento de cierre"
 
 #. module: l10n_ar_account_reports
 #: model:account.report,settlement_title:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados
@@ -546,8 +546,8 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/account_return.py:0
-msgid "Cheques a fecha"
-msgstr ""
+msgid "Post-dated Checks"
+msgstr "Cheques a fecha"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__company_id
@@ -605,25 +605,31 @@ msgstr "Fecha Hasta"
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
 msgid ""
-"Debe establecer el tipo de inscripción de IIBB del partner "
+"You must set the IIBB registration type for partner "
 "\"%(partner_name)s\" (id: %(partner_id)s)"
 msgstr ""
+"Debe establecer el tipo de inscripción de IIBB del partner "
+"\"%(partner_name)s\" (id: %(partner_id)s)"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
 msgid ""
-"Debe establecer la información de \"artículo/inciso\" en la configuración "
-"del impuesto \"%(tax_name)s\"en la solapa \"API\"."
+"You must set the \"article/section\" information in the configuration of tax "
+"\"%(tax_name)s\" in the \"API\" tab."
 msgstr ""
+"Debe establecer la información de \"artículo/inciso\" en la configuración "
+"del impuesto \"%(tax_name)s\" en la solapa \"API\"."
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
 msgid ""
-"Debe setear el tipo de inscripción de IIBB del contacto "
+"You must set the IIBB registration type for contact "
 "\"%(partner_name)s\" (id: %(partner_id)s)"
 msgstr ""
+"Debe setear el tipo de inscripción de IIBB del contacto "
+"\"%(partner_name)s\" (id: %(partner_id)s)"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_account_return_type__default_deadline_periodicity
@@ -680,58 +686,66 @@ msgstr ""
 #: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
 #: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
 msgid "Edit tax"
-msgstr ""
+msgstr "Editar impuesto"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
 #: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
-msgid "Editar contacto"
-msgstr ""
+msgid "Edit contact"
+msgstr "Editar contacto"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
 msgid ""
+"The inflation adjustment entry cannot be generated because the adjustment "
+"index for period %(month)s %(year)s is missing"
+msgstr ""
 "El asiento de ajuste por inflación no puede ser generado ya que hace falta "
 "el indice de ajuste para el periodo %(month)s %(year)s"
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
 msgid ""
+"The contact \"%(partner_name)s\" (id %(partner_id)s) must have the "
+"identification type CUIT, CUIL, or CDI."
+msgstr ""
 "El contacto \"%(partner_name)s\" (id %(partner_id)s), debe tener el tipo de "
 "identificación CUIT, CUIL, CDI."
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/l10n_ar_vat_ret_perc_sufrido.py:0
 msgid ""
+"The regime code must have 3 digits in the configuration of tax "
+"\"%(tax_name)s\""
+msgstr ""
 "El código de régimen tiene que tener 3 dígitos en la configuración del "
 "impuesto \"%(tax_name)s\""
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
-msgid "El impuesto no está asociado"
-msgstr ""
+msgid "The tax is not associated"
+msgstr "El impuesto no está asociado"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
 msgid ""
+"The partner \"%(partner_name)s\" (id %(partner_id)s) does not have an "
+"identification number set"
+msgstr ""
 "El partner \"%(partner_name)s\" (id %(partner_id)s) no tiene número de "
 "identificación establecido"
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/inflation_adjustment_index.py:0
-msgid "El índice debe comenzar el primer día de cada mes"
-msgstr ""
+msgid "The index must start on the first day of each month"
+msgstr "El índice debe comenzar el primer día de cada mes"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__end_index
@@ -788,13 +802,13 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/account_return.py:0
-msgid "Generar el asiento de ajuste por inflación para el período fiscal."
-msgstr ""
+msgid "Generate the inflation adjustment journal entry for the fiscal period."
+msgstr "Generar el asiento de ajuste por inflación para el período fiscal."
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__open_cloure_entry
-msgid "Ha realizado asientos de cierre/apertura?"
-msgstr ""
+msgid "Has Closing/Opening Entries?"
+msgstr "¿Ha realizado asientos de cierre/apertura?"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_account_chart_template__id
@@ -928,24 +942,29 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/sifere_report.py:0
 msgid ""
+"The perception %s (id: %d) of the document \"%s\" (id: %d) has no associated "
+"contact."
+msgstr ""
 "La percepción %s (id: %d) del comprobante \"%s\" (id: %d) no tiene contacto "
 "asociado."
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
 msgid ""
-"La responsabilidad frente a IVA \"%s\" no está soportada para ret/perc AGIP"
+"The VAT responsibility \"%s\" is not supported for AGIP withholding/perception"
 msgstr ""
+"La responsabilidad frente a IVA \"%s\" no está soportada para ret/perc AGIP"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
 msgid ""
+"The VAT responsibility \"%s\" is not supported for Santa Fe "
+"withholding/perception"
+msgstr ""
 "La responsabilidad frente a IVA \"%s\" no está soportada para ret/perc Santa "
 "Fe"
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__write_uid
@@ -973,32 +992,39 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/l10n_ar_vat_ret_perc_sufrido.py:0
 msgid ""
-"No hay código de régimen en la configuración del impuesto \"%(tax_name)s\""
+"There is no regime code in the configuration of tax \"%(tax_name)s\""
 msgstr ""
+"No hay código de régimen en la configuración del impuesto \"%(tax_name)s\""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
 msgid ""
+"There is no jurisdiction set in the tax \"%(tax_name)s\" or it does not have "
+"a jurisdiction code."
+msgstr ""
 "No hay jurisdicción establecida en el impuesto \"%(tax_name)s\" o no tiene "
 "código de jurisdicción."
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
 msgid ""
+"There is no withholding regime (ARCA Code 'l10n_ar_code') configured for tax "
+"'%(tax_name)s' of partner '%(partner_name)s'"
+msgstr ""
 "No hay regimen de retencion (ARCA Code 'l10n_ar_code') configurado para el "
 "impuesto '%(tax_name)s' del partner '%(partner_name)s'"
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
 msgid ""
+"There is no perception regime (ARCA Code 'l10n_ar_code') configured for tax: "
+"'%(tax_name)s'."
+msgstr ""
 "No hay régimen de percepción (ARCA Code 'l10n_ar_code') configurado para el "
 "impuesto: '%(tax_name)s'."
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model_terms:ir.actions.act_window,help:l10n_ar_account_reports.inflation_adjustment_index_action
@@ -1009,26 +1035,31 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
 msgid ""
+"No journal entries to adjust were found for the selected period."
+msgstr ""
 "No hemos encontrado ningún asiento contable para ajustar asociado al periodo "
 "seleccionado."
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
 msgid ""
+"Could not find the original document for %s (id %s). Please verify that in "
+"the credit note \"%s\", the origin field contains the original invoice number"
+msgstr ""
 "No pudimos encontrar el comprobante original para %s (id %s). Verifique que "
 "en la nota de crédito \"%s\", el campo origen es el número de la factura "
 "original"
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
 msgid ""
+"No inflation adjustment index was found for the previous date (%s). "
+"Please configure the corresponding index."
+msgstr ""
 "No se encontró un índice de ajuste por inflación para la fecha anterior "
 "(%s). Por favor, configure el índice correspondiente."
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_other_liabilities
@@ -1113,8 +1144,8 @@ msgstr "Periodicidad"
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
-msgid "Por favor indique el rango de fecha de inicio y fin"
-msgstr ""
+msgid "Please specify the start and end date range"
+msgstr "Por favor indique el rango de fecha de inicio y fin"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_provisions
@@ -1206,9 +1237,11 @@ msgstr "Asistente de creación de Declaración"
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/account_return.py:0
 msgid ""
+"Review and process third-party checks with deferred payment dates "
+"pending at period close."
+msgstr ""
 "Revisar y procesar los cheques de terceros con fecha de pago diferida "
 "pendientes al cierre del período."
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #: model:account.return.type,name:l10n_ar_account_reports.sicore_return_type
@@ -1260,15 +1293,17 @@ msgstr "Buscar Descripción"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields.selection,name:l10n_ar_account_reports.selection__inflation_adjustment__open_cloure_entry__yes
-msgid "Si"
-msgstr ""
+msgid "Yes"
+msgstr "Sí"
 
 #. module: l10n_ar_account_reports
 #: model:ir.model.fields,help:l10n_ar_account_reports.field_inflation_adjustment__open_cloure_entry
 msgid ""
+"If you have made the closing/opening entries, please indicate them so they "
+"can be excluded from the calculation."
+msgstr ""
 "Si usted ha realizado los asientos de cierre/apertura debe indicarnos cuales "
 "son para poder excluir los mismos en el cálculo."
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
@@ -1352,14 +1387,14 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
-msgid "Tipo de comprobante no reconocido"
-msgstr ""
+msgid "Unrecognized document type"
+msgstr "Tipo de comprobante no reconocido"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
-msgid "Tipo de impuesto %s equivocado"
-msgstr ""
+msgid "Wrong tax type %s"
+msgstr "Tipo de impuesto %s equivocado"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_assets
@@ -1415,9 +1450,11 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/inflation_adjustment_index.py:0
 msgid ""
+"An index already exists for period %s %s. You can only have one inflation "
+"index per month"
+msgstr ""
 "Ya existe un índice para el periodo %s %s. Solo puedes tener un índice de "
 "inflación por mes"
-msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python

--- a/l10n_ar_account_reports/i18n/l10n_ar_account_reports.pot
+++ b/l10n_ar_account_reports/i18n/l10n_ar_account_reports.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-15 18:57+0000\n"
-"PO-Revision-Date: 2026-05-15 18:57+0000\n"
+"POT-Creation-Date: 2026-05-28 11:55+0000\n"
+"PO-Revision-Date: 2026-05-28 11:55+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -334,6 +334,14 @@ msgid ""
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/inflation_adjustment_index.py:0
+msgid ""
+"An index already exists for period %s %s. You can only have one inflation "
+"index per month"
+msgstr ""
+
+#. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_advances_from_customers
 msgid "Anticipos de clientes"
 msgstr ""
@@ -389,16 +397,6 @@ msgstr ""
 #: model:ir.actions.act_window,name:l10n_ar_account_reports.inflation_adjustment_action
 #: model:ir.ui.menu,name:l10n_ar_account_reports.inflation_adjustment_menu
 msgid "Asiento de ajuste por inflación"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__open_move_id
-msgid "Asiento de apertura"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__closure_move_id
-msgid "Asiento de cierre"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -471,6 +469,11 @@ msgid "Cheques a fecha"
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__closure_move_id
+msgid "Closing Entry"
+msgstr ""
+
+#. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__company_id
 msgid "Company"
 msgstr ""
@@ -483,6 +486,15 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_cogs
 msgid "Costo de venta de bienes y servicios"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+msgid ""
+"Could not find the original document for %s (id %s). Please verify that in "
+"the credit note \"%s\", the origin field contains the original invoice "
+"number"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -593,6 +605,13 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_dividends_payable
 msgid "Dividendos a pagar"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+#: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
+msgid "Edit contact"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -713,8 +732,20 @@ msgid "Generar el asiento de ajuste por inflación para el período fiscal."
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
+msgid "Generate the inflation adjustment journal entry for the fiscal period."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid "Global Inflation Adjustment [%s] / [%s]"
+msgstr ""
+
+#. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__open_cloure_entry
-msgid "Ha realizado asientos de cierre/apertura?"
+msgid "Has Closing/Opening Entries?"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -795,6 +826,13 @@ msgid ""
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#: model:ir.model.fields,help:l10n_ar_account_reports.field_inflation_adjustment__open_cloure_entry
+msgid ""
+"If you have made the closing/opening entries, please indicate them so they "
+"can be excluded from the calculation."
+msgstr ""
+
+#. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_tax_inc
 msgid "Impuesto a las ganancias"
 msgstr ""
@@ -811,6 +849,18 @@ msgid "Inflation Adjustment"
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid "Inflation Adjustment %s"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
+msgid "Inflation Adjustment Entry"
+msgstr ""
+
+#. module: l10n_ar_account_reports
 #: model:ir.model,name:l10n_ar_account_reports.model_inflation_adjustment_index
 msgid "Inflation Adjustment Index"
 msgstr ""
@@ -818,6 +868,18 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #: model:ir.model,name:l10n_ar_account_reports.model_inflation_adjustment
 msgid "Inflation adjustment"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid "Inflation adjustment %s (%s * %.2f%%)"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid "Inflation adjustment opening balances (%s * %.2f%%)"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -930,6 +992,20 @@ msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid ""
+"No inflation adjustment index was found for the previous date (%s). Please "
+"configure the corresponding index."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid "No journal entries to adjust were found for the selected period."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
 msgid ""
 "No pudimos encontrar el comprobante original para %s (id %s). Verifique que "
@@ -943,6 +1019,11 @@ msgstr ""
 msgid ""
 "No se encontró un índice de ajuste por inflación para la fecha anterior "
 "(%s). Por favor, configure el índice correspondiente."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__open_move_id
+msgid "Opening Entry"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -1028,7 +1109,19 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid "Please specify the start and end date range"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
 msgid "Por favor indique el rango de fecha de inicio y fin"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
+msgid "Post-dated Checks"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -1121,6 +1214,14 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/account_return.py:0
 msgid ""
+"Review and process third-party checks with deferred payment dates pending at"
+" period close."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
+msgid ""
 "Revisar y procesar los cheques de terceros con fecha de pago diferida "
 "pendientes al cierre del período."
 msgstr ""
@@ -1174,21 +1275,33 @@ msgid "Search Description"
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:ir.model.fields.selection,name:l10n_ar_account_reports.selection__inflation_adjustment__open_cloure_entry__yes
-msgid "Si"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#: model:ir.model.fields,help:l10n_ar_account_reports.field_inflation_adjustment__open_cloure_entry
-msgid ""
-"Si usted ha realizado los asientos de cierre/apertura debe indicarnos cuales"
-" son para poder excluir los mismos en el cálculo."
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sicore_report.py:0
+msgid "Sicore Profits Withholdings TXT"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
-#: code:addons/l10n_ar_account_reports/models/sicore_report.py:0
-msgid "Sicore Profits Withholdings TXT"
+#: code:addons/l10n_ar_account_reports/models/tucuman_report.py:0
+msgid ""
+"Some corrective documents do not contain information about which original document they are reversing:\n"
+" %s"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/tucuman_report.py:0
+msgid ""
+"Some documents do not contain information about the street/city/province/postal code of the contact:\n"
+" %s"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/tucuman_report.py:0
+msgid ""
+"Some documents have a 5-digit point of sale but must have a 4-digit one to generate the Tucuman withholdings and perceptions TXT file:\n"
+" %s"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -1215,6 +1328,30 @@ msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+msgid ""
+"The VAT responsibility \"%s\" is not supported for AGIP "
+"withholding/perception"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
+msgid ""
+"The VAT responsibility \"%s\" is not supported for Santa Fe "
+"withholding/perception"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+msgid ""
+"The contact \"%(partner_name)s\" (id %(partner_id)s) must have the "
+"identification type CUIT, CUIL, or CDI."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
 #: code:addons/l10n_ar_account_reports/models/account_move.py:0
 msgid ""
 "The following document(s) have an invalid document number format.\n"
@@ -1233,6 +1370,28 @@ msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
+#: code:addons/l10n_ar_account_reports/models/inflation_adjustment_index.py:0
+msgid "The index must start on the first day of each month"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/wizard/inflation_adjustment.py:0
+msgid ""
+"The inflation adjustment entry cannot be generated because the adjustment "
+"index for period %(month)s %(year)s is missing"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+msgid ""
+"The partner \"%(partner_name)s\" (id %(partner_id)s) does not have an "
+"identification number set"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
 #: code:addons/l10n_ar_account_reports/models/sicore_report.py:0
 msgid ""
 "The partner \"%(partner_name)s\" (id %(partner_id)s) does not have the vat "
@@ -1247,10 +1406,62 @@ msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sifere_report.py:0
+msgid ""
+"The perception %s (id: %d) of the document \"%s\" (id: %d) has no associated"
+" contact."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/l10n_ar_vat_ret_perc_sufrido.py:0
+msgid ""
+"The regime code must have 3 digits in the configuration of tax "
+"\"%(tax_name)s\""
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
 #: code:addons/l10n_ar_account_reports/models/account_return.py:0
 msgid ""
 "The return type '%s' has no payment partner configured. Please set a Payment"
 " Partner on the return type."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+msgid "The tax is not associated"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
+msgid ""
+"There is no jurisdiction set in the tax \"%(tax_name)s\" or it does not have"
+" a jurisdiction code."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
+msgid ""
+"There is no perception regime (ARCA Code 'l10n_ar_code') configured for tax:"
+" '%(tax_name)s'."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/l10n_ar_vat_ret_perc_sufrido.py:0
+msgid "There is no regime code in the configuration of tax \"%(tax_name)s\""
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
+msgid ""
+"There is no withholding regime (ARCA Code 'l10n_ar_code') configured for tax"
+" '%(tax_name)s' of partner '%(partner_name)s'"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -1306,6 +1517,12 @@ msgid "Total pasivo no corriente"
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
+msgid "Unrecognized document type"
+msgstr ""
+
+#. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment_index__value
 msgid "Value"
 msgstr ""
@@ -1317,10 +1534,45 @@ msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
+#: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
+msgid "Wrong tax type %s"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
 #: code:addons/l10n_ar_account_reports/models/inflation_adjustment_index.py:0
 msgid ""
 "Ya existe un índice para el periodo %s %s. Solo puedes tener un índice de "
 "inflación por mes"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:ir.model.fields.selection,name:l10n_ar_account_reports.selection__inflation_adjustment__open_cloure_entry__yes
+msgid "Yes"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
+msgid ""
+"You must set the \"article/section\" information in the configuration of tax"
+" \"%(tax_name)s\" in the \"API\" tab."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/caba_report.py:0
+msgid ""
+"You must set the IIBB registration type for contact \"%(partner_name)s\" "
+"(id: %(partner_id)s)"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
+msgid ""
+"You must set the IIBB registration type for partner \"%(partner_name)s\" "
+"(id: %(partner_id)s)"
 msgstr ""
 
 #. module: l10n_ar_account_reports

--- a/l10n_ar_account_reports/models/account_return.py
+++ b/l10n_ar_account_reports/models/account_return.py
@@ -298,10 +298,9 @@ class AccountReturn(models.Model):
             )
             ar_checks.append(
                 {
-                    "name": _("Cheques a fecha"),
+                    "name": _("Post-dated Checks"),
                     "message": _(
-                        "Revisar y procesar los cheques de terceros con fecha de pago diferida "
-                        "pendientes al cierre del período."
+                        "Review and process third-party checks with deferred payment dates " "pending at period close."
                     ),
                     "code": "l10n_ar_cheques_a_fecha",
                     "action": action,
@@ -313,8 +312,8 @@ class AccountReturn(models.Model):
             action = self.env["ir.actions.actions"]._for_xml_id("l10n_ar_account_reports.inflation_adjustment_action")
             ar_checks.append(
                 {
-                    "name": _("Asiento de ajuste por inflación"),
-                    "message": _("Generar el asiento de ajuste por inflación para el período fiscal."),
+                    "name": _("Inflation Adjustment Entry"),
+                    "message": _("Generate the inflation adjustment journal entry for the fiscal period."),
                     "code": "l10n_ar_inflation_adjustment",
                     "action": action,
                     "result": "todo",

--- a/l10n_ar_account_reports/models/caba_report.py
+++ b/l10n_ar_account_reports/models/caba_report.py
@@ -107,12 +107,12 @@ class L10n_ArCabaReportHandler(models.AbstractModel):
             if not partner.vat:
                 raise RedirectWarning(
                     message=_(
-                        'El partner "%(partner_name)s" (id %(partner_id)s) no tiene número de identificación establecido',
+                        'The partner "%(partner_name)s" (id %(partner_id)s) does not have an identification number set',
                         partner_name=partner.name,
                         partner_id=partner.id,
                     ),
                     action=partner.get_formview_action(),
-                    button_text=_("Editar contacto"),
+                    button_text=_("Edit contact"),
                 )
             alicuot = tax.amount
 
@@ -196,7 +196,7 @@ class L10n_ArCabaReportHandler(models.AbstractModel):
                     other_taxes_amount = company_currency.round(total_amount - taxable_amount - vat_amount)
                     # other_taxes_amount = line.move_id.cc_other_taxes_amount
                 else:
-                    raise UserError(_("El impuesto no está asociado"))
+                    raise UserError(_("The tax is not associated"))
 
                 # 8 - Monto del comprobante
                 content += format_amount(total_amount, 16, 2, ",")
@@ -213,13 +213,13 @@ class L10n_ArCabaReportHandler(models.AbstractModel):
                 ]:
                     raise RedirectWarning(
                         message=_(
-                            'El contacto "%(partner_name)s" (id %(partner_id)s), debe tener el tipo de identificación'
-                            " CUIT, CUIL, CDI.",
+                            'The contact "%(partner_name)s" (id %(partner_id)s) must have the identification type'
+                            " CUIT, CUIL, or CDI.",
                             partner_name=partner.name,
                             partner_id=partner.id,
                         ),
                         action=partner.get_formview_action(),
-                        button_text=_("Editar contacto"),
+                        button_text=_("Edit contact"),
                     )
                 doc_type_mapping = {"CUIT": "3", "CUIL": "2", "CDI": "1"}
                 content += doc_type_mapping[partner.l10n_latam_identification_type_id.name]
@@ -233,12 +233,12 @@ class L10n_ArCabaReportHandler(models.AbstractModel):
                 if not partner.l10n_ar_gross_income_type:
                     raise RedirectWarning(
                         message=self.env._(
-                            'Debe setear el tipo de inscripción de IIBB del contacto "%(partner_name)s" (id: %(partner_id)s)',
+                            'You must set the IIBB registration type for contact "%(partner_name)s" (id: %(partner_id)s)',
                             partner_name=partner.name,
                             partner_id=partner.id,
                         ),
                         action=partner.get_formview_action(),
-                        button_text=self.env._("Editar contacto"),
+                        button_text=self.env._("Edit contact"),
                     )
 
                 # ahora se reportaria para cualquier inscripto el numero de cuit
@@ -271,7 +271,7 @@ class L10n_ArCabaReportHandler(models.AbstractModel):
                     content += "4"
                 else:
                     raise UserError(
-                        _('La responsabilidad frente a IVA "%s" no está soportada para ret/perc AGIP') % res_iva.name
+                        _('The VAT responsibility "%s" is not supported for AGIP withholding/perception') % res_iva.name
                     )
 
                 # 15 - Razón Social del Retenido
@@ -345,9 +345,9 @@ class L10n_ArCabaReportHandler(models.AbstractModel):
         if not or_inv:
             raise UserError(
                 _(
-                    "No pudimos encontrar el comprobante original para %s "
-                    '(id %s). Verifique que en la nota de crédito "%s", el'
-                    " campo origen es el número de la factura original"
+                    "Could not find the original document for %s "
+                    '(id %s). Please verify that in the credit note "%s", the'
+                    " origin field contains the original invoice number"
                 )
                 % (
                     line.move_id.display_name,

--- a/l10n_ar_account_reports/models/inflation_adjustment_index.py
+++ b/l10n_ar_account_reports/models/inflation_adjustment_index.py
@@ -43,7 +43,7 @@ class InflationAdjustmentIndex(models.Model):
             if len(repeated) > 1 or repeated.id != rec.id:
                 rec_date = fields.Date.from_string(rec.date)
                 raise ValidationError(
-                    _("Ya existe un índice para el periodo %s %s. Solo puedes tener un índice de inflación por mes")
+                    _("An index already exists for period %s %s. You can only have one inflation index per month")
                     % (rec_date.strftime("%B"), rec_date.year)
                 )
 
@@ -52,7 +52,7 @@ class InflationAdjustmentIndex(models.Model):
         for rec in self:
             date = fields.Date.from_string(rec.date)
             if date.day != 1:
-                raise ValidationError(_("El índice debe comenzar el primer día de cada mes"))
+                raise ValidationError(_("The index must start on the first day of each month"))
 
     @api.constrains("date")
     def check_xml_id(self):

--- a/l10n_ar_account_reports/models/l10n_ar_vat_ret_perc_sufrido.py
+++ b/l10n_ar_account_reports/models/l10n_ar_vat_ret_perc_sufrido.py
@@ -96,7 +96,7 @@ class L10n_ArIvaReportHandler(models.AbstractModel):
                 if not codigo_regimen:
                     raise RedirectWarning(
                         message=_(
-                            'No hay código de régimen en la configuración del impuesto "%(tax_name)s"',
+                            'There is no regime code in the configuration of tax "%(tax_name)s"',
                             tax_name=line_withholding_tax.name,
                         ),
                         action=line_withholding_tax.get_formview_action(),
@@ -105,7 +105,7 @@ class L10n_ArIvaReportHandler(models.AbstractModel):
                 if len(codigo_regimen) < 3:
                     raise RedirectWarning(
                         message=_(
-                            'El código de régimen tiene que tener 3 dígitos en la configuración del impuesto "%(tax_name)s"',
+                            'The regime code must have 3 digits in the configuration of tax "%(tax_name)s"',
                             tax_name=line_withholding_tax.name,
                         ),
                         action=line_withholding_tax.get_formview_action(),
@@ -135,7 +135,7 @@ class L10n_ArIvaReportHandler(models.AbstractModel):
                 if not codigo_regimen:
                     raise RedirectWarning(
                         message=_(
-                            'No hay código de régimen en la configuración del impuesto "%(tax_name)s"',
+                            'There is no regime code in the configuration of tax "%(tax_name)s"',
                             tax_name=tax.name,
                         ),
                         action=tax.get_formview_action(),
@@ -144,7 +144,7 @@ class L10n_ArIvaReportHandler(models.AbstractModel):
                 if len(codigo_regimen) < 3:
                     raise RedirectWarning(
                         message=_(
-                            'El código de régimen tiene que tener 3 dígitos en la configuración del impuesto "%(tax_name)s"',
+                            'The regime code must have 3 digits in the configuration of tax "%(tax_name)s"',
                             tax_name=tax.name,
                         ),
                         action=tax.get_formview_action(),

--- a/l10n_ar_account_reports/models/santa_fe_report.py
+++ b/l10n_ar_account_reports/models/santa_fe_report.py
@@ -100,13 +100,13 @@ class L10n_ArSantaFeReportHandler(models.AbstractModel):
                 articulo_inciso_calculo = tax.api_articulo_inciso_calculo_retencion
                 articulo_inciso_retiene = tax.api_codigo_articulo_retencion
             else:
-                raise UserError(_("Tipo de impuesto %s equivocado") % (tax.tax_group_id.name))
+                raise UserError(_("Wrong tax type %s") % (tax.tax_group_id.name))
 
             if not articulo_inciso_calculo or not articulo_inciso_retiene:
                 raise RedirectWarning(
                     message=_(
-                        'Debe establecer la información de "artículo/inciso" en la configuración del impuesto "%(tax_name)s"'
-                        'en la solapa "API".',
+                        'You must set the "article/section" information in the configuration of tax "%(tax_name)s"'
+                        ' in the "API" tab.',
                         tax_name=tax.name,
                     ),
                     action=tax.get_formview_action(),
@@ -179,12 +179,12 @@ class L10n_ArSantaFeReportHandler(models.AbstractModel):
             if not gross_income_type:
                 raise RedirectWarning(
                     message=_(
-                        'Debe establecer el tipo de inscripción de IIBB del partner "%(partner_name)s" (id: %(partner_id)s)',
+                        'You must set the IIBB registration type for partner "%(partner_name)s" (id: %(partner_id)s)',
                         partner_name=partner.name,
                         partner_id=partner.id,
                     ),
                     action=partner.get_formview_action(),
-                    button_text=_("Editar contacto"),
+                    button_text=_("Edit contact"),
                 )
             if gross_income_type in ["multilateral", "local"]:
                 content += "1"
@@ -211,7 +211,7 @@ class L10n_ArSantaFeReportHandler(models.AbstractModel):
                 content += "4"
             else:
                 raise UserError(
-                    _('La responsabilidad frente a IVA "%s" no está soportada para ret/perc Santa Fe') % res_iva.name
+                    _('The VAT responsibility "%s" is not supported for Santa Fe withholding/perception') % res_iva.name
                 )
 
             # 14 - Marca inscripción Otros Gravámenes

--- a/l10n_ar_account_reports/models/sifere_report.py
+++ b/l10n_ar_account_reports/models/sifere_report.py
@@ -130,7 +130,7 @@ class L10n_ArSifereReportHandler(models.AbstractModel):
 
             if not line.partner_id:
                 raise UserError(
-                    _('La percepción %s (id: %d) del comprobante "%s" (id: %d) no tiene contacto asociado.')
+                    _('The perception %s (id: %d) of the document "%s" (id: %d) has no associated contact.')
                     % (line.withholding_id.name, line.id, line.move_id.name, line.move_id.id)
                 )
             line.partner_id.ensure_vat()

--- a/l10n_ar_account_reports/models/sircar_report.py
+++ b/l10n_ar_account_reports/models/sircar_report.py
@@ -126,7 +126,7 @@ class L10n_ArSircarReportHandler(models.AbstractModel):
                 if not tax.l10n_ar_code:
                     raise RedirectWarning(
                         message=_(
-                            "No hay regimen de retencion (ARCA Code 'l10n_ar_code') configurado para el impuesto '%(tax_name)s' del partner '%(partner_name)s'",
+                            "There is no withholding regime (ARCA Code 'l10n_ar_code') configured for tax '%(tax_name)s' of partner '%(partner_name)s'",
                             tax_name=tax.name,
                             partner_name=line.partner_id.name,
                         ),
@@ -140,7 +140,7 @@ class L10n_ArSircarReportHandler(models.AbstractModel):
                 if not tax.l10n_ar_state_id.jurisdiction_code or not tax.l10n_ar_state_id.jurisdiction_code:
                     raise RedirectWarning(
                         message=_(
-                            'No hay jurisdicción establecida en el impuesto "%(tax_name)s" o no tiene código de jurisdicción.',
+                            'There is no jurisdiction set in the tax "%(tax_name)s" or it does not have a jurisdiction code.',
                             tax_name=tax.name,
                         ),
                         action=tax.get_formview_action(),
@@ -192,7 +192,7 @@ class L10n_ArSircarReportHandler(models.AbstractModel):
                 elif line.move_id.type == "out_refund":
                     tipo_comprobante = 120
                 else:
-                    raise UserError(_("Tipo de comprobante no reconocido"))
+                    raise UserError(_("Unrecognized document type"))
                 content.append("%03d" % tipo_comprobante)
 
                 # 3 Letra del comprobante
@@ -221,7 +221,7 @@ class L10n_ArSircarReportHandler(models.AbstractModel):
                 if not tax.l10n_ar_code:
                     raise RedirectWarning(
                         message=_(
-                            "No hay régimen de percepción (ARCA Code 'l10n_ar_code') configurado para el impuesto: '%(tax_name)s'.",
+                            "There is no perception regime (ARCA Code 'l10n_ar_code') configured for tax: '%(tax_name)s'.",
                             tax_name=tax.name,
                         ),
                         action=tax.get_formview_action(),
@@ -234,7 +234,7 @@ class L10n_ArSircarReportHandler(models.AbstractModel):
                 if not tax.l10n_ar_state_id.jurisdiction_code or not tax.l10n_ar_state_id.jurisdiction_code:
                     raise RedirectWarning(
                         message=_(
-                            'No hay jurisdicción establecida en el impuesto "%(tax_name)s" o no tiene código de jurisdicción.',
+                            'There is no jurisdiction set in the tax "%(tax_name)s" or it does not have a jurisdiction code.',
                             tax_name=tax.name,
                         ),
                         action=tax.get_formview_action(),
@@ -279,7 +279,7 @@ class L10n_ArSircarReportHandler(models.AbstractModel):
         elif related_invoice.move_type == "out_refund":
             document_type = 120
         else:
-            raise UserError(_("Tipo de comprobante no reconocido"))
+            raise UserError(_("Unrecognized document type"))
         res += str(document_type)[:1]
 
         # 3 Letra del comprobante

--- a/l10n_ar_account_reports/models/tucuman_report.py
+++ b/l10n_ar_account_reports/models/tucuman_report.py
@@ -108,8 +108,8 @@ class L10n_ArTucumanReportHandler(models.AbstractModel):
         ):
             raise UserError(
                 _(
-                    "Algunos comprobantes rectificativos no contienen información de que "
-                    "comprobante original están revirtiendo:\n %s"
+                    "Some corrective documents do not contain information about which "
+                    "original document they are reversing:\n %s"
                 )
                 % (", ".join(nc_without_reversed_entry_id.mapped("move_id.name")))
             )
@@ -121,8 +121,8 @@ class L10n_ArTucumanReportHandler(models.AbstractModel):
         ):
             raise UserError(
                 _(
-                    "Algunos comprobantes no contienen información acerca de la calle/ciudad/provincia/cod "
-                    "postal del contacto:\n %s"
+                    "Some documents do not contain information about the street/city/province/postal "
+                    "code of the contact:\n %s"
                 )
                 % (", ".join(moves_without_street_city_state.mapped("move_id.name")))
             )
@@ -135,8 +135,8 @@ class L10n_ArTucumanReportHandler(models.AbstractModel):
         if move_lines_with_five_digits_pos:
             raise UserError(
                 _(
-                    "Algunos comprobantes tienen punto de venta de 5 dígitos y deben tener de 4 dígitos para "
-                    "poder generar el archivo txt de retenciones y percepciones de Tucuman:\n %s"
+                    "Some documents have a 5-digit point of sale but must have a 4-digit one to "
+                    "generate the Tucuman withholdings and perceptions TXT file:\n %s"
                 )
                 % (", ".join(move_lines_with_five_digits_pos.mapped("move_id.name")))
             )

--- a/l10n_ar_account_reports/wizard/inflation_adjustment.py
+++ b/l10n_ar_account_reports/wizard/inflation_adjustment.py
@@ -33,19 +33,19 @@ class InflationAdjustment(models.TransientModel):
         compute="_compute_index",
     )
     open_cloure_entry = fields.Selection(
-        [("yes", "Si"), ("no", "No")],
-        string="Ha realizado asientos de cierre/apertura?",
+        [("yes", "Yes"), ("no", "No")],
+        string="Has Closing/Opening Entries?",
         default="no",
-        help="Si usted ha realizado los asientos de cierre/apertura debe"
-        " indicarnos cuales son para poder excluir los mismos en el cálculo.",
+        help="If you have made the closing/opening entries, please indicate them"
+        " so they can be excluded from the calculation.",
     )
     closure_move_id = fields.Many2one(
         "account.move",
-        string="Asiento de cierre",
+        string="Closing Entry",
     )
     open_move_id = fields.Many2one(
         "account.move",
-        string="Asiento de apertura",
+        string="Opening Entry",
     )
 
     def get_account_id(self, line):
@@ -95,7 +95,7 @@ class InflationAdjustment(models.TransientModel):
             end_index = self.env["inflation.adjustment.index"].find(end_date).value
 
         if not start_date or not end_date:
-            raise UserError(_("Por favor indique el rango de fecha de inicio y fin"))
+            raise UserError(_("Please specify the start and end date range"))
 
         res = []
 
@@ -109,7 +109,7 @@ class InflationAdjustment(models.TransientModel):
             index = indexes.filtered(lambda x: x.date >= start_date and x.date <= date_to)
             if not index:
                 message = _(
-                    "El asiento de ajuste por inflación no puede ser generado ya que hace falta el indice de ajuste para el periodo %(month)s %(year)s"
+                    "The inflation adjustment entry cannot be generated because the adjustment index for period %(month)s %(year)s is missing"
                 ) % {
                     "month": start_date.strftime("%B"),
                     "year": start_date.year,
@@ -167,8 +167,8 @@ class InflationAdjustment(models.TransientModel):
         if not before_index:
             raise UserError(
                 _(
-                    "No se encontró un índice de ajuste por inflación para la fecha anterior (%s). "
-                    "Por favor, configure el índice correspondiente."
+                    "No inflation adjustment index was found for the previous date (%s). "
+                    "Please configure the corresponding index."
                 )
                 % format_date(self.env, before_date_from)
             )
@@ -183,7 +183,7 @@ class InflationAdjustment(models.TransientModel):
             lines.append(
                 {
                     "account_id": self.get_account_id(line),
-                    "name": _("Ajuste por inflación cuentas al inicio (%s * %.2f%%)")
+                    "name": _("Inflation adjustment opening balances (%s * %.2f%%)")
                     % (FormatAmount(line.get("balance")), initial_factor * 100.0),
                     "date_maturity": before_date_from,
                     "debit" if adjustment > 0 else "credit": abs(adjustment),
@@ -209,7 +209,7 @@ class InflationAdjustment(models.TransientModel):
                 lines.append(
                     {
                         "account_id": self.get_account_id(line),
-                        "name": _("Ajuste por inflación %s (%s * %.2f%%)")
+                        "name": _("Inflation adjustment %s (%s * %.2f%%)")
                         % (
                             format_date(self.env, date_from, date_format="MM/Y"),
                             FormatAmount(line.get("balance")),
@@ -222,16 +222,14 @@ class InflationAdjustment(models.TransientModel):
                 adjustment_total["debit" if adjustment > 0 else "credit"] += abs(adjustment)
 
         if not lines:
-            raise UserError(
-                _("No hemos encontrado ningún asiento contable para ajustar asociado al periodo seleccionado.")
-            )
+            raise UserError(_("No journal entries to adjust were found for the selected period."))
 
         # Generate total amount adjustment line
         adj_diff = adjustment_total.get("debit", 0.0) - adjustment_total.get("credit", 0.0)
         lines.append(
             {
                 "account_id": self.account_id.id,
-                "name": _("Ajuste por inflación Global [%s] / [%s]") % (self.date_from, self.date_to),
+                "name": _("Global Inflation Adjustment [%s] / [%s]") % (self.date_from, self.date_to),
                 "debit" if adj_diff < 0 else "credit": abs(adj_diff),
                 "date_maturity": self.date_to,
             }
@@ -245,7 +243,7 @@ class InflationAdjustment(models.TransientModel):
                 {
                     "journal_id": self.journal_id.id,
                     "date": self.date_to,
-                    "ref": _("Ajuste por inflación %s") % (date_to.year),
+                    "ref": _("Inflation Adjustment %s") % (date_to.year),
                     "line_ids": [(0, 0, line_data) for line_data in lines],
                 }
             )

--- a/l10n_ar_currency_update/i18n/es.po
+++ b/l10n_ar_currency_update/i18n/es.po
@@ -70,11 +70,15 @@ msgstr "ID (identificación)"
 #. odoo-python
 #: code:addons/l10n_ar_currency_update/models/res_currency.py:0
 msgid ""
+"Cannot change the name/code of %(currencies)s as it has an ARCA Code "
+"defined.\n"
+"Doing so would affect both the automatic currency rate synchronization "
+"service and the electronic invoicing service."
+msgstr ""
 "No se puede cambiar el nombre/código de %(currencies)s ya que tiene un "
-"Código ARCA definido. \n"
+"Código ARCA definido.\n"
 "Hacerlo repercutiría tanto en el servicio de sincronización automática de "
 "tasa de cambio como en el servicio de facturación electrónica."
-msgstr ""
 
 #. module: l10n_ar_currency_update
 #: model:ir.model.fields,field_description:l10n_ar_currency_update.field_res_company__rate_perc

--- a/l10n_ar_currency_update/i18n/l10n_ar_currency_update.pot
+++ b/l10n_ar_currency_update/i18n/l10n_ar_currency_update.pot
@@ -63,8 +63,10 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_currency_update/models/res_currency.py:0
 msgid ""
-"No se puede cambiar el nombre/código de %(currencies)s ya que tiene un Código ARCA definido. \n"
-"Hacerlo repercutiría tanto en el servicio de sincronización automática de tasa de cambio como en el servicio de facturación electrónica."
+"Cannot change the name/code of %(currencies)s as it has an ARCA Code "
+"defined.\n"
+"Doing so would affect both the automatic currency rate synchronization "
+"service and the electronic invoicing service."
 msgstr ""
 
 #. module: l10n_ar_currency_update

--- a/l10n_ar_currency_update/models/res_currency.py
+++ b/l10n_ar_currency_update/models/res_currency.py
@@ -12,8 +12,8 @@ class ResCurrency(models.Model):
             if renamed_protected:
                 raise UserError(
                     _(
-                        "No se puede cambiar el nombre/código de %(currencies)s ya que tiene un Código ARCA definido. \n"
-                        "Hacerlo repercutiría tanto en el servicio de sincronización automática de tasa de cambio como en el servicio de facturación electrónica.",
+                        "Cannot change the name/code of %(currencies)s as it has an ARCA Code defined.\n"
+                        "Doing so would affect both the automatic currency rate synchronization service and the electronic invoicing service.",
                         currencies=", ".join(renamed_protected.mapped("name")),
                     )
                 )

--- a/l10n_ar_currency_update/tests/test_l10n_ar_currency_update.py
+++ b/l10n_ar_currency_update/tests/test_l10n_ar_currency_update.py
@@ -199,7 +199,7 @@ class TestL10nArCurrencyUpdate(TransactionCase):
         )
 
     def test_protected_currency_name_cannot_be_changed(self):
-        with self.assertRaisesRegex(UserError, "No se puede cambiar el nombre/código"):
+        with self.assertRaisesRegex(UserError, "Cannot change the name/code"):
             self.USD.write({"name": "USX"})
 
     def test_non_protected_currency_name_can_be_changed(self):


### PR DESCRIPTION
Move user-facing strings hardcoded in Spanish inside _() calls (and field string=/help= in Python) to English, following Odoo i18n convention (English msgid, Spanish translation in es.po).
Regenerate .pot files.
Add Spanish translations in es.po for all converted strings.
Modules affected: l10n_ar_account_reports (9 Python files: sifere_report, caba_report, santa_fe_report, sircar_report, l10n_ar_vat_ret_perc_sufrido, tucuman_report, account_return, inflation_adjustment_index, wizard/inflation_adjustment) and l10n_ar_currency_update (1 Python file: models/res_currency).