### PR TITLE
[IMP] account_accountant_ux: bypass lock date validation via system param

### DIFF
--- a/account_accountant_ux/data/account_accountant_data.xml
+++ b/account_accountant_ux/data/account_accountant_data.xml
@@ -18,4 +18,9 @@
             <field name="filter_aml_ir_filters">True</field>
             <field name="filter_show_all_custom">True</field>
         </record>
+
+        <record id="bypass_lock_date_validation" model="ir.config_parameter">
+            <field name="key">account.bypass_lock_date_validation</field>
+            <field name="value">False</field>
+        </record>
 </odoo>

--- a/account_accountant_ux/models/__init__.py
+++ b/account_accountant_ux/models/__init__.py
@@ -9,6 +9,7 @@ from . import (
     account_move_line,
     account_partner_ledger,
     account_return,
+    res_company,
     res_partner,
     account_report,
     account_followup_report,

--- a/account_accountant_ux/models/res_company.py
+++ b/account_accountant_ux/models/res_company.py
@@ -1,0 +1,20 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    def _validate_locks(self, values):
+        # Bypass controlado por parámetro de sistema 'account.bypass_lock_date_validation'.
+        # Útil para correcciones puntuales de datos (ej: desbloquear hard_lock_date).
+        # Por defecto False; activar con precaución y desactivar inmediatamente después.
+        bypass = (
+            self.env["ir.config_parameter"].sudo().get_param("account.bypass_lock_date_validation", default="False")
+        )
+        if bypass == "True":
+            return
+        return super()._validate_locks(values)

--- a/account_accountant_ux/tests/__init__.py
+++ b/account_accountant_ux/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_reconcile_wizard
+from . import test_change_lock_date

--- a/account_accountant_ux/tests/test_change_lock_date.py
+++ b/account_accountant_ux/tests/test_change_lock_date.py
@@ -1,0 +1,44 @@
+# © ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import fields
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestChangeLockDateBypass(AccountTestInvoicingCommon):
+    """Regresión (tarea 69068): el parámetro 'account.bypass_lock_date_validation'
+    debe permitir mover hacia atrás el Hard Lock Date desde el wizard 'Change Lock Date'.
+
+    Sin el fix, el wizard corta en _prepare_lock_date_values con
+    'It is not possible to decrease or remove the Hard Lock Date' antes de llegar
+    a res.company.write (donde vive el bypass de _validate_locks).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.company_data["company"]
+        cls.older_date = fields.Date.from_string("2016-01-31")
+        cls.company.hard_lock_date = fields.Date.from_string("2016-06-30")
+
+    def _wizard(self, hard_lock_date):
+        return self.env["account.change.lock.date"].create(
+            {
+                "company_id": self.company.id,
+                "hard_lock_date": hard_lock_date,
+            }
+        )
+
+    def test_bypass_off_blocks_hard_lock_decrease(self):
+        """Sin bypass: mover el hard lock date hacia atrás debe seguir fallando."""
+        self.env["ir.config_parameter"].sudo().set_param("account.bypass_lock_date_validation", "False")
+        with self.assertRaisesRegex(UserError, "decrease or remove the Hard Lock Date"):
+            self._wizard(self.older_date).change_lock_date()
+
+    def test_bypass_on_allows_hard_lock_decrease(self):
+        """Con bypass: el wizard debe permitir retroceder el hard lock date."""
+        self.env["ir.config_parameter"].sudo().set_param("account.bypass_lock_date_validation", "True")
+        self._wizard(self.older_date).change_lock_date()
+        self.assertEqual(self.company.hard_lock_date, self.older_date)

--- a/account_accountant_ux/wizards/account_change_lock_date.py
+++ b/account_accountant_ux/wizards/account_change_lock_date.py
@@ -3,6 +3,7 @@
 # directory
 ##############################################################################
 from odoo import _, api, fields, models
+from odoo.addons.account.models.company import LOCK_DATE_FIELDS
 from odoo.exceptions import UserError
 
 
@@ -19,6 +20,19 @@ class AccountChangeLockDate(models.TransientModel):
         self.purchase_lock_date = self.company_id.purchase_lock_date
         self.fiscalyear_lock_date = self.company_id.fiscalyear_lock_date
         self.tax_lock_date = self.company_id.tax_lock_date
+
+    def _prepare_lock_date_values(self, exception_vals_list=None):
+        bypass = (
+            self.env["ir.config_parameter"].sudo().get_param("account.bypass_lock_date_validation", default="False")
+            == "True"
+        )
+        if not bypass:
+            return super()._prepare_lock_date_values(exception_vals_list=exception_vals_list)
+        # Bypass: devolvemos solo los lock dates que cambiaron, sin el raise del core
+        # que impide bajar/quitar el hard lock date. La escritura real la deja pasar
+        # res.company._validate_locks (tambien bypasseado); acá solo evitamos que el
+        # wizard corte antes de llegar a esa escritura.
+        return {field: self[field] for field in LOCK_DATE_FIELDS if self[field] != self.env.company[field]}
 
     def change_lock_date(self):
         if self.env.user.has_group("account.group_account_manager"):


### PR DESCRIPTION
## What

Adds a system parameter `account.bypass_lock_date_validation` (default `False`) that, when set to `True`, skips the `_validate_locks` checks in `res.company`.

This allows performing exceptional data corrections (e.g. removing or rolling back a `hard_lock_date`) without triggering the standard validation errors.

## Changes

- `account_accountant_ux/models/res_company.py` — new override of `_validate_locks` that early-returns when the parameter is `True`
- `account_accountant_ux/data/account_accountant_data.xml` — creates the `ir.config_parameter` record with value `False` (noupdate)

## Usage

1. Go to Settings → Technical → System Parameters
2. Set `account.bypass_lock_date_validation` = `True`
3. Perform the required write operation
4. Immediately set the parameter back to `False`

## Test plan

- [ ] With param = `False` (default): write `hard_lock_date = False` on a company that has one → `UserError` raised as expected
- [ ] With param = `True`: same write succeeds without error
- [ ] After setting param back to `False`: validation is restored

Task: https://www.adhoc.inc/odoo/my-tasks/69068