### PR TITLE
[FIX] l10n_ar_currency_update: evita perder re-check cuando alguna moneda falla

### DIFF
--- a/l10n_ar_currency_update/models/res_company.py
+++ b/l10n_ar_currency_update/models/res_company.py
@@ -25,6 +25,7 @@ class ResCompany(models.Model):
         digits=(16, 4),
     )
     l10n_ar_last_currency_sync_date = fields.Date(string="ARCA Last Sync Date", readonly=True)
+    l10n_ar_currency_recheck_needed = fields.Boolean(default=False)
 
     @api.model
     def _compute_currency_provider(self):
@@ -71,8 +72,10 @@ class ResCompany(models.Model):
                 ("currency_provider", "=", "afip"),
                 ("currency_interval_unit", "=", currency_interval_unit),
                 "|",
+                "|",
                 ("l10n_ar_last_currency_sync_date", "<", l10n_ar_last_currency_sync_date),
                 ("l10n_ar_last_currency_sync_date", "=", False),
+                ("l10n_ar_currency_recheck_needed", "=", True),
             ]
         ).with_context(l10n_ar_force_create_rate=l10n_ar_force_create_rate).update_currency_rates()
 
@@ -108,6 +111,7 @@ class ResCompany(models.Model):
             lambda c: not all_company_ids.issubset(updated_per_currency.get(c.id, set()))
         )
         if not available_currencies:
+            self.filtered(lambda x: x.currency_provider == "afip").write({"l10n_ar_currency_recheck_needed": False})
             return res or False
 
         valid_certificate = (
@@ -130,6 +134,7 @@ class ResCompany(models.Model):
         original_env = self.env
         self.env = self.env(context=dict(self.env.context, allowed_company_ids=company.ids))
         any_failed = False
+        any_succeeded = False
         for currency in available_currencies:
             try:
                 # Obtain the currencies to be updated
@@ -141,6 +146,7 @@ class ResCompany(models.Model):
                 if afip_date == rate_date or self.env.context.get("l10n_ar_force_create_rate"):
                     res.update({currency.name: (1.0 / rate, rate_date)})
                     _logger.info("Currency %s %s %s", currency.name, rate_date, rate)
+                    any_succeeded = True
                 else:
                     raise UserError(
                         "Returned ARCA rate is not today's rate (%s, %s vs %s, %s)"
@@ -149,11 +155,14 @@ class ResCompany(models.Model):
             except Exception as e:
                 _logger.info("Could not get rate for currency %s. This is what we get:\n%s", currency.name, e)
                 any_failed = True
-        if not any_failed:
-            for company in self.filtered(lambda x: x.currency_provider == "afip"):
-                company.l10n_ar_last_currency_sync_date = fields.Date.context_today(
-                    self.with_context(tz="America/Argentina/Buenos_Aires")
-                )
+        afip_companies = self.filtered(lambda x: x.currency_provider == "afip")
+        if any_succeeded:
+            sync_date = fields.Date.context_today(self.with_context(tz="America/Argentina/Buenos_Aires"))
+            afip_companies.write(
+                {"l10n_ar_last_currency_sync_date": sync_date, "l10n_ar_currency_recheck_needed": any_failed}
+            )
+        elif any_failed:
+            afip_companies.write({"l10n_ar_currency_recheck_needed": True})
         self.env = original_env
         return res or False
 

--- a/l10n_ar_currency_update/models/res_company.py
+++ b/l10n_ar_currency_update/models/res_company.py
@@ -93,6 +93,23 @@ class ResCompany(models.Model):
         available_currencies = available_currencies.filtered("l10n_ar_afip_code") - currency_ars
         rate_date = today
 
+        existing_rates = self.env["res.currency.rate"].search(
+            [
+                ("name", "=", today),
+                ("company_id", "in", self.ids),
+                ("currency_id", "in", available_currencies.ids),
+            ]
+        )
+        updated_per_currency = {}
+        for rate_rec in existing_rates:
+            updated_per_currency.setdefault(rate_rec.currency_id.id, set()).add(rate_rec.company_id.id)
+        all_company_ids = set(self.ids)
+        available_currencies = available_currencies.filtered(
+            lambda c: not all_company_ids.issubset(updated_per_currency.get(c.id, set()))
+        )
+        if not available_currencies:
+            return res or False
+
         valid_certificate = (
             self.env["certificate.certificate"]
             .search([("active", "=", True), ("date_end", ">=", today)])
@@ -112,6 +129,7 @@ class ResCompany(models.Model):
         # https://github.com/odoo/enterprise/commit/4fdcf86392f#diff-05c14fb3f27dcc12f22adcfaef217ec6f80ef5ad0b0f37a4bd7b501fdc55461dR499
         original_env = self.env
         self.env = self.env(context=dict(self.env.context, allowed_company_ids=company.ids))
+        any_failed = False
         for currency in available_currencies:
             try:
                 # Obtain the currencies to be updated
@@ -130,11 +148,12 @@ class ResCompany(models.Model):
                     )
             except Exception as e:
                 _logger.info("Could not get rate for currency %s. This is what we get:\n%s", currency.name, e)
-            else:
-                for company in self.filtered(lambda x: x.currency_provider == "afip"):
-                    company.l10n_ar_last_currency_sync_date = fields.Date.context_today(
-                        self.with_context(tz="America/Argentina/Buenos_Aires")
-                    )
+                any_failed = True
+        if not any_failed:
+            for company in self.filtered(lambda x: x.currency_provider == "afip"):
+                company.l10n_ar_last_currency_sync_date = fields.Date.context_today(
+                    self.with_context(tz="America/Argentina/Buenos_Aires")
+                )
         self.env = original_env
         return res or False
 


### PR DESCRIPTION
## Problema

Cuando ARCA no devuelve la tasa del día para alguna moneda (caso típico: USD y CLP el lunes a la madrugada, antes de que ARCA publique el cierre del último día hábil), el campo `l10n_ar_last_currency_sync_date` quedaba seteado a `today` de todas formas, porque las monedas que sí se actualizaban (EUR, COP, UYU) ejecutaban el bloque `else` del `try` en cada iteración y actualizaban el campo.

Consecuencia: el cron **Re Check Afip Currency Rate** busca compañías donde `l10n_ar_last_currency_sync_date < today`, pero el campo ya era `today` → encontraba 0 compañías → USD y CLP quedaban sin cotización para toda la jornada.

## Cambios

- `l10n_ar_last_currency_sync_date` ahora solo se actualiza al final del loop, y únicamente si **ninguna moneda falló** (`any_failed` flag). Así el re-check del mismo día puede encontrar la compañía y reintentar.
- `available_currencies` se filtra al inicio del método para excluir monedas que ya tienen tasa para hoy en todas las compañías del recordset. Esto evita llamadas innecesarias a ARCA en los re-checks (EUR/COP/UYU ya actualizadas no se vuelven a consultar).

## Test plan

- Verificar que un lunes (o post-feriado) el cron principal corre, algunas monedas fallan, y `l10n_ar_last_currency_sync_date` **no** se actualiza.
- Verificar que el re-check posterior encuentra la compañía y actualiza solo las monedas pendientes.
- Verificar que las monedas ya actualizadas no generan llamadas a ARCA en el re-check.

Ticket interno: https://www.adhoc.inc/odoo/helpdesk/118911