### PR TITLE
[IMP] l10n_ar_account_reports: txt sicore backward compatibility

### DIFF
--- a/l10n_ar_account_reports/models/sicore_report.py
+++ b/l10n_ar_account_reports/models/sicore_report.py
@@ -97,12 +97,13 @@ class L10n_ArSicoreReportHandler(models.AbstractModel):
             issue_date = payment.date
 
             # Importe Comprobante (document amount)           [16]
-            content += f"{abs(payment.amount):016.2f}"
+            content += f"{abs(payment.payment_total):016.2f}"
             # Codigo de Impuesto (tax code)            [ 4]
             # Codigo de Regimen (regime code)             [ 3]
 
             content += "0217"
-            regimen = line.tax_line_id.l10n_ar_code
+            tax = line._get_settlement_tax(date=line.date)
+            regimen = tax.l10n_ar_code
 
             content += f"{''.join(filter(str.isdigit, str(regimen))):0>3}" if regimen else "000"
 
@@ -110,7 +111,7 @@ class L10n_ArSicoreReportHandler(models.AbstractModel):
             content += "1"
 
             # Base de Calculo (base amount)               [14]
-            content += f"{abs(line.tax_base_amount):014.2f}"
+            content += f"{abs(line.withholding_id.base_amount):014.2f}"
 
             # Fecha Emision Retencion (move line date)        [10] (dd/mm/yyyy)
             content += fields.Date.from_string(issue_date).strftime("%d/%m/%Y")

--- a/l10n_ar_account_reports_backward_comp/models/account_move_line.py
+++ b/l10n_ar_account_reports_backward_comp/models/account_move_line.py
@@ -19,6 +19,15 @@ class AccountMoveLine(models.Model):
             self.partner_id.l10n_ar_partner_perception_ids if is_perception else self.partner_id.l10n_ar_partner_tax_ids
         )
         date = date or self.date
+        if self.tax_line_id.l10n_ar_tax_type == "earnings":
+            if partner_tax := partner_field.filtered(
+                lambda x: x.company_id == self.company_id
+                and not x.tax_id.l10n_ar_state_id
+                and x.tax_id.l10n_ar_tax_type in ["earnings", "earnings_scale"]
+                and (x.from_date <= date if x.from_date else True)
+                and (x.to_date >= date if x.to_date else True)
+            ):
+                return partner_tax.tax_id
         if partner_tax := partner_field.filtered(
             lambda x: x.company_id == self.company_id
             and x.tax_id.l10n_ar_state_id == self.tax_line_id.l10n_ar_state_id


### PR DESCRIPTION
Hay inconvenientes para descargar el archivo txt de retenciones migradas de SICORE: 
1) No se ven la líneas de retenciones migradas en el reporte de SICORE en el menú de declaración fiscal. Para que se vean hice el upgrade line "[RET19] Provincia y grupos de impuestos en 19" (query = f"""UPDATE account_tax SET l10n_ar_tax_type = 'earnings' WHERE id = {old_earnings_tax.id};""") donde establezco l10n_ar_tax_type = 'earnings' en el impuesto de retención de ganancias migrado para que se puedan ver las líneas de retenciones migradas en el reporte de SICORE. 
2) Hice este pull request con el backward compatibility del txt de sicore porque no se estaba llevando el código de régimen ni la base de cálculo al txt de SICORE para las retenciones de ganancias migradas.
Ticket: 120314