### PR TITLE
[FIX] account_accountant_ux: propose write-off in company currency with reconcile_on_company_currency

### DIFF
--- a/account_accountant_ux/tests/__init__.py
+++ b/account_accountant_ux/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_reconcile_wizard

--- a/account_accountant_ux/tests/test_reconcile_wizard.py
+++ b/account_accountant_ux/tests/test_reconcile_wizard.py
@@ -1,0 +1,97 @@
+# © ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import Command, fields
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestReconcileWizardCompanyCurrency(AccountTestInvoicingCommon):
+    """Regresión: con reconcile_on_company_currency activo el wizard de conciliación
+    debe proponer el write-off en moneda de compañía con el importe exacto, sin
+    convertir a moneda secundaria y de vuelta (lo que introduce error de redondeo).
+
+    Caso real (ticket 120245): débito 1.210 vs crédito 700/0,50 en moneda secundaria
+    → diferencia 510 en moneda de compañía. Sin el fix el wizard elige la moneda
+    secundaria y propone 0,36 × 1400 = 504 en lugar de 510 (verificado).
+
+    Nota: la moneda de compañía del entorno de test (AccountTestInvoicingCommon) es
+    USD, así que usamos EUR como la moneda secundaria "cara" que en producción
+    representa el USD frente al ARS. La tasa 1 EUR = 1400 (moneda de compañía)
+    reproduce el mismo factor de redondeo del caso real.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.company_data["company"]
+        # Las compañías argentinas exigen redondeo global (constraint de
+        # saas_client_l10n_ar); lo seteamos junto con el país para no pegar
+        # contra un estado intermedio inválido.
+        cls.company.write(
+            {
+                "country_id": cls.env.ref("base.ar").id,
+                "tax_calculation_rounding_method": "round_globally",
+            }
+        )
+        cls.company.reconcile_on_company_currency = True
+        cls.company_currency = cls.company_data["currency"]
+        # rate = unidades de moneda secundaria por unidad de compañía → 1/1400
+        # significa 1 EUR = 1400 (moneda de compañía).
+        cls.foreign_currency = cls.setup_other_currency("EUR", rates=[("2016-01-01", 1 / 1400)])
+        cls.receivable = cls.company_data["default_account_receivable"]
+        cls.receivable.currency_id = False
+        cls.date = fields.Date.from_string("2016-01-01")
+
+    def _receivable_line(self, balance, currency, amount_currency):
+        move = self.env["account.move"].create(
+            {
+                "move_type": "entry",
+                "date": self.date,
+                "journal_id": self.company_data["default_journal_misc"].id,
+                "line_ids": [
+                    Command.create(
+                        {
+                            "account_id": self.receivable.id,
+                            "balance": balance,
+                            "currency_id": currency.id,
+                            "amount_currency": amount_currency,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "account_id": self.company_data["default_account_revenue"].id,
+                            "balance": -balance,
+                            "currency_id": currency.id,
+                            "amount_currency": -amount_currency,
+                        }
+                    ),
+                ],
+            }
+        )
+        move.action_post()
+        return move.line_ids.filtered(lambda l: l.account_id == self.receivable)
+
+    def test_wizard_proposes_write_off_in_company_currency(self):
+        """El wizard debe proponer 510 en moneda de compañía, no 504 (0,36 × 1400)."""
+        # Débito: 1.210 en moneda de compañía, sin moneda secundaria.
+        debit_line = self._receivable_line(1210.0, self.company_currency, 1210.0)
+        # Crédito: 700 (compañía) / 0,50 EUR (pago manual en moneda secundaria
+        # a la cotización del día: -700 × 1/1400 = -0,50).
+        credit_line = self._receivable_line(-700.0, self.foreign_currency, -0.50)
+
+        wizard = (
+            self.env["account.reconcile.wizard"]
+            .with_context(
+                active_model="account.move.line",
+                active_ids=(debit_line | credit_line).ids,
+            )
+            .create({})
+        )
+
+        # Con reconcile_on_company_currency el write-off debe estar en ARS.
+        self.assertEqual(wizard.reco_currency_id, self.company_currency)
+        # El importe debe ser la diferencia exacta en ARS, sin pérdida por redondeo
+        # al pasar por moneda secundaria.
+        self.assertAlmostEqual(wizard.amount, 510.0)
+        self.assertAlmostEqual(wizard.amount_currency, 510.0)

--- a/account_accountant_ux/wizards/account_reconcile_wizard.py
+++ b/account_accountant_ux/wizards/account_reconcile_wizard.py
@@ -10,6 +10,29 @@ class AccountReconcileWizard(models.TransientModel):
 
     multiple_partners = fields.Boolean(compute="_compute_multiple_partners")
 
+    @api.depends("move_line_ids")
+    def _compute_reco_wizard_data(self):
+        super()._compute_reco_wizard_data()
+        for wizard in self:
+            if (
+                not wizard.company_id.reconcile_on_company_currency
+                or not wizard.reco_currency_id
+                or wizard.reco_currency_id == wizard.company_currency_id
+            ):
+                continue
+            # Con reconcile_on_company_currency la conciliación es íntegramente
+            # en moneda de compañía. El wizard nativo elige USD como reco_currency
+            # cuando hay una sola moneda foránea y convierte el residual ARS→USD→ARS
+            # usando cotizaciones diferentes, introduciendo error de redondeo
+            # (ej. 510 ARS → 0,36 USD × 1400 = 504 ARS). Forzamos moneda de
+            # compañía y calculamos el importe desde el balance neto de los apuntes,
+            # que siempre coincide con el write-off necesario.
+            company_currency = wizard.company_currency_id
+            wizard.reco_currency_id = company_currency
+            net = company_currency.round(sum(aml.amount_residual for aml in wizard.move_line_ids._origin))
+            wizard.amount = net
+            wizard.amount_currency = net
+
     @api.depends("move_line_ids.partner_id")
     @api.depends_context("active_ids")
     def _compute_multiple_partners(self):


### PR DESCRIPTION
## Summary

When `reconcile_on_company_currency` is active, the native reconcile wizard selects the foreign currency (e.g. USD) as `reco_currency` whenever there is exactly one foreign currency among the selected lines. It then converts the ARS residual to USD and back using potentially different exchange rates, introducing a rounding error (e.g. 510 ARS → 0.36 USD × 1400 = 504 ARS).

### Root cause

`_compute_reco_wizard_data` calls `_prepare_move_line_residual_amounts` which, for a pure-ARS receivable line with a foreign-currency counterpart, adds a USD entry by converting the residual at today's Odoo rate. The wizard then picks USD as `reco_currency` (single foreign currency branch) and computes the ARS write-off as `round(residual_USD * rate)`, which differs from the direct ARS residual due to rounding in the USD conversion.

### Fix

Override `_compute_reco_wizard_data` in `account_accountant_ux`: after `super()`, when `reconcile_on_company_currency` is active and the wizard chose a foreign `reco_currency`, force `reco_currency_id` back to company currency and recompute `amount` from the net balance of the selected lines (which always equals the required write-off amount, with no intermediate currency conversion).

## Related

Companion fix for the partial reconcile residual: ingadhoc/account-financial-tools#977

## Test plan

- [ ] Run `account_accountant_ux` test suite: `test_reconcile_wizard.py::TestReconcileWizardCompanyCurrency::test_wizard_proposes_write_off_in_company_currency`
- [ ] Manually reproduce: company with `reconcile_on_company_currency`, select one ARS line (1218) and one ARS/USD line (708 ARS / 0.50 USD) in the reconciliation widget → wizard must propose 510 ARS, not 504 ARS