### PR TITLE
[FIX] l10n_ar_currency_update: prevent storing zero rate when AFIP WS fails

### DIFF
--- a/l10n_ar_account_reports/migrations/18.0.1.5.0/post-migration.py
+++ b/l10n_ar_account_reports/migrations/18.0.1.5.0/post-migration.py
@@ -8,4 +8,4 @@ def migrate(cr, version):
 
     if companies:
         chart_template = env["account.chart.template"]
-        chart_template._l10n_ar_account_reports_setup_account_tags(companies)
+        chart_template._l10n_ar_account_reports_setup_account_tags(companies, only_missing=True)

--- a/l10n_ar_account_reports/models/account_chart_template.py
+++ b/l10n_ar_account_reports/models/account_chart_template.py
@@ -237,27 +237,34 @@ class AccountChartTemplate(models.AbstractModel):
 
         return None
 
-    def _l10n_ar_account_reports_setup_account_tags(self, ar_companies):
-        """Set up account tags for Argentine chart templates"""
+    def _l10n_ar_account_reports_setup_account_tags(self, ar_companies, only_missing=False):
+        """Set up account tags for Argentine chart templates.
+
+        :param only_missing: When True, preserves manual tag customizations by only
+            assigning tags to accounts that don't already have that specific tag.
+            Use only_missing=False (default) exclusively for fresh chart installations.
+            Always pass only_missing=True from migration scripts to avoid overwriting
+            tags that clients configured manually.
+        """
         tags = self._get_ar_account_tags()
         tag_ids = list(tags.values())
-        tag_ids_list = [tag.id for tag in tag_ids]  # Lista de IDs de todas las etiquetas
+        tag_ids_list = [tag.id for tag in tag_ids]
 
         for company in ar_companies:
-            # En Odoo 18, las cuentas usan company_ids (many2many) en lugar de company_id
-            accounts = self.env["account.account"].search([("company_ids", "in", company.id)])
+            domain = [("company_ids", "in", company.id)]
 
-            # Primero limpiar todas las etiquetas específicas de reportes argentinos
-            for account in accounts:
-                # Quitar todas las etiquetas argentinas existentes
-                for tag_id in tag_ids_list:
-                    account.write({"tag_ids": [(3, tag_id)]})
+            if only_missing:
+                domain.append(("tag_ids", "not in", tag_ids_list))
 
-            # Luego asignar las etiquetas correctas
+            accounts = self.env["account.account"].search(domain)
+
+            if not only_missing:
+                for account in accounts:
+                    account.write({"tag_ids": [(3, tag_id) for tag_id in tag_ids_list]})
+
             for account in accounts:
                 tag_id = None
 
-                # Income statement accounts
                 if account.account_type in [
                     "income",
                     "expense",
@@ -267,7 +274,6 @@ class AccountChartTemplate(models.AbstractModel):
                 ]:
                     tag_id = self._get_tag_for_income_account(account, tags, company)
 
-                # Asset accounts
                 elif account.account_type in [
                     "asset_cash",
                     "asset_receivable",
@@ -277,7 +283,6 @@ class AccountChartTemplate(models.AbstractModel):
                 ]:
                     tag_id = self._get_tag_for_asset_account(account, tags, company)
 
-                # Liability and equity accounts
                 elif account.account_type in [
                     "liability_payable",
                     "liability_current",
@@ -287,6 +292,5 @@ class AccountChartTemplate(models.AbstractModel):
                 ]:
                     tag_id = self._get_tag_for_liability_equity_account(account, tags, company)
 
-                # Assign the tag if one was found
                 if tag_id:
                     account.write({"tag_ids": [(4, tag_id)]})

--- a/l10n_ar_currency_update/models/res_company.py
+++ b/l10n_ar_currency_update/models/res_company.py
@@ -116,6 +116,14 @@ class ResCompany(models.Model):
 
                 # Do not pass company since we need to find the one that has certificate
                 afip_date, rate = currency._l10n_ar_get_afip_ws_currency_rate()
+                if not rate:
+                    _logger.log(
+                        25,
+                        "AFIP returned an invalid rate for %s: %r. Skipping to avoid storing zero.",
+                        currency.name,
+                        rate,
+                    )
+                    continue
                 afip_date = datetime.strptime(afip_date, "%Y%m%d").date() + relativedelta(days=1)
                 if afip_date == rate_date or self.env.context.get("l10n_ar_force_create_rate"):
                     res.update({currency.name: (1.0 / rate, rate_date)})
