### PR TITLE
[FIX] account_balance_import: ensure onboarding progress exists before fiscal year save

### DIFF
--- a/account_balance_import/models/__init__.py
+++ b/account_balance_import/models/__init__.py
@@ -3,3 +3,4 @@ from . import account_import_summary
 from . import account_financial_year_op
 from . import account_account
 from . import res_company
+from . import onboarding_onboarding

--- a/account_balance_import/models/onboarding_onboarding.py
+++ b/account_balance_import/models/onboarding_onboarding.py
@@ -1,0 +1,10 @@
+from odoo import models
+
+
+class OnboardingOnboarding(models.Model):
+    _inherit = "onboarding.onboarding"
+
+    def _prepare_rendering_values(self):
+        if not self.current_progress_id:
+            self.sudo()._search_or_create_progress()
+        return super()._prepare_rendering_values()


### PR DESCRIPTION
## Problem

When `action_save_onboarding_fiscal_year` is called by a user who has never opened the accounting onboarding panel, no `onboarding.progress` record exists for `account.onboarding_onboarding_account_dashboard`. The super chain eventually calls `_prepare_rendering_values()` which accesses `current_progress_id` and calls `_get_and_update_onboarding_state()` on it — crashing with:

```
ValueError: Expected singleton: onboarding.progress()
```

## Fix

Override `_prepare_rendering_values` on `onboarding.onboarding` to call `_search_or_create_progress()` (Odoo's canonical method for this) before delegating to super, ensuring the record is created on demand.

The existing `action_save_onboarding_fiscal_year` override (which adds `sudo()` for onboarding step write permissions) is unchanged.

## Test plan

- Open the fiscal year wizard as an accounting user on a database where the accounting onboarding panel was never rendered
- Click save — should complete without error