### PR TITLE
[ADD] l10n_ar_account_reports: asiento de liquidación único para sucursales

### DIFF
--- a/l10n_ar_account_reports/__manifest__.py
+++ b/l10n_ar_account_reports/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Accounting Reports Customized for Argentina",
-    "version": "19.0.1.18.0",
+    "version": "19.0.1.19.0",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",

--- a/l10n_ar_account_reports/i18n/es.po
+++ b/l10n_ar_account_reports/i18n/es.po
@@ -301,6 +301,21 @@ msgid "AR Simple Closing"
 msgstr "AR Cierre Simple"
 
 #. module: l10n_ar_account_reports
+#: model:ir.model.fields,field_description:l10n_ar_account_reports.field_account_return_type__l10n_ar_single_branch_closing_entry
+msgid "Single Closing Entry for Branches"
+msgstr "Asiento de liquidación único para sucursales"
+
+#. module: l10n_ar_account_reports
+#: model:ir.model.fields,help:l10n_ar_account_reports.field_account_return_type__l10n_ar_single_branch_closing_entry
+msgid ""
+"If enabled, when the company has branches a single consolidated closing "
+"entry is created in the parent company instead of one entry per branch."
+msgstr ""
+"Si se habilita, cuando la compañía tiene sucursales se genera un único "
+"asiento de liquidación consolidado en la compañía padre en lugar de un "
+"asiento por cada sucursal."
+
+#. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__account_id
 msgid "Account"
 msgstr "Cuenta"

--- a/l10n_ar_account_reports/i18n/l10n_ar_account_reports.pot
+++ b/l10n_ar_account_reports/i18n/l10n_ar_account_reports.pot
@@ -249,6 +249,18 @@ msgid "AR Simple Closing"
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#: model:ir.model.fields,field_description:l10n_ar_account_reports.field_account_return_type__l10n_ar_single_branch_closing_entry
+msgid "Single Closing Entry for Branches"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#: model:ir.model.fields,help:l10n_ar_account_reports.field_account_return_type__l10n_ar_single_branch_closing_entry
+msgid ""
+"If enabled, when the company has branches a single consolidated closing "
+"entry is created in the parent company instead of one entry per branch."
+msgstr ""
+
+#. module: l10n_ar_account_reports
 #: model:ir.model.fields,field_description:l10n_ar_account_reports.field_inflation_adjustment__account_id
 msgid "Account"
 msgstr ""

--- a/l10n_ar_account_reports/models/account_return.py
+++ b/l10n_ar_account_reports/models/account_return.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from odoo import Command, _, fields, models
 from odoo.exceptions import UserError
 
@@ -186,6 +188,72 @@ class AccountReturn(models.Model):
         if self.closing_move_ids.filtered(lambda m: m.state == "draft"):
             return self.closing_move_ids._get_records_action()
         return res
