### PR TITLE
[FIX] l10n_ar_currency_update: prevent storing zero rate when AFIP WS fails

### DIFF
--- a/l10n_ar_currency_update/models/res_company.py
+++ b/l10n_ar_currency_update/models/res_company.py
@@ -115,6 +115,13 @@ class ResCompany(models.Model):
 
                 # Do not pass company since we need to find the one that has certificate
                 afip_date, rate = currency._l10n_ar_get_afip_ws_currency_rate()
+                if not rate:
+                    _logger.info(
+                        "AFIP returned an invalid rate for %s: %r. Skipping to avoid storing zero.",
+                        currency.name,
+                        rate,
+                    )
+                    continue
                 afip_date = datetime.strptime(afip_date, "%Y%m%d").date() + relativedelta(days=1)
                 if afip_date == rate_date or self.env.context.get("l10n_ar_force_create_rate"):
                     res.update({currency.name: (1.0 / rate, rate_date)})
@@ -150,6 +157,9 @@ class ResCompany(models.Model):
         for company in ar_companies:
             new_parsed_data = parsed_data.copy()
             for currency, (rate, date_rate) in parsed_data.items():
+                if not rate:
+                    new_parsed_data.pop(currency, None)
+                    continue
                 already_existing_rate = currency_rate.search(
                     [
                         ("currency_id", "=", currency_object.search([("name", "=", currency)]).id),

--- a/l10n_ar_currency_update/tests/test_l10n_ar_currency_update.py
+++ b/l10n_ar_currency_update/tests/test_l10n_ar_currency_update.py
@@ -157,3 +157,25 @@ class TestL10nArCurrencyUpdate(AccountTestInvoicingCommon):
             rate_record_company_2.rate,
             "Company 1 and Company 2 should have different rates due to the markup applied only to Company 1.",
         )
+
+    def test_zero_rate_from_afip_is_not_stored(self):
+        """If parsed_data contains a zero rate (e.g. AFIP returned False/0), no record should be created."""
+        test_date = datetime.date.today()
+
+        existing_rates = self.env["res.currency.rate"].search(
+            [("currency_id", "=", self.USD.id), ("name", "=", test_date), ("company_id", "=", self.env.company.id)]
+        )
+        existing_rates.unlink()
+
+        mocked_res = {
+            "ARS": (1.0, test_date),
+            "USD": (0.0, test_date),
+        }
+
+        with patch(f"{self.utils_path}._parse_afip_data", return_value=mocked_res):
+            self.env.company.update_currency_rates()
+
+        rate_after = self.env["res.currency.rate"].search(
+            [("currency_id", "=", self.USD.id), ("name", "=", test_date), ("company_id", "=", self.env.company.id)]
+        )
+        self.assertFalse(rate_after, "A rate=0.0 should not have been stored in the database.")


### PR DESCRIPTION
## Problem

When the AFIP web service is temporarily unavailable or returns an error for a given date, `_l10n_ar_get_afip_ws_currency_rate()` can return `False` or `0` as the exchange rate. This value was not validated before being passed down the chain, and ended up stored as `rate=0.0` in `res.currency.rate`.

The consequence is subtle and hard to spot: the UI masks the problem because `_compute_company_rate` uses Python's `or` operator — `0.0` is falsy, so it falls back to the previous day's rate and displays a seemingly correct value. However, `_get_rates()` builds the actual rate used in accounting entries via SQL `COALESCE`, which treats `0.0` as a valid non-NULL value. The fallback never triggers at the SQL level, and entries end up using an incorrect rate.

## Fix

Two guards added to `l10n_ar_currency_update`:

**`_parse_afip_data`** — early exit per currency: if AFIP returns a falsy rate, log and `continue` to the next currency without adding anything to `res`. This is the primary guard, closest to the source.

```python
afip_date, rate = currency._l10n_ar_get_afip_ws_currency_rate()
if not rate:
    _logger.info("AFIP returned an invalid rate for %s: %r. Skipping to avoid storing zero.", currency.name, rate)
    continue
```

**`_generate_currency_rates`** — defensive filter: strip any zero/falsy rate from `new_parsed_data` before calling `super()`. This covers any other path that could introduce a zero rate.

```python
new_parsed_data = {cur: (r, d) for cur, (r, d) in new_parsed_data.items() if r}
```

## Why the UI showed a correct value but the backend had 0.0

`company_rate` (the field shown in the UI) is computed with:
```python
currency_rate.company_rate = (currency_rate.rate or currency_rate._get_latest_rate().rate or 1.0) / last_rate[company]
```
`0.0 or X` in Python returns `X`, so the UI silently falls back to the previous valid rate.

`_get_rates()` in `res.currency` uses SQL:
```sql
COALESCE(rate_for_date, rate_fallback, 1.0)
```
`0.0` is not NULL in SQL, so `COALESCE(0.0, fallback)` returns `0.0` — no fallback, wrong rate applied in entries.

## Test

`test_zero_rate_from_afip_is_not_stored`: mocks `_parse_afip_data` to return `USD: (0.0, today)` and asserts no `res.currency.rate` record is created for that date.