### PR TITLE
[FIX] account_journal_book_report: notify when report is sent to background

### DIFF
--- a/account_journal_book_report/__manifest__.py
+++ b/account_journal_book_report/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Reporte de Libro Diario Contable",
-    "version": "18.0.1.2.0",
+    "version": "18.0.1.2.1",
     "author": "ADHOC SA",
     "website": "www.adhoc.com.ar",
     "category": "Localization/Accounting",

--- a/account_journal_book_report/__manifest__.py
+++ b/account_journal_book_report/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Reporte de Libro Diario Contable",
-    "version": "18.0.1.2.1",
+    "version": "18.0.1.2.0",
     "author": "ADHOC SA",
     "website": "www.adhoc.com.ar",
     "category": "Localization/Accounting",

--- a/account_journal_book_report/i18n/es.po
+++ b/account_journal_book_report/i18n/es.po
@@ -97,6 +97,11 @@ msgid "Journal Book Report"
 msgstr "Reporte de Grupo de Diario"
 
 #. module: account_journal_book_report
+#: code:addons/account_journal_book_report/wizard/account_journal_book_report.py:0
+msgid "Journal Book report sent to background"
+msgstr "Reporte de Libro Diario enviado a segundo plano"
+
+#. module: account_journal_book_report
 #: model:ir.model.fields,field_description:account_journal_book_report.field_account_journal_book_group__write_uid
 #: model:ir.model.fields,field_description:account_journal_book_report.field_account_journal_book_report__write_uid
 msgid "Last Updated by"
@@ -138,6 +143,15 @@ msgstr "Fecha de inicio"
 #: model:ir.model.fields,field_description:account_journal_book_report.field_account_journal_book_report__target_move
 msgid "Target Moves"
 msgstr "Movimientos Objetivos"
+
+#. module: account_journal_book_report
+#: code:addons/account_journal_book_report/wizard/account_journal_book_report.py:0
+msgid ""
+"The Journal Book report is being generated in the background. You will be "
+"notified with a download link when it is ready."
+msgstr ""
+"El reporte de Libro Diario se está generando en segundo plano. Se le "
+"notificará con un enlace de descarga cuando esté listo."
 
 #. module: account_journal_book_report
 #: model:ir.model.fields,field_description:account_journal_book_report.field_account_journal_book_report__last_entry_number

--- a/account_journal_book_report/wizard/account_journal_book_report.py
+++ b/account_journal_book_report/wizard/account_journal_book_report.py
@@ -5,7 +5,7 @@ import base64
 
 from dateutil.relativedelta import relativedelta
 from markupsafe import Markup
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.tools.misc import get_lang
 
 
@@ -105,10 +105,12 @@ class AccountJournalBookReport(models.TransientModel):
         """Este método se llama desde el botón 'Imprimir' del wizard 'Libro Diario'"""
         self.ensure_one()
         if not self._context.get("bg_job"):
-            # bg_enqueue devuelve (action, jobs); el botón del wizard espera solo la
-            # acción. Sin desempaquetar, el cliente recibe una lista y no renderiza la
-            # notificación de "se enviará en segundo plano".
             action, _jobs = self.bg_enqueue("action_check_report")
+            action["params"]["title"] = _("Journal Book report sent to background")
+            action["params"]["message"] = _(
+                "The Journal Book report is being generated in the background. "
+                "You will be notified with a download link when it is ready."
+            )
             return action
         else:
             data = {}

--- a/account_journal_book_report/wizard/account_journal_book_report.py
+++ b/account_journal_book_report/wizard/account_journal_book_report.py
@@ -105,7 +105,11 @@ class AccountJournalBookReport(models.TransientModel):
         """Este método se llama desde el botón 'Imprimir' del wizard 'Libro Diario'"""
         self.ensure_one()
         if not self._context.get("bg_job"):
-            return self.bg_enqueue("action_check_report")
+            # bg_enqueue devuelve (action, jobs); el botón del wizard espera solo la
+            # acción. Sin desempaquetar, el cliente recibe una lista y no renderiza la
+            # notificación de "se enviará en segundo plano".
+            action, _jobs = self.bg_enqueue("action_check_report")
+            return action
         else:
             data = {}
             data["ids"] = self.env.context.get("active_ids", [])


### PR DESCRIPTION
## Problem

When launching the *Libro Diario* (Journal Book) report, which is processed in background via `base_bg`, the "sent to background" notification was never shown to the user. The job was still enqueued and processed correctly, but the user got no feedback.

## Root cause

`base.bg.bg_enqueue()` returns a `(action, jobs)` tuple. The `action_check_report` wizard button returned that tuple verbatim, so the web client received a list instead of a single action dict and silently failed to render the `display_notification` client action.

This is a desync with a `base_bg` API change: `bg_enqueue` used to return just the notification dict and now returns `(dict, jobs)`. Other callers (e.g. the bank reconciliation widget) already unpack it.

## Fix

Unpack the tuple in `action_check_report` and return only the `display_notification` action.

## Test plan

1. Open the *Libro Diario* wizard, fill the dates and journals, click *Imprimir*.
2. Confirm the success notification ("Processes sent to background successfully / You will be notified when they are done.") now appears.
3. Confirm the background job still runs and the report download link is delivered when it finishes.