### PR TITLE
[I18N] account_balance_import: translate missing es terms

### DIFF
--- a/account_balance_import/i18n/es.po
+++ b/account_balance_import/i18n/es.po
@@ -319,7 +319,7 @@ msgstr "Modo de Importación"
 #. module: account_balance_import
 #: model:ir.model,name:account_balance_import.model_onboarding_onboarding
 msgid "Onboarding"
-msgstr ""
+msgstr "Incorporación"
 
 #. module: account_balance_import
 #: model:ir.model,name:account_balance_import.model_account_financial_year_op
@@ -385,7 +385,7 @@ msgstr "Saldos de Partners"
 #. odoo-javascript
 #: code:addons/account_balance_import/static/src/xml/account_import.xml:0
 msgid "Set Periods"
-msgstr ""
+msgstr "Configurar Periodos"
 
 #. module: account_balance_import
 #. odoo-javascript


### PR DESCRIPTION
## Summary

Translate the two remaining untranslated entries in `account_balance_import/i18n/es.po`. These were the only `msgid`s with an empty `msgstr` in the Spanish catalog.

| msgid | msgstr (es) |
|---|---|
| `Onboarding` | `Incorporación` |
| `Set Periods` | `Configurar Periodos` |

Both follow the conventions already used by standard Odoo Spanish catalogs (`Onboarding` → `Incorporación`, `Set Periods` → `Configurar periodos`), with title-case adjusted to match the sibling onboarding step labels in this module (`Crear Diarios`, `Configurar Conexión`, etc.).

## Test plan

- `account_balance_import/i18n/es.po` has no remaining empty `msgstr` (verified).
- The two onboarding steps render in Spanish in the accounting onboarding panel.

Task: 69662