+
+    def _generate_tax_closing_entries(self, options):
+        """EXTENDS account_reports.
+
+        Cuando el tipo de retorno tiene activado ``l10n_ar_single_branch_closing_entry`` y el
+        return abarca una compañía padre junto con sus sucursales (branches) —a cualquier nivel de
+        anidamiento— generamos un único asiento de liquidación consolidado en la compañía padre en
+        lugar de uno por cada branch.
+
+        El método nativo recorre ``company_ids`` (padre + branches) y crea un asiento por compañía.
+        Acá computamos las líneas de cada compañía con el mismo helper nativo
+        (``_compute_tax_closing_entry``, que aísla los montos por compañía vía ``forced_domain``),
+        las concatenamos en un solo asiento de la padre y consolidamos los subtotales por grupo de
+        impuesto para una única línea de contrapartida.
+
+        Solo consolidamos cuando ``company_ids`` está formado por una compañía padre —que además
+        es la compañía del return, no asumimos que el asiento siempre se cree en la padre— más
+        sucursales **descendientes** suyas, sin importar la profundidad (sub-sucursales incluidas).
+        Usamos ``parent_path`` para chequear pertenencia al árbol, así una jerarquía multinivel
+        (padre → sucursal → sub-sucursal) consolida igual. Cualquier otro escenario multi-compañía
+        (p. ej. una unidad de impuestos / tax unit con compañías no relacionadas) se delega al
+        comportamiento nativo: un asiento por compañía.
+        """
+        self.ensure_one()
+
+        companies = self.company_ids
+        # Determinamos explícitamente la compañía padre del conjunto: la única cuyo parent no
+        # pertenece al propio conjunto (la raíz de las sucursales involucradas).
+        parent_company = companies.filtered(lambda c: c.parent_id not in companies)
+        branches = companies - parent_company
+        is_branch_consolidation = (
+            self.type_id.l10n_ar_single_branch_closing_entry
+            and parent_company == self.company_id
+            and branches
+            # ``parent_path`` ("1/5/12/") permite verificar descendencia a cualquier nivel: toda
+            # branch del conjunto debe colgar del árbol de la padre (sub-sucursales incluidas).
+            and all(branch.parent_path.startswith(parent_company.parent_path) for branch in branches)
+        )
+        if not is_branch_consolidation:
+            return super()._generate_tax_closing_entries(options)
+
+        self._ensure_tax_group_configuration_for_tax_closing()
+
+        line_ids_vals = []
+        consolidated_subtotal = defaultdict(float)
+        for company in companies:
+            company_lines, tax_group_subtotal = self._compute_tax_closing_entry(company, options)
+            line_ids_vals += company_lines
+            for key, amount in tax_group_subtotal.items():
+                consolidated_subtotal[key] += amount
+
+        line_ids_vals += self._add_tax_group_closing_items(consolidated_subtotal)
+
+        move = self.env["account.move"].create(
+            {
+                "company_id": parent_company.id,
+                "journal_id": parent_company._get_tax_closing_journal().id,
+                "date": self.date_to,
+                "closing_return_id": self.id,
+                "ref": self.name,
+                "line_ids": line_ids_vals,
+            }
+        )
+        # Mantiene el comportamiento AR: action_post queda interceptado y deja el asiento en
+        # borrador para los tipos de cierre argentinos (ver override en account_move.py).
+        move.action_post()
 
     def _run_checks(self, check_codes_to_ignore):
         # if "l10n_ar_account_reports." in self.type_external_id:

--- a/l10n_ar_account_reports/models/account_return_type.py
+++ b/l10n_ar_account_reports/models/account_return_type.py
@@ -48,6 +48,14 @@ class AccountReturnType(models.Model):
         help="If enabled, this return type uses simplified closing logic: "
         "no carryover mechanism and no automatic tax_lock_date update.",
     )
+    l10n_ar_single_branch_closing_entry = fields.Boolean(
+        string="Single Closing Entry for Branches",
+        help="If enabled, when the company has branches a single consolidated closing entry "
+        "is created in the parent company instead of one entry per branch.",
+    )
+    # Helper para mostrar campos exclusivos de AR solo en tipos de retorno argentinos
+    # (no debe ofrecerse esta funcionalidad para otras localizaciones).
+    l10n_ar_country_code = fields.Char(related="country_id.code")
 
     @api.depends("country_id")
     def _compute_l10n_ar_is_simple_closing_return(self):

--- a/l10n_ar_account_reports/tests/__init__.py
+++ b/l10n_ar_account_reports/tests/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import test_single_branch_closing_entry

