### PR TITLE
[FIX] l10n_ar_edi_ux: override _get_vat method

### DIFF
--- a/l10n_ar_edi_ux/models/account_move.py
+++ b/l10n_ar_edi_ux/models/account_move.py
@@ -61,6 +61,24 @@ class AccountMove(models.Model):
                 )
             )
 
+    def _get_vat(self, base_lines=None):
+        res = super()._get_vat(base_lines=base_lines)
+        # Upstream refactor (commit 114cae88b) skips VAT groups where base and tax
+        # both aggregate to zero (e.g. 100% advance deduction netting them out).
+        # Old code iterated individual tax lines and always emitted an entry per group
+        # with BaseImp=0/Importe=0 — AFIP accepted that with the real alícuota Id.
+        # Replicate: when super() returns [], find groups with non-zero individual tax
+        # lines and emit the same zero entries using the actual alícuota code.
+        if not res:
+            seen = {}
+            for line in self.line_ids:
+                code = line.tax_line_id.tax_group_id.l10n_ar_vat_afip_code if line.tax_line_id else False
+                if code and code not in ("0", "1", "2") and line.amount_currency and code not in seen:
+                    seen[code] = line.tax_line_id.tax_group_id
+            if seen:
+                res = [{"Id": code, "BaseImp": 0.0, "Importe": 0.0} for code in seen]
+        return res
+
     @api.model
     def wsfe_get_cae_request(self, client=None):
         res = super().wsfe_get_cae_request(client=client)


### PR DESCRIPTION
En Odoo metieron un cambio el 20 de enero de 2026 en `l10n_ar` pq refactorizaron `_get_vat()` para usar el nuevo motor de agregación de impuestos de Odoo

Antes
Iterababamos las tax lines individuales del asiento. Con anticipo 100%, existían dos tax lines para la misma alícuota: +$943K (productos) y -$943K (deducción). Ambas tienen `amount_currency ≠ 0` individualmente, por lo que ambas pasaban el filtro. Al sumarlas y calcular el entry resultaba:
{'Id': '4', 'BaseImp': 0.0, 'Importe': 0.0}
Lista no vacía → AFIP no tiraba error 10018.

Ahora 
Agrega primero por grupo usando` _aggregate_base_lines_aggregated_values`, y luego aplica un filtro:
```
if ... and (values['base_amount_currency'] or values['tax_amount_currency']):
    res.append(...)
```
Con anticipo 100%, el grupo IVA 10.5% neta a base=0, tax=0 → (0 or 0) es falsy → el entry se descarta →` _get_vat()` devuelve` [] `→ Iva: None en el request WSFE → AFIP error 10018.

**Cambios de este PR**
Hice un override en l10n_ar_edi_ux (módulo Adhoc) que detecta si `super()._get_vat()` devolvió lista vacía habiendo tax lines individuales no-zero, y emite los entries con BaseImp=0, Importe=0 usando el código real de la alícuota