### PR TITLE
[FIX] l10n_ar_edi_ux: clear error when associated invoice is in draft

### DIFF
--- a/l10n_ar_edi_ux/models/account_move.py
+++ b/l10n_ar_edi_ux/models/account_move.py
@@ -216,3 +216,25 @@ class AccountMove(models.Model):
         ):
             return False
         return super()._is_dummy_afip_validation()
+
+    def action_post(self):
+        for move in self.filtered(lambda x: x.journal_id.l10n_ar_is_pos and x.journal_id.l10n_ar_afip_ws):
+            # If the related document (e.g., the source invoice of an electronic
+            # credit/debit note) is still in draft state, it does not yet have a
+            # definitive number or date, causing the AFIP related-document payload
+            # generation to fail with a generic error. Validate this condition upfront
+            # and provide a clear message indicating that the related document must be
+            # posted first.
+            related_inv = move._found_related_invoice()
+            if related_inv and related_inv.state != "posted":
+                raise UserError(
+                    _(
+                        "Cannot electronically validate '%(move)s' because the related "
+                        "document '%(related)s' is still in draft state. Please post the "
+                        "related document before issuing the electronic credit/debit note.",
+                        move=move.display_name,
+                        related=related_inv.display_name,
+                    )
+                )
+
+        return super().action_post()


### PR DESCRIPTION
## Qué

Al validar una nota de crédito/débito electrónica cuyo comprobante asociado (CbteAsoc) está todavía en estado borrador, la factura relacionada no tiene número de documento ni fecha definitiva. El armado del request a AFIP en `_get_related_invoice_data` rompía con un error genérico ("¡Vaya! Ocurrió un error…"), sin pista de la causa.

## Cambio

`l10n_ar_edi_ux`: override de `_get_related_invoice_data` que valida que el comprobante asociado esté `posted` antes de armar el CbteAsoc. Si está en borrador (o no posteado), levanta un `UserError` claro pidiendo confirmar el comprobante asociado primero.

## Test plan

1. Crear una factura electrónica AR y dejarla en **borrador**.
2. Generar una nota de crédito electrónica asociada a esa factura.
3. Confirmar la NC.
   - **Antes:** error genérico sin detalle.
   - **Después:** `UserError` indicando que el comprobante asociado está en borrador y hay que confirmarlo primero.
4. Confirmar la factura origen y reintentar → la NC valida normalmente en AFIP.