### PR TITLE
[FIX] l10n_ar_import_bill: fix sale journal domain filter in AFIP import wizard

### DIFF
--- a/l10n_ar_import_bill/wizards/afip_import_wizard.py
+++ b/l10n_ar_import_bill/wizards/afip_import_wizard.py
@@ -43,9 +43,9 @@ class AfipImportWizard(models.TransientModel):
     @api.depends_context("import_type")
     def _compute_journal_domain(self):
         if self._context.get("import_type") == "sale":
-            domain = [("type", "in", "sale"), ("l10n_ar_is_pos", "=", False)]
+            domain = [("type", "=", "sale"), ("l10n_ar_is_pos", "=", False)]
         elif self._context.get("import_type") == "purchase":
-            domain = [("type", "in", "purchase"), ("l10n_latam_use_documents", "=", True)]
+            domain = [("type", "=", "purchase"), ("l10n_latam_use_documents", "=", True)]
         else:
             domain = []
         self.journal_domain = domain


### PR DESCRIPTION
The `_compute_journal_domain` method was passing a string (`"sale"`, `"purchase"`) instead of using the `=` operator. The `"in"` operator iterates the string character by character, so the domain became `type in ['s', 'a', 'l', 'e']`, which matches no journal. This prevented selecting any journal in the AFIP import wizard.

**Fix:** replace `("type", "in", "sale"/"purchase")` with `("type", "=", "sale"/"purchase")` in both branches of `_compute_journal_domain`.