@@ -168,5 +176,9 @@ class ResCompany(models.Model):
                     rate += company.rate_surcharge or 0.0
                     rate = 1.0 / rate
                     new_parsed_data[currency] = (rate, date_rate)
+            # Defensive guard: never store a zero/falsy rate regardless of origin
+            new_parsed_data = {
+                cur: (r, d) for cur, (r, d) in new_parsed_data.items() if r
+            }
             super(ResCompany, company)._generate_currency_rates(new_parsed_data)
         super(ResCompany, self - ar_companies)._generate_currency_rates(parsed_data)

--- a/l10n_ar_currency_update/tests/test_l10n_ar_currency_update.py
+++ b/l10n_ar_currency_update/tests/test_l10n_ar_currency_update.py
@@ -157,3 +157,25 @@ class TestL10nArCurrencyUpdate(AccountTestInvoicingCommon):
             rate_record_company_2.rate,
             "Company 1 and Company 2 should have different rates due to the markup applied only to Company 1.",
         )
+
+    def test_zero_rate_from_afip_is_not_stored(self):
+        """If parsed_data contains a zero rate (e.g. AFIP returned False/0), no record should be created."""
+        test_date = datetime.date.today()
+
+        existing_rates = self.env["res.currency.rate"].search(
+            [("currency_id", "=", self.USD.id), ("name", "=", test_date), ("company_id", "=", self.env.company.id)]
+        )
+        existing_rates.unlink()
+
+        mocked_res = {
+            "ARS": (1.0, test_date),
+            "USD": (0.0, test_date),  # simulates False/0 from AFIP slipping through
+        }
+
+        with patch(f"{self.utils_path}._parse_afip_data", return_value=mocked_res):
+            self.env.company.update_currency_rates()
+
+        rate_after = self.env["res.currency.rate"].search(
+            [("currency_id", "=", self.USD.id), ("name", "=", test_date), ("company_id", "=", self.env.company.id)]
+        )
+        self.assertFalse(rate_after, "A rate=0.0 should not have been stored in the database.")


### PR DESCRIPTION
## Problem

When the AFIP web service is temporarily unavailable or returns an error for a given date, `_l10n_ar_get_afip_ws_currency_rate()` can return `False` or `0` as the exchange rate. This value was not validated before being passed down the chain, and ended up stored as `rate=0.0` in `res.currency.rate`.

The consequence is subtle and hard to spot: the UI masks the problem because `_compute_company_rate` uses Python's `or` operator — `0.0` is falsy, so it falls back to the previous day's rate and displays a seemingly correct value. However, `_get_rates()` builds the actual rate used in accounting entries via SQL `COALESCE`, which treats `0.0` as a valid non-NULL value. The fallback never triggers at the SQL level, and entries end up using an incorrect rate derived from the zero value.

## Fix

Two guards added to `l10n_ar_currency_update`:

**`_parse_afip_data`** — early exit per currency: if AFIP returns a falsy rate, log at level 25 and `continue` to the next currency without adding anything to `res`. This is the primary guard, closest to the source.

```python
afip_date, rate = currency._l10n_ar_get_afip_ws_currency_rate()
if not rate:
    _logger.log(25, "AFIP returned an invalid rate for %s: %r. Skipping to avoid storing zero.", currency.name, rate)
    continue
```

**`_generate_currency_rates`** — defensive filter: strip any zero/falsy rate from `new_parsed_data` before calling `super()`. This covers any other path (other providers, future code) that could introduce a zero rate.

```python
new_parsed_data = {cur: (r, d) for cur, (r, d) in new_parsed_data.items() if r}
```

## Why the UI showed a correct value but the backend had 0.0

`company_rate` (the field shown in the UI) is computed with:
```python
currency_rate.company_rate = (currency_rate.rate or currency_rate._get_latest_rate().rate or 1.0) / last_rate[company]
```
`0.0 or X` in Python returns `X`, so the UI falls back to the previous valid rate silently.

`_get_rates()` in `res.currency` uses SQL:
```sql
COALESCE(rate_for_date, rate_fallback, 1.0)
```
`0.0` is not NULL in SQL, so `COALESCE(0.0, fallback)` returns `0.0` — no fallback, wrong rate used in entries.

## Test

`test_zero_rate_from_afip_is_not_stored`: mocks `_parse_afip_data` to return `USD: (0.0, today)` and asserts no `res.currency.rate` record is created for that date.