### PR TITLE
[FIX] l10n_ar_account_reports: export TXT for all selected companies

### DIFF
--- a/l10n_ar_account_reports/i18n/es.po
+++ b/l10n_ar_account_reports/i18n/es.po
@@ -1353,10 +1353,10 @@ msgstr ""
 #: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
 msgid ""
 "There is no withholding regime (ARCA Code 'l10n_ar_code') configured for tax "
-"'%(tax_name)s' of partner '%(partner_name)s'"
+"'%(tax_name)s'"
 msgstr ""
-"No hay regimen de retencion (ARCA Code 'l10n_ar_code') configurado para el "
-"impuesto '%(tax_name)s' del partner '%(partner_name)s'"
+"No hay régimen de retención (Código de ARCA 'l10n_ar_code') configurado para "
+"el impuesto '%(tax_name)s'"
 
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_patrimonial_line_total_assets

--- a/l10n_ar_account_reports/i18n/l10n_ar_account_reports.pot
+++ b/l10n_ar_account_reports/i18n/l10n_ar_account_reports.pot
@@ -1231,8 +1231,8 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/sircar_report.py:0
 msgid ""
-"There is no withholding regime (ARCA Code 'l10n_ar_code') configured for tax"
-" '%(tax_name)s' of partner '%(partner_name)s'"
+"There is no withholding regime (ARCA Code 'l10n_ar_code') configured for tax "
+"'%(tax_name)s'"
 msgstr ""
 
 #. module: l10n_ar_account_reports

--- a/l10n_ar_account_reports/models/caba_report.py
+++ b/l10n_ar_account_reports/models/caba_report.py
@@ -76,7 +76,7 @@ class L10n_ArCabaReportHandler(models.AbstractModel):
         return self.env["account.move.line"].search(domain, order="date asc, name asc, id asc")
 
     def _caba_get_lines_domain(self, options, refund=False):
-        domain = get_standard_lines_domain(self.env.company.ids, options)
+        domain = get_standard_lines_domain(self.env["account.report"].get_report_company_ids(options), options)
         if refund:
             domain += [("move_id.move_type", "=", "out_refund")]
         else:

--- a/l10n_ar_account_reports/models/l10n_ar_vat_ret_perc_sufrido.py
+++ b/l10n_ar_account_reports/models/l10n_ar_vat_ret_perc_sufrido.py
@@ -67,7 +67,7 @@ class L10n_ArIvaReportHandler(models.AbstractModel):
             )
         domain = [
             ("tax_line_id.l10n_ar_state_id", "=", False),
-        ] + get_standard_lines_domain(self.env.company.ids, options)
+        ] + get_standard_lines_domain(self.env["account.report"].get_report_company_ids(options), options)
 
         if file_type == "ret":
             # TODO: ver que agregamos en el domain para retenciones iva sufridas

--- a/l10n_ar_account_reports/models/mendoza_report.py
+++ b/l10n_ar_account_reports/models/mendoza_report.py
@@ -62,7 +62,7 @@ class L10n_ArMendozaReportHandler(models.AbstractModel):
             ("tax_line_id.l10n_ar_state_id.code", "=", "M"),
             ("tax_line_id.l10n_ar_state_id.country_id.code", "=", "AR"),
             ("tax_line_id.l10n_ar_withholding_payment_type", "=", "supplier"),
-        ] + get_standard_lines_domain(self.env.company.ids, options)
+        ] + get_standard_lines_domain(self.env["account.report"].get_report_company_ids(options), options)
         return self.env["account.move.line"].search(domain, order="date asc, name asc, id asc")
 
     def _get_mendoza_txt_content(self, move_lines):

--- a/l10n_ar_account_reports/models/misiones_report.py
+++ b/l10n_ar_account_reports/models/misiones_report.py
@@ -66,7 +66,7 @@ class L10n_ArMisionesReportHandler(models.AbstractModel):
         domain = [
             ("tax_line_id.l10n_ar_state_id.code", "=", "N"),
             ("tax_line_id.l10n_ar_state_id.country_id.code", "=", "AR"),
-        ] + get_standard_lines_domain(self.env.company.ids, options)
+        ] + get_standard_lines_domain(self.env["account.report"].get_report_company_ids(options), options)
 
         if file_type == "ret":
             domain += [("tax_line_id.l10n_ar_withholding_payment_type", "=", "supplier")]

--- a/l10n_ar_account_reports/models/pba_report.py
+++ b/l10n_ar_account_reports/models/pba_report.py
@@ -119,7 +119,7 @@ class L10n_ArPbaReportHandler(models.AbstractModel):
         domain = [
             ("tax_line_id.l10n_ar_state_id.code", "=", "B"),
             ("tax_line_id.l10n_ar_state_id.country_id.code", "=", "AR"),
-        ] + get_standard_lines_domain(self.env.company.ids, options)
+        ] + get_standard_lines_domain(self.env["account.report"].get_report_company_ids(options), options)
 
         if file_type == "ret_a122r":
             domain += [("tax_line_id.l10n_ar_withholding_payment_type", "=", "supplier")]

--- a/l10n_ar_account_reports/models/santa_fe_report.py
+++ b/l10n_ar_account_reports/models/santa_fe_report.py
@@ -55,7 +55,7 @@ class L10n_ArSantaFeReportHandler(models.AbstractModel):
             "|",
             ("tax_line_id.type_tax_use", "=", "sale"),
             ("tax_line_id.l10n_ar_withholding_payment_type", "=", "supplier"),
-        ] + get_standard_lines_domain(self.env.company.ids, options)
+        ] + get_standard_lines_domain(self.env["account.report"].get_report_company_ids(options), options)
         return self.env["account.move.line"].search(domain, order="date asc, name asc, id asc")
 
     def _get_santa_fe_txt_content(self, move_lines):