--- a/l10n_ar_account_reports/tests/test_single_branch_closing_entry.py
+++ b/l10n_ar_account_reports/tests/test_single_branch_closing_entry.py
@@ -1,0 +1,270 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from contextlib import ExitStack
+from unittest.mock import patch
+
+from odoo import Command
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSingleBranchClosingEntry(AccountTestInvoicingCommon):
+    """Valida el flag ``l10n_ar_single_branch_closing_entry`` del tipo de retorno.
+
+    Aislamos la lógica de consolidación de ``_generate_tax_closing_entries``:
+    parcheamos los helpers pesados (cómputo de líneas por compañía, validación de
+    grupos de impuesto, diario de cierre y posteo) para no depender del plan de
+    cuentas AR ni de facturas reales, y verificamos únicamente cuántos asientos se
+    crean y en qué compañía.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.parent_company = cls.company_data["company"]
+        # Sucursal / branch directa de la compañía padre (comparte plan de cuentas).
+        cls.branch = cls.env["res.company"].create(
+            {
+                "name": "Sucursal Test",
+                "parent_id": cls.parent_company.id,
+                "currency_id": cls.parent_company.currency_id.id,
+            }
+        )
+        # Sub-sucursal: branch de la branch (segundo nivel de anidamiento).
+        cls.sub_branch = cls.env["res.company"].create(
+            {
+                "name": "Sub-sucursal Test",
+                "parent_id": cls.branch.id,
+                "currency_id": cls.parent_company.currency_id.id,
+            }
+        )
+        cls.all_companies = cls.parent_company + cls.branch + cls.sub_branch
+
+        # Compañía independiente (sin parent_id): simula una unidad de impuestos (tax unit) con
+        # compañías NO relacionadas. No debe disparar la consolidación de sucursales.
+        cls.unrelated_company_data = cls.setup_other_company()
+        cls.unrelated_company = cls.unrelated_company_data["company"]
+
+        # Reporte de impuestos mínimo para poder crear el tipo de retorno.
+        cls.report = cls.env["account.report"].create(
+            {
+                "name": "Test branch closing report",
+                "country_id": cls.parent_company.account_fiscal_country_id.id,
+                "root_report_id": cls.env.ref("account.generic_tax_report").id,
+                "column_ids": [Command.create({"name": "Balance", "sequence": 1, "expression_label": "balance"})],
+            }
+        )
+        cls.return_type = cls.env["account.return.type"].create(
+            {
+                "name": "Branch Closing Return",
+                "report_id": cls.report.id,
+            }
+        )
+
+        # Un diario de cierre por compañía (el move debe tener el diario de su propia compañía).
+        cls.journal_by_company = {}
+        for company in cls.all_companies + cls.unrelated_company:
+            cls.journal_by_company[company.id] = cls.env["account.journal"].create(
+                {
+                    "name": f"Tax Closing {company.name}",
+                    "code": f"TC{company.id}",
+                    "type": "general",
+                    "company_id": company.id,
+                }
+            )
+
+        # Cuenta válida por compañía: el padre (raíz del árbol) la comparte con su sucursal;
+        # la compañía no relacionada usa la suya propia (otro plan de cuentas).
+        cls.account_by_company = {
+            cls.parent_company.id: cls.company_data["default_account_expense"],
+            cls.branch.id: cls.company_data["default_account_expense"],
+            cls.sub_branch.id: cls.company_data["default_account_expense"],
+            cls.unrelated_company.id: cls.unrelated_company_data["default_account_expense"],
+        }
+
+    # ------------------------------------------------------------------
+    # Helpers de parcheo
+    # ------------------------------------------------------------------
+    def _patched_env(self, company_ids=None, with_counterpart=True):
+        """Devuelve la lista de patches que aíslan la lógica bajo test.
+
+        :param company_ids: conjunto de compañías que abarca el return (default: padre + sucursal).
+        :param with_counterpart: si False, el helper de contrapartida no agrega línea (útil para el
+            caso multi-compañía no relacionado, donde cada asiento vive en su propia compañía y no
+            hay una cuenta común válida para la contrapartida).
+        """
+        test = self
+        companies = company_ids if company_ids is not None else self.all_companies
+        return_model = self.registry["account.return"]
+        company_model = self.registry["res.company"]
+        move_model = self.registry["account.move"]
+
+        def fake_get_company_ids(self, main_company, tax_unit, report):
+            return companies
+
+        def fake_ensure_tax_group(self):
+            return True
+
+        def fake_compute_tax_closing_entry(self, company, options):
+            # Una línea por compañía, identificable por su nombre y con una cuenta válida en ella.
+            account = test.account_by_company[company.id]
+            lines = [
+                Command.create(
+                    {
+                        "name": f"tax {company.name}",
+                        "debit": 100.0,
+                        "credit": 0.0,
+                        "account_id": account.id,
+                    }
+                )
+            ]
+            if not with_counterpart:
+                # Sin contrapartida común (caso multi-compañía no relacionado): balanceamos el
+                # asiento dentro de su propia compañía para que el create nativo no lo rechace.
+                lines.append(
+                    Command.create(
+                        {
+                            "name": f"tax counterpart {company.name}",
+                            "debit": 0.0,
+                            "credit": 100.0,
+                            "account_id": account.id,
+                        }
+                    )
+                )
+                return lines, {("k",): 0.0}
+            return lines, {("k",): -100.0}
+
+        def fake_add_tax_group_closing_items(self, tax_group_subtotal):
+            if not with_counterpart:
+                return []
+            total = sum(tax_group_subtotal.values())
+            return [
+                Command.create(
+                    {
+                        "name": "counterpart",
+                        "debit": 0.0,
+                        "credit": abs(total),
+                        "account_id": test.account_by_company[self.company_id.id].id,
+                    }
+                )
+            ]
+
+        def fake_get_tax_closing_journal(self):
+            return test.journal_by_company[self.id]
+
+        def fake_action_post(self):
+            # No posteamos: el test solo verifica la creación de los asientos.
+            return True
+
+        return [
+            patch.object(return_model, "_get_company_ids", fake_get_company_ids),
+            patch.object(return_model, "_ensure_tax_group_configuration_for_tax_closing", fake_ensure_tax_group),
+            patch.object(return_model, "_compute_tax_closing_entry", fake_compute_tax_closing_entry),
+            patch.object(return_model, "_add_tax_group_closing_items", fake_add_tax_group_closing_items),
+            patch.object(company_model, "_get_tax_closing_journal", fake_get_tax_closing_journal),
+            patch.object(move_model, "action_post", fake_action_post),
+        ]
+
+    def _create_return(self, expected_companies=None):
+        expected_companies = expected_companies if expected_companies is not None else self.all_companies
+        tax_return = self.env["account.return"].create(
+            {
+                "name": "Return test",
+                "type_id": self.return_type.id,
+                "company_id": self.parent_company.id,
+                "date_from": "2024-01-01",
+                "date_to": "2024-12-31",
+            }
+        )
+        # company_ids es computado/stored; forzamos el recálculo con el patch activo.
+        tax_return.invalidate_recordset(["company_ids"])
+        self.assertEqual(
+            tax_return.company_ids,
+            expected_companies,
+            "El setup debe dejar el return abarcando las compañías esperadas.",
+        )
+        return tax_return
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+    def test_single_consolidated_entry_when_flag_enabled(self):
+        """Con el flag activo y sucursales —incluyendo sub-sucursales (jerarquía multinivel
+        padre → sucursal → sub-sucursal)— se crea un único asiento consolidado en la padre."""
+        self.return_type.l10n_ar_single_branch_closing_entry = True
+
+        with ExitStack() as stack:
+            for patcher in self._patched_env():
+                stack.enter_context(patcher)
+            tax_return = self._create_return()
+            tax_return._generate_tax_closing_entries({})
+
+        self.assertEqual(
+            len(tax_return.closing_move_ids),
+            1,
+            "Con consolidación debe generarse un solo asiento de liquidación.",
+        )
+        self.assertEqual(
+            tax_return.closing_move_ids.company_id,
+            self.parent_company,
+            "El asiento consolidado debe quedar en la compañía padre.",
+        )
+        # 1 línea por compañía (padre + sucursal + sub-sucursal = 3) + 1 contrapartida = 4.
+        self.assertEqual(
+            len(tax_return.closing_move_ids.line_ids),
+            4,
+            "El asiento consolidado debe contener las líneas de todas las compañías del árbol.",
+        )
+
+    def test_one_entry_per_company_when_flag_disabled(self):
+        """Sin el flag, se mantiene el comportamiento nativo: un asiento por compañía."""
+        self.return_type.l10n_ar_single_branch_closing_entry = False
+
+        with ExitStack() as stack:
+            for patcher in self._patched_env():
+                stack.enter_context(patcher)
+            tax_return = self._create_return()
+            tax_return._generate_tax_closing_entries({})
+
+        self.assertEqual(
+            len(tax_return.closing_move_ids),
+            3,
+            "Sin consolidación debe generarse un asiento por compañía (padre + sucursal + sub-sucursal).",
+        )
+        self.assertEqual(
+            tax_return.closing_move_ids.company_id,
+            self.all_companies,
+            "Debe haber un asiento por cada compañía del return.",
+        )
+
+    def test_no_consolidation_for_unrelated_multicompany(self):
+        """Con el flag activo pero compañías NO relacionadas (sin relación parent_id), NO se
+        consolida: se delega al comportamiento nativo (un asiento por compañía).
+
+        Cubre el caso que motivó la observación de review: una unidad de impuestos (tax unit) con
+        compañías independientes no debe tratarse como un grupo de sucursales solo porque
+        ``len(company_ids) > 1``.
+        """
+        self.return_type.l10n_ar_single_branch_closing_entry = True
+        unrelated_set = self.parent_company + self.unrelated_company
+
+        with ExitStack() as stack:
+            for patcher in self._patched_env(company_ids=unrelated_set, with_counterpart=False):
+                stack.enter_context(patcher)
+            tax_return = self._create_return(expected_companies=unrelated_set)
+            tax_return._generate_tax_closing_entries({})
+
+        self.assertEqual(
+            len(tax_return.closing_move_ids),
+            2,
+            "Compañías no relacionadas no se consolidan: un asiento por compañía.",
+        )
+        self.assertEqual(
+            tax_return.closing_move_ids.company_id,
+            unrelated_set,
+            "Debe haber un asiento por cada compañía no relacionada del return.",
+        )

--- a/l10n_ar_account_reports/views/account_return_type_views.xml
+++ b/l10n_ar_account_reports/views/account_return_type_views.xml
@@ -7,9 +7,12 @@
         <field name="arch" type="xml">
             <field name="payment_partner_id" position="after">
                 <field name="l10n_ar_is_simple_closing_return" invisible="1"/>
+                <field name="l10n_ar_country_code" invisible="1"/>
                 <field name="l10n_ar_account_id"
                     invisible="not l10n_ar_is_simple_closing_return"
                     options="{'no_create': True}"/>
+                <field name="l10n_ar_single_branch_closing_entry"
+                    invisible="l10n_ar_country_code != 'AR'"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
## Qué hace

Agrega el campo **`l10n_ar_single_branch_closing_entry`** en `account.return.type`. Cuando está activo y la compañía tiene sucursales/branches, el asiento de liquidación de impuestos (`_generate_tax_closing_entries`) se genera **consolidado en la compañía padre** en lugar de uno por cada branch.

- Sin el flag (o sin branches): comportamiento nativo intacto (un asiento por compañía).
- Con el flag y branches: un único `account.move` en la compañía padre, computando las líneas de cada compañía con el helper nativo `_compute_tax_closing_entry` (aísla montos por compañía vía `forced_domain`) y consolidando los subtotales por grupo de impuesto en una sola contrapartida.
- Mantiene el comportamiento AR de dejar el asiento en borrador para que el usuario lo revise.

## Incluye

- Campo + override + vista del tipo de retorno.
- Traducciones (`es.po` / `.pot`).
- Tests (`TestSingleBranchClosingEntry`): flag ON → 1 asiento consolidado en la padre; flag OFF → 1 asiento por compañía. **Ambos en verde.**

Ticket: 120712