### PR TITLE
[FIX] l10n_ar_arba_ws: no enviar retenciones con importe cero a ARBA

### DIFF
--- a/l10n_ar_arba_ws/models/l10n_ar_payment_withholding.py
+++ b/l10n_ar_arba_ws/models/l10n_ar_payment_withholding.py
@@ -35,5 +35,5 @@ class L10nArPaymentWithholding(models.Model):
 
     def send_to_arba(self):
         """Send the withholding to ARBA webservice and store the certificate number"""
-        for withholding in self.filtered(lambda x: not x.l10n_ar_cert_number):
+        for withholding in self.filtered(lambda x: not x.l10n_ar_cert_number and x.amount > 0):
             withholding.l10n_ar_dj_arba_id._create_withholding(withholding)


### PR DESCRIPTION
## Problema

Se estaban enviando al webservice de ARBA retenciones con importe igual
a cero, lo cual no representa una retención real y puede generar
comprobantes inválidos.
Error que soluciona:
Cuando el importe de una retención da cero, el campo name (número de
secuencia) queda como "/" — comportamiento incorporado en
https://github.com/ingadhoc/odoo-argentina/pull/1164. Al construir el campo nTransaccionAgente
para el webservice se aplica re.sub("[^0-9]", "", wh_line.name), que
sobre "/" produce una cadena vacía, lo que provoca el error 400 de ARBA:

  ESTADO 400
  CÓDIGO NOT_VALID
  MENSAJE: nTransaccionAgente debe ser mayor 0, nTransaccionAgente
  debe ser distinto de nulo o bien debe ser número de
  nTransaccionAgente válido

La solución es filtrar en send_to_arba() las retenciones con
amount == 0 para no intentar informarlas a ARBA.

## Solución

Se agrega el filtro `amount > 0` en el método `send_to_arba()` de
`l10n_ar.payment.withholding`. El filtro se ubica en ese método porque
es el único punto de entrada para todos los flujos de envío (automático
desde `action_post` y cualquier llamada manual futura), garantizando
que la condición siempre se aplique.

## Task

https://www.adhoc.inc/odoo/project/1/task/119209