--- a/l10n_ar_account_reports/models/sicore_report.py
+++ b/l10n_ar_account_reports/models/sicore_report.py
@@ -54,7 +54,7 @@ class L10n_ArSicoreReportHandler(models.AbstractModel):
             ("tax_line_id.l10n_ar_tax_type", "in", ["earnings", "earnings_scale"]),
             ("tax_line_id.l10n_ar_withholding_payment_type", "=", "supplier"),
             ("tax_line_id.country_code", "=", "AR"),
-        ] + get_standard_lines_domain(self.env.company.ids, options)
+        ] + get_standard_lines_domain(self.env["account.report"].get_report_company_ids(options), options)
         return self.env["account.move.line"].search(domain, order="date asc, name asc, id asc")
 
     def _get_sicore_txt_content(self, move_lines):

--- a/l10n_ar_account_reports/models/sifere_report.py
+++ b/l10n_ar_account_reports/models/sifere_report.py
@@ -83,7 +83,7 @@ class L10n_ArSifereReportHandler(models.AbstractModel):
             )
         domain = [
             ("tax_line_id.l10n_ar_state_id.country_id.code", "=", "AR"),
-        ] + get_standard_lines_domain(self.env.company.ids, options)
+        ] + get_standard_lines_domain(self.env["account.report"].get_report_company_ids(options), options)
 
         if file_type == "ret":
             domain += [("tax_line_id.l10n_ar_withholding_payment_type", "=", "customer")]

--- a/l10n_ar_account_reports/models/sircar_report.py
+++ b/l10n_ar_account_reports/models/sircar_report.py
@@ -69,7 +69,7 @@ class L10n_ArSircarReportHandler(models.AbstractModel):
         domain = [
             ("tax_line_id.l10n_ar_state_id.code", "not in", ["C", "B", "T"]),
             ("tax_line_id.l10n_ar_state_id.country_id.code", "=", "AR"),
-        ] + get_standard_lines_domain(self.env.company.ids, options)
+        ] + get_standard_lines_domain(self.env["account.report"].get_report_company_ids(options), options)
 
         if file_type == "ret":
             domain += [("tax_line_id.l10n_ar_withholding_payment_type", "=", "supplier")]
@@ -126,9 +126,8 @@ class L10n_ArSircarReportHandler(models.AbstractModel):
                 if not tax.l10n_ar_code:
                     raise RedirectWarning(
                         message=_(
-                            "There is no withholding regime (ARCA Code 'l10n_ar_code') configured for tax '%(tax_name)s' of partner '%(partner_name)s'",
+                            "There is no withholding regime (ARCA Code 'l10n_ar_code') configured for tax '%(tax_name)s'",
                             tax_name=tax.name,
-                            partner_name=line.partner_id.name,
                         ),
                         action=tax.get_formview_action(),
                         button_text=_("Edit tax"),

--- a/l10n_ar_account_reports/models/tucuman_report.py
+++ b/l10n_ar_account_reports/models/tucuman_report.py
@@ -90,7 +90,7 @@ class L10n_ArTucumanReportHandler(models.AbstractModel):
             "|",
             ("tax_line_id.type_tax_use", "=", "sale"),
             ("tax_line_id.l10n_ar_withholding_payment_type", "=", "supplier"),
-        ] + get_standard_lines_domain(self.env.company.ids, options)
+        ] + get_standard_lines_domain(self.env["account.report"].get_report_company_ids(options), options)
 
         # lo hacemos igual que está hoy, probablemente tengamos que hacer busqueda negativa para los otros casos?
         if file_type == "ncfact":


### PR DESCRIPTION
Los reportes TXT de regímenes de IIBB / retenciones / percepciones filtraban los apuntes contables por `self.env.company.ids`, por lo que solo exportaban las líneas de la compañía activa en vez de todas las compañías seleccionadas en el selector multi-compañía del reporte.

## Cambio principal: export multi-compañía

En todos los call sites de `get_standard_lines_domain()` se reemplaza `self.env.company.ids` por `self.env["account.report"].get_report_company_ids(options)`, que es el helper del framework de `account_reports` que devuelve las compañías efectivamente seleccionadas en las `options` del reporte.

Archivos afectados (un call site cada uno):

- `sircar_report.py`
- `sicore_report.py`
- `sifere_report.py`
- `caba_report.py`
- `pba_report.py`
- `mendoza_report.py`
- `santa_fe_report.py`
- `tucuman_report.py`
- `misiones_report.py`
- `l10n_ar_vat_ret_perc_sufrido.py`

## Cambio secundario: mensaje SIRCAR y traducción

En `sircar_report.py`, el `RedirectWarning` de "no hay régimen de retención configurado" se simplifica:

- Se quita la referencia al partner del mensaje (`of partner '%(partner_name)s'`) y el argumento `partner_name`, ahora sin uso.
- Se actualiza el `msgid` del `.pot` para que matchee el nuevo texto en inglés.
- Se ajusta la traducción al español (`es.po`) para que sea consistente con el `msgid` actual: se elimina el `del contacto` sobrante (el mensaje ya no incluye el partner) y se corrige la ortografía (`régimen`, `retención`).

## Test plan

- Con un usuario que tenga varias compañías seleccionadas en el selector multi-compañía, generar cualquiera de los TXT (ej. SIRCAR Retenciones/Percepciones) y verificar que el archivo incluye apuntes de todas las compañías seleccionadas, no solo la activa.
- Con una sola compañía seleccionada, el resultado debe ser idéntico al comportamiento anterior.
- Forzar el `RedirectWarning` (impuesto SIRCAR sin `l10n_ar_code`) y verificar que el mensaje ya no menciona el contacto, en inglés y en español.
