### PR TITLE
[IMP] l10n_ar_import_bill: make user messages translatable

### DIFF
--- a/l10n_ar_import_bill/i18n/es.po
+++ b/l10n_ar_import_bill/i18n/es.po
@@ -27,8 +27,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_ar_import_bill.view_afip_import_wizard_form
 msgid ""
 "<i class=\"fa fa-exclamation-triangle\" title=\"Warning\"/>\n"
-"                   <span>Importing sales from ARCA: Only invoices dated "
-"before the accounting start date will be imported.</span>"
+"                   <span>Importing sales from ARCA: Only invoices dated before the accounting start date will be imported.</span>"
 msgstr ""
 "<i class=\"fa fa-exclamation-triangle\" title=\"Warning\"/>\n"
 "                   <span>Importación de ventas desde ARCA: Solo se "
@@ -47,6 +46,11 @@ msgstr ""
 "se crearán porque ya existen. </span>"
 
 #. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__file_data
+msgid "ARCA Excel File"
+msgstr "Archivo Excel ARCA"
+
+#. module: l10n_ar_import_bill
 #: model:ir.model,name:l10n_ar_import_bill.model_account_import_summary
 msgid "Account import summary view"
 msgstr "Vista de resumen de la importación de cuentas"
@@ -57,39 +61,52 @@ msgid "Account used as counterpart when importing from settings"
 msgstr "Cuenta utilizada como contrapartida al importar desde la configuración"
 
 #. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__file_data
-msgid "Archivo ARCA Excel"
-msgstr ""
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__exists
+msgid "Already Exists"
+msgstr "Ya Existe"
 
 #. module: l10n_ar_import_bill
-#: model:ir.model.fields,help:l10n_ar_import_bill.field_afip_import_wizard__file_data
-msgid "Archivo Excel exportado desde ARCA"
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/models/account_journal.py:0
+msgid ""
+"An uploaded file does not correspond to either sales or purchases for "
+"importing invoices from ARCA."
 msgstr ""
+"Se subió un archivo que no se corresponde ni con ventas ni con compras para "
+"importar facturas desde ARCA."
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__auto_validate
-msgid "Autovalidar Facturas Importadas"
-msgstr ""
+msgid "Auto-validate Imported Invoices"
+msgstr "Autovalidar Facturas Importadas"
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__cae
 msgid "CAE"
-msgstr ""
+msgstr "CAE"
 
 #. module: l10n_ar_import_bill
 #: model_terms:ir.ui.view,arch_db:l10n_ar_import_bill.view_afip_import_file_wizard_form
+#: model_terms:ir.ui.view,arch_db:l10n_ar_import_bill.view_afip_import_wizard_form
 msgid "Cancel"
 msgstr "Cancelar"
 
 #. module: l10n_ar_import_bill
-#: model_terms:ir.ui.view,arch_db:l10n_ar_import_bill.view_afip_import_wizard_form
-msgid "Cancelar"
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid ""
+"Cannot import invoice dated %(invoice_date)s because it is after the "
+"accounting start date (%(start_date)s). Only invoices before the accounting "
+"start date can be imported."
 msgstr ""
+"No se puede importar la factura con fecha %(invoice_date)s porque es "
+"posterior a la fecha de inicio de la contabilidad (%(start_date)s). Solo se "
+"pueden importar facturas anteriores a la fecha de inicio de la contabilidad."
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__company_id
 msgid "Company"
-msgstr "Companía"
+msgstr "Compañía"
 
 #. module: l10n_ar_import_bill
 #: model_terms:ir.ui.view,arch_db:l10n_ar_import_bill.view_afip_import_file_wizard_form
@@ -102,21 +119,47 @@ msgid "Counterpart Account"
 msgstr "Cuenta de contrapartida"
 
 #. module: l10n_ar_import_bill
-#: model_terms:ir.ui.view,arch_db:l10n_ar_import_bill.view_afip_import_wizard_form
-msgid "Crear Facturas"
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid ""
+"Counterpart account is required when importing sales from ARCA. Please select "
+"an account."
 msgstr ""
+"La cuenta de contrapartida es obligatoria al importar ventas desde ARCA. Por "
+"favor, seleccione una cuenta."
+
+#. module: l10n_ar_import_bill
+#: model_terms:ir.ui.view,arch_db:l10n_ar_import_bill.view_afip_import_wizard_form
+msgid "Create Invoices"
+msgstr "Crear Facturas"
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__create_uid
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__create_uid
 msgid "Created by"
-msgstr "Creado Por"
+msgstr "Creado por"
+
+#. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard_line.py:0
+msgid "Created by invoice import"
+msgstr "Creado por importación de facturas"
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__create_date
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__create_date
 msgid "Created on"
-msgstr "Creado en"
+msgstr "Creado el"
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__currency
+msgid "Currency"
+msgstr "Moneda"
+
+#. module: l10n_ar_import_bill
+#: model_terms:ir.ui.view,arch_db:l10n_ar_import_bill.view_afip_import_wizard_form
+msgid "Delete"
+msgstr "Eliminar"
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_account_import_summary__display_name
@@ -127,38 +170,37 @@ msgid "Display Name"
 msgstr "Nombre para mostrar"
 
 #. module: l10n_ar_import_bill
-#. odoo-python
-#: code:addons/l10n_ar_import_bill/models/account_journal.py:0
-msgid ""
-"El archivo no contiene las siguientes columnas requeridas: %s.\n"
-"\n"
-"Si no realizó cambios manuales en el archivo Excel, es posible que ARCA haya "
-"modificado el formato del archivo. En ese caso, por favor reporte el "
-"inconveniente a través de un ticket de soporte."
-msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model_terms:ir.ui.view,arch_db:l10n_ar_import_bill.view_afip_import_wizard_form
-msgid "Eliminar"
-msgstr ""
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__document_type
+msgid "Document Type"
+msgstr "Tipo de Documento"
 
 #. module: l10n_ar_import_bill
 #. odoo-python
 #: code:addons/l10n_ar_import_bill/models/account_journal.py:0
-msgid ""
+msgid "Error reading the file. Please verify it is a valid .xlsx file. Error: %s"
+msgstr ""
 "Error al leer el archivo. Por favor verifique que sea un archivo válido de "
 "tipo .xlsx. Error: %s"
-msgstr ""
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,help:l10n_ar_import_bill.field_afip_import_wizard__file_data
+msgid "Excel file exported from ARCA"
+msgstr "Archivo Excel exportado desde ARCA"
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__currency_rate
+msgid "Exchange Rate"
+msgstr "Tipo de Cambio"
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__exento
-msgid "Exento"
-msgstr ""
+msgid "Exempt"
+msgstr "Exento"
 
 #. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__date_invoice
-msgid "Fecha de Factura"
-msgstr ""
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__file_name
+msgid "File Name"
+msgstr "Nombre del Archivo"
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_account_import_summary__id
@@ -166,37 +208,12 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__id
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__id
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 #. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_0
-msgid "IVA 0%"
-msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_10_5
-msgid "IVA 10.5%"
-msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_2_5
-msgid "IVA 2.5%"
-msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_21
-msgid "IVA 21%"
-msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_27
-msgid "IVA 27%"
-msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_5
-msgid "IVA 5%"
-msgstr ""
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__partner_identification_type
+msgid "Identification Type"
+msgstr "Tipo de Identificación"
 
 #. module: l10n_ar_import_bill
 #: model:ir.model,name:l10n_ar_import_bill.model_afip_import_wizard
@@ -204,16 +221,38 @@ msgid "Import AFIP bills from xlsx"
 msgstr "Importar facturas de ARCA desde xlsx"
 
 #. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/models/account_journal.py:0
+msgid "Import Customer Invoices"
+msgstr "Importación de Facturas de Cliente"
+
+#. module: l10n_ar_import_bill
 #. odoo-javascript
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/models/account_import_summary.py:0
 #: code:addons/l10n_ar_import_bill/static/src/xml/account_import_arca.xml:0
 msgid "Import Purchases from ARCA"
 msgstr "Importar Compras desde ARCA"
 
 #. module: l10n_ar_import_bill
 #. odoo-javascript
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/models/account_import_summary.py:0
 #: code:addons/l10n_ar_import_bill/static/src/xml/account_import_arca.xml:0
 msgid "Import Sales from ARCA"
 msgstr "Importar Ventas desde ARCA"
+
+#. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/models/account_journal.py:0
+msgid "Import Vendor Bills"
+msgstr "Importación de Facturas de Proveedor"
+
+#. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid "Import completed"
+msgstr "Importación completada"
 
 #. module: l10n_ar_import_bill
 #. odoo-javascript
@@ -240,6 +279,43 @@ msgid "Import your sales invoices from ARCA Excel file."
 msgstr "Importa tus facturas de venta desde archivo Mis Comprobantes de ARCA"
 
 #. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid "Imported Customer Invoices"
+msgstr "Facturas de Cliente Importadas"
+
+#. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid "Imported Vendor Bills"
+msgstr "Facturas de Proveedor Importadas"
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__date_invoice
+msgid "Invoice Date"
+msgstr "Fecha de Factura"
+
+#. module: l10n_ar_import_bill
+#: model:ir.model,name:l10n_ar_import_bill.model_afip_import_wizard_line
+msgid "Invoice Line Imported from Excel"
+msgstr "Línea de Factura Importada desde Excel"
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__line_ids
+msgid "Invoice Lines"
+msgstr "Líneas de Facturas"
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__invoice_number
+msgid "Invoice Number"
+msgstr "Número de Factura"
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__move_type
+msgid "Invoice Type"
+msgstr "Tipo de Factura"
+
+#. module: l10n_ar_import_bill
 #: model:ir.model,name:l10n_ar_import_bill.model_account_journal
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__journal_id
 msgid "Journal"
@@ -254,63 +330,91 @@ msgstr "Dominio Diario"
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__write_uid
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__write_uid
 msgid "Last Updated by"
-msgstr "Última Actualización Por"
+msgstr "Última Actualización por"
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__write_date
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__write_date
 msgid "Last Updated on"
-msgstr "Última Actualización en"
-
-#. module: l10n_ar_import_bill
-#: model:ir.model,name:l10n_ar_import_bill.model_afip_import_wizard_line
-msgid "Línea de Factura Importada desde Excel"
-msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__line_ids
-msgid "Líneas de Facturas"
-msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__currency
-msgid "Moneda"
-msgstr ""
+msgstr "Última Actualización el"
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__neto_grav_iva_0
-msgid "Neto Gravado IVA 0%"
-msgstr ""
+msgid "Net Taxable VAT 0%"
+msgstr "Neto Gravado IVA 0%"
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__neto_grav_iva_10_5
-msgid "Neto Gravado IVA 10.5%"
-msgstr ""
+msgid "Net Taxable VAT 10.5%"
+msgstr "Neto Gravado IVA 10.5%"
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__neto_grav_iva_2_5
-msgid "Neto Gravado IVA 2.5%"
-msgstr ""
+msgid "Net Taxable VAT 2.5%"
+msgstr "Neto Gravado IVA 2.5%"
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__neto_grav_iva_21
-msgid "Neto Gravado IVA 21%"
-msgstr ""
+msgid "Net Taxable VAT 21%"
+msgstr "Neto Gravado IVA 21%"
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__neto_grav_iva_27
-msgid "Neto Gravado IVA 27%"
-msgstr ""
+msgid "Net Taxable VAT 27%"
+msgstr "Neto Gravado IVA 27%"
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__neto_grav_iva_5
-msgid "Neto Gravado IVA 5%"
-msgstr ""
+msgid "Net Taxable VAT 5%"
+msgstr "Neto Gravado IVA 5%"
 
 #. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__no_gravado
-msgid "No Gravado"
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid ""
+"No 'VAT Not Applicable' tax found. You must create a purchase tax with the "
+"'VAT Not Applicable' group."
 msgstr ""
+"No se encontró un impuesto de IVA No Corresponde. Debe crear un impuesto de "
+"compras con el grupo 'IVA No Corresponde'."
+
+#. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid ""
+"No Non-Taxable VAT tax found. You must create a purchase tax with the "
+"'Non-Taxable VAT' group."
+msgstr ""
+"No se encontró un impuesto de IVA No Gravado. Debe crear un impuesto de "
+"compras con el grupo 'IVA No Gravado'."
+
+#. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid ""
+"No Other Taxes tax found. You must create a purchase tax with the 'Other "
+"Taxes' tribute group."
+msgstr ""
+"No se encontró un impuesto de Otros Tributos. Debe crear un impuesto de "
+"compras con el grupo de tributo 'Otros Tributos'."
+
+#. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid ""
+"No VAT Exempt tax found. You must create a purchase tax with the 'VAT Exempt' "
+"group."
+msgstr ""
+"No se encontró un impuesto de IVA Exento. Debe crear un impuesto de compras "
+"con el grupo 'IVA Exento'."
+
+#. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid "No VAT tax found for the %s%% rate. Check whether this tax is disabled."
+msgstr ""
+"No se encontró un impuesto de IVA para la alícuota %s%%. Revise si este "
+"impuesto está deshabilitado."
 
 #. module: l10n_ar_import_bill
 #. odoo-python
@@ -331,72 +435,97 @@ msgid "No document type found for code: %s"
 msgstr "No se encontró tipo de documento para el código: %s"
 
 #. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__file_name
-msgid "Nombre del Archivo"
-msgstr ""
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid "No invoices were created: all required invoices already exist."
+msgstr "No se crearon facturas: todas las facturas requeridas ya existen."
 
 #. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__invoice_number
-msgid "Número de Factura"
-msgstr ""
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__no_gravado
+msgid "Non-Taxable"
+msgstr "No Gravado"
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__otros_tributos
-msgid "Otros Tributos"
-msgstr ""
+msgid "Other Taxes"
+msgstr "Otros Tributos"
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__partner_name
-msgid "Proveedor"
-msgstr ""
+msgid "Partner Name"
+msgstr "Nombre del Contacto"
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__partner_vat
+msgid "Partner VAT"
+msgstr "CUIT del Contacto"
+
+#. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid "Please upload an Excel file to import."
+msgstr "Por favor, suba un archivo Excel para importar."
 
 #. module: l10n_ar_import_bill
 #. odoo-python
 #: code:addons/l10n_ar_import_bill/models/account_journal.py:0
 msgid ""
-"Se subió un archivo que no se corresponde ni con ventas ni con compras para "
-"importar facturas desde AFIP."
+"The file does not contain the following required columns: %s.\n"
+"\n"
+"If you did not make manual changes to the Excel file, ARCA may have changed "
+"the file format. In that case, please report the issue through a support "
+"ticket."
 msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__document_type
-msgid "Tipo de Documento"
-msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__move_type
-msgid "Tipo de Factura"
-msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__partner_identification_type
-msgid "Tipo de Identificación"
-msgstr ""
+"El archivo no contiene las siguientes columnas requeridas: %s.\n"
+"\n"
+"Si no realizó cambios manuales en el archivo Excel, es posible que ARCA haya "
+"modificado el formato del archivo. En ese caso, por favor reporte el "
+"inconveniente a través de un ticket de soporte."
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__amount_total
 msgid "Total"
-msgstr ""
+msgstr "Total"
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__total_bills_exists
-msgid "Total de Facturas Existentes"
-msgstr ""
+msgid "Total Existing Invoices"
+msgstr "Total de Facturas Existentes"
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__total_bills_to_create
-msgid "Total de Facturas a Crear"
-msgstr ""
+msgid "Total Invoices to Create"
+msgstr "Total de Facturas a Crear"
 
 #. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__partner_vat
-msgid "VAT del Proveedor"
-msgstr ""
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_0
+msgid "VAT 0%"
+msgstr "IVA 0%"
 
 #. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__currency_rate
-msgid "Valor de cambio"
-msgstr ""
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_10_5
+msgid "VAT 10.5%"
+msgstr "IVA 10.5%"
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_2_5
+msgid "VAT 2.5%"
+msgstr "IVA 2.5%"
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_21
+msgid "VAT 21%"
+msgstr "IVA 21%"
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_27
+msgid "VAT 27%"
+msgstr "IVA 27%"
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_5
+msgid "VAT 5%"
+msgstr "IVA 5%"
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__wizard_id
@@ -404,6 +533,21 @@ msgid "Wizard"
 msgstr "Asistente"
 
 #. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__exists
-msgid "Ya Existe"
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/models/account_import_summary.py:0
+msgid ""
+"You must set fiscal periods first before importing purchases from ARCA. "
+"Please use the 'Set Periods' button to configure your fiscal year."
 msgstr ""
+"Debe configurar los períodos fiscales antes de importar compras desde ARCA. "
+"Por favor, use el botón 'Establecer Períodos' para configurar su año fiscal."
+
+#. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/models/account_import_summary.py:0
+msgid ""
+"You must set fiscal periods first before importing sales from ARCA. Please "
+"use the 'Set Periods' button to configure your fiscal year."
+msgstr ""
+"Debe configurar los períodos fiscales antes de importar ventas desde ARCA. "
+"Por favor, use el botón 'Establecer Períodos' para configurar su año fiscal."

--- a/l10n_ar_import_bill/i18n/l10n_ar_import_bill.pot
+++ b/l10n_ar_import_bill/i18n/l10n_ar_import_bill.pot
@@ -32,6 +32,11 @@ msgid ""
 msgstr ""
 
 #. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__file_data
+msgid "ARCA Excel File"
+msgstr ""
+
+#. module: l10n_ar_import_bill
 #: model:ir.model,name:l10n_ar_import_bill.model_account_import_summary
 msgid "Account import summary view"
 msgstr ""
@@ -42,18 +47,21 @@ msgid "Account used as counterpart when importing from settings"
 msgstr ""
 
 #. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__file_data
-msgid "Archivo ARCA Excel"
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__exists
+msgid "Already Exists"
 msgstr ""
 
 #. module: l10n_ar_import_bill
-#: model:ir.model.fields,help:l10n_ar_import_bill.field_afip_import_wizard__file_data
-msgid "Archivo Excel exportado desde ARCA"
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/models/account_journal.py:0
+msgid ""
+"An uploaded file does not correspond to either sales or purchases for "
+"importing invoices from ARCA."
 msgstr ""
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__auto_validate
-msgid "Autovalidar Facturas Importadas"
+msgid "Auto-validate Imported Invoices"
 msgstr ""
 
 #. module: l10n_ar_import_bill
@@ -63,12 +71,17 @@ msgstr ""
 
 #. module: l10n_ar_import_bill
 #: model_terms:ir.ui.view,arch_db:l10n_ar_import_bill.view_afip_import_file_wizard_form
+#: model_terms:ir.ui.view,arch_db:l10n_ar_import_bill.view_afip_import_wizard_form
 msgid "Cancel"
 msgstr ""
 
 #. module: l10n_ar_import_bill
-#: model_terms:ir.ui.view,arch_db:l10n_ar_import_bill.view_afip_import_wizard_form
-msgid "Cancelar"
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid ""
+"Cannot import invoice dated %(invoice_date)s because it is after the "
+"accounting start date (%(start_date)s). Only invoices before the accounting "
+"start date can be imported."
 msgstr ""
 
 #. module: l10n_ar_import_bill
@@ -87,8 +100,16 @@ msgid "Counterpart Account"
 msgstr ""
 
 #. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid ""
+"Counterpart account is required when importing sales from ARCA. Please select "
+"an account."
+msgstr ""
+
+#. module: l10n_ar_import_bill
 #: model_terms:ir.ui.view,arch_db:l10n_ar_import_bill.view_afip_import_wizard_form
-msgid "Crear Facturas"
+msgid "Create Invoices"
 msgstr ""
 
 #. module: l10n_ar_import_bill
@@ -98,9 +119,25 @@ msgid "Created by"
 msgstr ""
 
 #. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard_line.py:0
+msgid "Created by invoice import"
+msgstr ""
+
+#. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__create_date
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__create_date
 msgid "Created on"
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__currency
+msgid "Currency"
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#: model_terms:ir.ui.view,arch_db:l10n_ar_import_bill.view_afip_import_wizard_form
+msgid "Delete"
 msgstr ""
 
 #. module: l10n_ar_import_bill
@@ -112,35 +149,34 @@ msgid "Display Name"
 msgstr ""
 
 #. module: l10n_ar_import_bill
-#. odoo-python
-#: code:addons/l10n_ar_import_bill/models/account_journal.py:0
-msgid ""
-"El archivo no contiene las siguientes columnas requeridas: %s.\n"
-"\n"
-"Si no realizó cambios manuales en el archivo Excel, es posible que ARCA haya modificado el formato del archivo. En ese caso, por favor reporte el inconveniente a través de un ticket de soporte."
-msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model_terms:ir.ui.view,arch_db:l10n_ar_import_bill.view_afip_import_wizard_form
-msgid "Eliminar"
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__document_type
+msgid "Document Type"
 msgstr ""
 
 #. module: l10n_ar_import_bill
 #. odoo-python
 #: code:addons/l10n_ar_import_bill/models/account_journal.py:0
-msgid ""
-"Error al leer el archivo. Por favor verifique que sea un archivo válido de "
-"tipo .xlsx. Error: %s"
+msgid "Error reading the file. Please verify it is a valid .xlsx file. Error: %s"
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,help:l10n_ar_import_bill.field_afip_import_wizard__file_data
+msgid "Excel file exported from ARCA"
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__currency_rate
+msgid "Exchange Rate"
 msgstr ""
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__exento
-msgid "Exento"
+msgid "Exempt"
 msgstr ""
 
 #. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__date_invoice
-msgid "Fecha de Factura"
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__file_name
+msgid "File Name"
 msgstr ""
 
 #. module: l10n_ar_import_bill
@@ -152,33 +188,8 @@ msgid "ID"
 msgstr ""
 
 #. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_0
-msgid "IVA 0%"
-msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_10_5
-msgid "IVA 10.5%"
-msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_2_5
-msgid "IVA 2.5%"
-msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_21
-msgid "IVA 21%"
-msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_27
-msgid "IVA 27%"
-msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_5
-msgid "IVA 5%"
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__partner_identification_type
+msgid "Identification Type"
 msgstr ""
 
 #. module: l10n_ar_import_bill
@@ -187,15 +198,37 @@ msgid "Import AFIP bills from xlsx"
 msgstr ""
 
 #. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/models/account_journal.py:0
+msgid "Import Customer Invoices"
+msgstr ""
+
+#. module: l10n_ar_import_bill
 #. odoo-javascript
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/models/account_import_summary.py:0
 #: code:addons/l10n_ar_import_bill/static/src/xml/account_import_arca.xml:0
 msgid "Import Purchases from ARCA"
 msgstr ""
 
 #. module: l10n_ar_import_bill
 #. odoo-javascript
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/models/account_import_summary.py:0
 #: code:addons/l10n_ar_import_bill/static/src/xml/account_import_arca.xml:0
 msgid "Import Sales from ARCA"
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/models/account_journal.py:0
+msgid "Import Vendor Bills"
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid "Import completed"
 msgstr ""
 
 #. module: l10n_ar_import_bill
@@ -223,6 +256,43 @@ msgid "Import your sales invoices from ARCA Excel file."
 msgstr ""
 
 #. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid "Imported Customer Invoices"
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid "Imported Vendor Bills"
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__date_invoice
+msgid "Invoice Date"
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#: model:ir.model,name:l10n_ar_import_bill.model_afip_import_wizard_line
+msgid "Invoice Line Imported from Excel"
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__line_ids
+msgid "Invoice Lines"
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__invoice_number
+msgid "Invoice Number"
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__move_type
+msgid "Invoice Type"
+msgstr ""
+
+#. module: l10n_ar_import_bill
 #: model:ir.model,name:l10n_ar_import_bill.model_account_journal
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__journal_id
 msgid "Journal"
@@ -246,53 +316,71 @@ msgid "Last Updated on"
 msgstr ""
 
 #. module: l10n_ar_import_bill
-#: model:ir.model,name:l10n_ar_import_bill.model_afip_import_wizard_line
-msgid "Línea de Factura Importada desde Excel"
-msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__line_ids
-msgid "Líneas de Facturas"
-msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__currency
-msgid "Moneda"
-msgstr ""
-
-#. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__neto_grav_iva_0
-msgid "Neto Gravado IVA 0%"
+msgid "Net Taxable VAT 0%"
 msgstr ""
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__neto_grav_iva_10_5
-msgid "Neto Gravado IVA 10.5%"
+msgid "Net Taxable VAT 10.5%"
 msgstr ""
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__neto_grav_iva_2_5
-msgid "Neto Gravado IVA 2.5%"
+msgid "Net Taxable VAT 2.5%"
 msgstr ""
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__neto_grav_iva_21
-msgid "Neto Gravado IVA 21%"
+msgid "Net Taxable VAT 21%"
 msgstr ""
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__neto_grav_iva_27
-msgid "Neto Gravado IVA 27%"
+msgid "Net Taxable VAT 27%"
 msgstr ""
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__neto_grav_iva_5
-msgid "Neto Gravado IVA 5%"
+msgid "Net Taxable VAT 5%"
 msgstr ""
 
 #. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__no_gravado
-msgid "No Gravado"
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid ""
+"No 'VAT Not Applicable' tax found. You must create a purchase tax with the "
+"'VAT Not Applicable' group."
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid ""
+"No Non-Taxable VAT tax found. You must create a purchase tax with the "
+"'Non-Taxable VAT' group."
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid ""
+"No Other Taxes tax found. You must create a purchase tax with the 'Other "
+"Taxes' tribute group."
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid ""
+"No VAT Exempt tax found. You must create a purchase tax with the 'VAT Exempt' "
+"group."
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid "No VAT tax found for the %s%% rate. Check whether this tax is disabled."
 msgstr ""
 
 #. module: l10n_ar_import_bill
@@ -314,46 +402,46 @@ msgid "No document type found for code: %s"
 msgstr ""
 
 #. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__file_name
-msgid "Nombre del Archivo"
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid "No invoices were created: all required invoices already exist."
 msgstr ""
 
 #. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__invoice_number
-msgid "Número de Factura"
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__no_gravado
+msgid "Non-Taxable"
 msgstr ""
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__otros_tributos
-msgid "Otros Tributos"
+msgid "Other Taxes"
 msgstr ""
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__partner_name
-msgid "Proveedor"
+msgid "Partner Name"
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__partner_vat
+msgid "Partner VAT"
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/wizards/afip_import_wizard.py:0
+msgid "Please upload an Excel file to import."
 msgstr ""
 
 #. module: l10n_ar_import_bill
 #. odoo-python
 #: code:addons/l10n_ar_import_bill/models/account_journal.py:0
 msgid ""
-"Se subió un archivo que no se corresponde ni con ventas ni con compras para "
-"importar facturas desde AFIP."
-msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__document_type
-msgid "Tipo de Documento"
-msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__move_type
-msgid "Tipo de Factura"
-msgstr ""
-
-#. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__partner_identification_type
-msgid "Tipo de Identificación"
+"The file does not contain the following required columns: %s.\n"
+"\n"
+"If you did not make manual changes to the Excel file, ARCA may have changed "
+"the file format. In that case, please report the issue through a support "
+"ticket."
 msgstr ""
 
 #. module: l10n_ar_import_bill
@@ -363,22 +451,42 @@ msgstr ""
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__total_bills_exists
-msgid "Total de Facturas Existentes"
+msgid "Total Existing Invoices"
 msgstr ""
 
 #. module: l10n_ar_import_bill
 #: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard__total_bills_to_create
-msgid "Total de Facturas a Crear"
+msgid "Total Invoices to Create"
 msgstr ""
 
 #. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__partner_vat
-msgid "VAT del Proveedor"
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_0
+msgid "VAT 0%"
 msgstr ""
 
 #. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__currency_rate
-msgid "Valor de cambio"
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_10_5
+msgid "VAT 10.5%"
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_2_5
+msgid "VAT 2.5%"
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_21
+msgid "VAT 21%"
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_27
+msgid "VAT 27%"
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__iva_5
+msgid "VAT 5%"
 msgstr ""
 
 #. module: l10n_ar_import_bill
@@ -387,6 +495,17 @@ msgid "Wizard"
 msgstr ""
 
 #. module: l10n_ar_import_bill
-#: model:ir.model.fields,field_description:l10n_ar_import_bill.field_afip_import_wizard_line__exists
-msgid "Ya Existe"
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/models/account_import_summary.py:0
+msgid ""
+"You must set fiscal periods first before importing purchases from ARCA. "
+"Please use the 'Set Periods' button to configure your fiscal year."
+msgstr ""
+
+#. module: l10n_ar_import_bill
+#. odoo-python
+#: code:addons/l10n_ar_import_bill/models/account_import_summary.py:0
+msgid ""
+"You must set fiscal periods first before importing sales from ARCA. Please "
+"use the 'Set Periods' button to configure your fiscal year."
 msgstr ""

--- a/l10n_ar_import_bill/models/account_import_summary.py
+++ b/l10n_ar_import_bill/models/account_import_summary.py
@@ -1,4 +1,4 @@
-from odoo import models
+from odoo import _, models
 from odoo.exceptions import UserError
 
 
@@ -10,15 +10,17 @@ class AccountImportSummary(models.TransientModel):
         # Check if fiscal periods have been set (accounting_start_date must be set)
         if not self.env.company.account_opening_date:
             raise UserError(
-                "You must set fiscal periods first before importing sales from ARCA. "
-                "Please use 'Set Periods' button to configure your fiscal year."
+                _(
+                    "You must set fiscal periods first before importing sales from ARCA. "
+                    "Please use the 'Set Periods' button to configure your fiscal year."
+                )
             )
 
         return (
             self.env["afip.import.wizard"]
             .with_context(default_company_id=self.env.company.id, import_type="sale")
             ._get_records_action(
-                name="Import Sales from ARCA",
+                name=_("Import Sales from ARCA"),
                 target="new",
                 views=[(self.env.ref("l10n_ar_import_bill.view_afip_import_file_wizard_form").id, "form")],
             )
@@ -29,14 +31,16 @@ class AccountImportSummary(models.TransientModel):
         # Check if fiscal periods have been set (accounting_start_date must be set)
         if not self.env.company.account_opening_date:
             raise UserError(
-                "You must set fiscal periods first before importing purchases from ARCA. "
-                "Please use 'Set Periods' button to configure your fiscal year."
+                _(
+                    "You must set fiscal periods first before importing purchases from ARCA. "
+                    "Please use the 'Set Periods' button to configure your fiscal year."
+                )
             )
         return (
             self.env["afip.import.wizard"]
             .with_context(default_company_id=self.env.company.id, import_type="purchase")
             ._get_records_action(
-                name="Import Purchases from ARCA",
+                name=_("Import Purchases from ARCA"),
                 target="new",
                 views=[(self.env.ref("l10n_ar_import_bill.view_afip_import_file_wizard_form").id, "form")],
             )

--- a/l10n_ar_import_bill/models/account_journal.py
+++ b/l10n_ar_import_bill/models/account_journal.py
@@ -35,12 +35,7 @@ class AccountJournal(models.Model):
             try:
                 df = pd.read_excel(BytesIO(file_content), engine="openpyxl")  # use openpyxl for .xlsx
             except Exception as e:
-                raise UserError(
-                    _(
-                        "Error al leer el archivo. Por favor verifique que sea un archivo válido de tipo .xlsx. Error: %s"
-                    )
-                    % e
-                )
+                raise UserError(_("Error reading the file. Please verify it is a valid .xlsx file. Error: %s") % e)
             # El archivo tiene un header en la primera fila, lo eliminamos
             df.columns = df.iloc[0]
             df = df[1:].reset_index(drop=True)
@@ -58,7 +53,8 @@ class AccountJournal(models.Model):
             else:
                 raise UserError(
                     _(
-                        "Se subió un archivo que no se corresponde ni con ventas ni con compras para importar facturas desde AFIP."
+                        "An uploaded file does not correspond to either sales or purchases for importing "
+                        "invoices from ARCA."
                     )
                 )
 
@@ -182,9 +178,7 @@ class AccountJournal(models.Model):
             wizard.write({"line_ids": line_vals})
 
             # Determine wizard name based on journal type
-            wizard_name = (
-                "Importación de Facturas de Cliente" if self.type == "sale" else "Importación de Facturas de Proveedor"
-            )
+            wizard_name = _("Import Customer Invoices") if self.type == "sale" else _("Import Vendor Bills")
 
             return wizard._get_records_action(
                 name=wizard_name,
@@ -203,10 +197,9 @@ class AccountJournal(models.Model):
         if missing_columns:
             raise UserError(
                 _(
-                    "El archivo no contiene las siguientes columnas requeridas: %s.\n\n"
-                    "Si no realizó cambios manuales en el archivo Excel, es posible que ARCA haya "
-                    "modificado el formato del archivo. En ese caso, por favor reporte el inconveniente "
-                    "a través de un ticket de soporte."
+                    "The file does not contain the following required columns: %s.\n\n"
+                    "If you did not make manual changes to the Excel file, ARCA may have changed the "
+                    "file format. In that case, please report the issue through a support ticket."
                 )
                 % ", ".join(missing_columns)
             )

--- a/l10n_ar_import_bill/wizards/afip_import_wizard.py
+++ b/l10n_ar_import_bill/wizards/afip_import_wizard.py
@@ -1,6 +1,6 @@
 import math
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 
@@ -10,10 +10,10 @@ class AfipImportWizard(models.TransientModel):
     _check_company_auto = True
     _check_company_domain = models.check_companies_domain_parent_of
 
-    line_ids = fields.One2many("afip.import.wizard.line", "wizard_id", string="Líneas de Facturas")
+    line_ids = fields.One2many("afip.import.wizard.line", "wizard_id", string="Invoice Lines")
     company_id = fields.Many2one("res.company", required=True, default=lambda self: self.env.company)
     journal_id = fields.Many2one("account.journal", required=True, check_company=True, domain="journal_domain")
-    auto_validate = fields.Boolean(string="Autovalidar Facturas Importadas", default=False)
+    auto_validate = fields.Boolean(string="Auto-validate Imported Invoices", default=False)
     counterpart_account_id = fields.Many2one(
         "account.account",
         default=lambda self: self.env.company.get_unaffected_earnings_account(),
@@ -23,19 +23,19 @@ class AfipImportWizard(models.TransientModel):
     )
     total_bills_to_create = fields.Integer(
         compute="_compute_bills_to_create",
-        string="Total de Facturas a Crear",
+        string="Total Invoices to Create",
     )
     total_bills_exists = fields.Integer(
         compute="_compute_bills_exists",
-        string="Total de Facturas Existentes",
+        string="Total Existing Invoices",
     )
 
     #####
     # for initial import from settings
     #####
 
-    file_data = fields.Binary(string="Archivo ARCA Excel", help="Archivo Excel exportado desde ARCA")
-    file_name = fields.Char(string="Nombre del Archivo")
+    file_data = fields.Binary(string="ARCA Excel File", help="Excel file exported from ARCA")
+    file_name = fields.Char()
     journal_domain = fields.Binary(
         compute="_compute_journal_domain",
     )
@@ -53,7 +53,7 @@ class AfipImportWizard(models.TransientModel):
     def action_process_file(self):
         """Process the uploaded file and open the main import wizard"""
         if not self.file_data:
-            raise UserError("Please upload an Excel file to import.")
+            raise UserError(_("Please upload an Excel file to import."))
 
         # Create a temporary attachment
         attachment = self.env["ir.attachment"].create(
@@ -82,7 +82,7 @@ class AfipImportWizard(models.TransientModel):
         if self.env.context.get("initial_setup"):
             if not self.counterpart_account_id:
                 raise UserError(
-                    "Counterpart account is required when importing sales from ARCA. Please select an account."
+                    _("Counterpart account is required when importing sales from ARCA. Please select an account.")
                 )
 
             # Check for invoices after accounting start date
@@ -90,10 +90,15 @@ class AfipImportWizard(models.TransientModel):
                 for line in self.line_ids.filtered(lambda l: not l.exists):
                     if line.date_invoice and line.date_invoice >= self.company_id.account_opening_date:
                         raise UserError(
-                            f"Cannot import invoice dated {line.date_invoice.strftime('%Y-%m-%d')} "
-                            f"because it is after the accounting start date "
-                            f"({self.company_id.account_opening_date.strftime('%Y-%m-%d')}). "
-                            "Only invoices before the accounting start date can be imported."
+                            _(
+                                "Cannot import invoice dated %(invoice_date)s because it is after the accounting "
+                                "start date (%(start_date)s). Only invoices before the accounting start date can "
+                                "be imported."
+                            )
+                            % {
+                                "invoice_date": line.date_invoice.strftime("%Y-%m-%d"),
+                                "start_date": self.company_id.account_opening_date.strftime("%Y-%m-%d"),
+                            }
                         )
 
             counterpart_account_id = self.counterpart_account_id.id
@@ -103,8 +108,8 @@ class AfipImportWizard(models.TransientModel):
                 "type": "ir.actions.client",
                 "tag": "display_notification",
                 "params": {
-                    "title": "Import completed",
-                    "message": "No invoices were created: all required invoices already exist.",
+                    "title": _("Import completed"),
+                    "message": _("No invoices were created: all required invoices already exist."),
                     "type": "warning",
                     "sticky": False,
                 },
@@ -191,16 +196,14 @@ class AfipImportWizard(models.TransientModel):
                         move_vals["line_ids"].append(line._create_line(neto_amount, [iva_tax.id]))
                     else:
                         raise UserError(
-                            f"No se encontró un impuesto de IVA para la alícuota {vat_rate}%. "
-                            "Revise si este impuesto esta deshabilitado."
+                            _("No VAT tax found for the %s%% rate. Check whether this tax is disabled.") % vat_rate
                         )
 
             # Add line for "exento" if it has a value
             if not math.isnan(line.exento) and line.exento > 0:
                 if not tax_iva_exento:
                     raise UserError(
-                        "No se encontró un impuesto de IVA Exento. "
-                        "Debe crear un impuesto de compras con el grupo 'IVA Exento'."
+                        _("No VAT Exempt tax found. You must create a purchase tax with the 'VAT Exempt' group.")
                     )
                 move_vals["line_ids"].append(line._create_line(line.exento, [tax_iva_exento.id]))
 
@@ -208,8 +211,10 @@ class AfipImportWizard(models.TransientModel):
             if not math.isnan(line.no_gravado) and line.no_gravado > 0:
                 if not tax_iva_no_gravado:
                     raise UserError(
-                        "No se encontró un impuesto de IVA No Gravado. "
-                        "Debe crear un impuesto de compras con el grupo 'IVA No Gravado'."
+                        _(
+                            "No Non-Taxable VAT tax found. You must create a purchase tax with the "
+                            "'Non-Taxable VAT' group."
+                        )
                     )
                 move_vals["line_ids"].append(line._create_line(line.no_gravado, [tax_iva_no_gravado.id]))
 
@@ -222,8 +227,10 @@ class AfipImportWizard(models.TransientModel):
 
                 if not tax_iva_no_corresponde:
                     raise UserError(
-                        "No se encontró un impuesto de IVA No Corresponde. "
-                        "Debe crear un impuesto de compras con el grupo 'IVA No Corresponde'"
+                        _(
+                            "No 'VAT Not Applicable' tax found. You must create a purchase tax with the "
+                            "'VAT Not Applicable' group."
+                        )
                     )
                 move_vals["line_ids"].append(line._create_line(base_amount, [tax_iva_no_corresponde.id]))
 
@@ -237,8 +244,10 @@ class AfipImportWizard(models.TransientModel):
             if line.otros_tributos > 0:
                 if not tax_otros_tributos:
                     raise UserError(
-                        "No se encontró un impuesto de Otros Tributos. "
-                        "Debe crear un impuesto de compras con el grupo de tributo 'Otros Tributos'."
+                        _(
+                            "No Other Taxes tax found. You must create a purchase tax with the "
+                            "'Other Taxes' tribute group."
+                        )
                     )
 
                 # Crear el wizard con el contexto correcto
@@ -284,9 +293,7 @@ class AfipImportWizard(models.TransientModel):
             new_moves += move
 
         # Determine title based on journal type
-        title = (
-            "Facturas de Cliente Importadas" if self.journal_id.type == "sale" else "Facturas de Proveedor Importadas"
-        )
+        title = _("Imported Customer Invoices") if self.journal_id.type == "sale" else _("Imported Vendor Bills")
 
         return new_moves._get_records_action(
             name=title,

--- a/l10n_ar_import_bill/wizards/afip_import_wizard.xml
+++ b/l10n_ar_import_bill/wizards/afip_import_wizard.xml
@@ -65,15 +65,15 @@
                         <field name="date_invoice"/>
                         <field name="currency"/>
                         <field name="amount_total"/>
-                        <button name="action_remove" type="object" icon="fa-trash-o" title="Eliminar" class="oe_inline"/>
+                        <button name="action_remove" type="object" icon="fa-trash-o" title="Delete" class="oe_inline"/>
                     </list>
 
                 </field>
 
                 <footer>
 
-                    <button name="action_confirm" type="object" string="Crear Facturas" class="btn-primary"/>
-                    <button string="Cancelar" special="cancel" class="btn-secondary"/>
+                    <button name="action_confirm" type="object" string="Create Invoices" class="btn-primary"/>
+                    <button string="Cancel" special="cancel" class="btn-secondary"/>
 
                 </footer>
             </form>

--- a/l10n_ar_import_bill/wizards/afip_import_wizard_line.py
+++ b/l10n_ar_import_bill/wizards/afip_import_wizard_line.py
@@ -4,35 +4,35 @@ from odoo.exceptions import UserError
 
 class AfipImportWizardLine(models.TransientModel):
     _name = "afip.import.wizard.line"
-    _description = "Línea de Factura Importada desde Excel"
+    _description = "Invoice Line Imported from Excel"
 
     wizard_id = fields.Many2one("afip.import.wizard", required=True, ondelete="cascade")
-    invoice_number = fields.Char("Número de Factura")
-    partner_name = fields.Char("Proveedor")
-    partner_vat = fields.Char("VAT del Proveedor")
-    partner_identification_type = fields.Char("Tipo de Identificación")
-    date_invoice = fields.Date("Fecha de Factura")
-    currency = fields.Char("Moneda")
-    currency_rate = fields.Float("Valor de cambio")
+    invoice_number = fields.Char()
+    partner_name = fields.Char()
+    partner_vat = fields.Char("Partner VAT")
+    partner_identification_type = fields.Char("Identification Type")
+    date_invoice = fields.Date("Invoice Date")
+    currency = fields.Char()
+    currency_rate = fields.Float("Exchange Rate")
     amount_total = fields.Float("Total")
-    document_type = fields.Char(string="Tipo de Documento")
-    move_type = fields.Char(string="Tipo de Factura")
-    exists = fields.Boolean("Ya Existe", compute="_compute_exists", store=True)
-    iva_0 = fields.Float("IVA 0%")
-    neto_grav_iva_0 = fields.Float("Neto Gravado IVA 0%")
-    iva_2_5 = fields.Float("IVA 2.5%")
-    neto_grav_iva_2_5 = fields.Float("Neto Gravado IVA 2.5%")
-    iva_5 = fields.Float("IVA 5%")
-    neto_grav_iva_5 = fields.Float("Neto Gravado IVA 5%")
-    iva_10_5 = fields.Float("IVA 10.5%")
-    neto_grav_iva_10_5 = fields.Float("Neto Gravado IVA 10.5%")
-    iva_21 = fields.Float("IVA 21%")
-    neto_grav_iva_21 = fields.Float("Neto Gravado IVA 21%")
-    iva_27 = fields.Float("IVA 27%")
-    neto_grav_iva_27 = fields.Float("Neto Gravado IVA 27%")
-    no_gravado = fields.Float()
-    otros_tributos = fields.Float()
-    exento = fields.Float()
+    document_type = fields.Char()
+    move_type = fields.Char(string="Invoice Type")
+    exists = fields.Boolean("Already Exists", compute="_compute_exists", store=True)
+    iva_0 = fields.Float("VAT 0%")
+    neto_grav_iva_0 = fields.Float("Net Taxable VAT 0%")
+    iva_2_5 = fields.Float("VAT 2.5%")
+    neto_grav_iva_2_5 = fields.Float("Net Taxable VAT 2.5%")
+    iva_5 = fields.Float("VAT 5%")
+    neto_grav_iva_5 = fields.Float("Net Taxable VAT 5%")
+    iva_10_5 = fields.Float("VAT 10.5%")
+    neto_grav_iva_10_5 = fields.Float("Net Taxable VAT 10.5%")
+    iva_21 = fields.Float("VAT 21%")
+    neto_grav_iva_21 = fields.Float("Net Taxable VAT 21%")
+    iva_27 = fields.Float("VAT 27%")
+    neto_grav_iva_27 = fields.Float("Net Taxable VAT 27%")
+    no_gravado = fields.Float(string="Non-Taxable")
+    otros_tributos = fields.Float(string="Other Taxes")
+    exento = fields.Float(string="Exempt")
     cae = fields.Char("CAE")
 
     @api.depends("invoice_number", "partner_vat")
@@ -145,7 +145,7 @@ class AfipImportWizardLine(models.TransientModel):
     def _create_line(self, price_unit, tax_ids):
         partner = self._get_partner_by_vat()
         vals = {
-            "name": "Creado por importación de facturas",
+            "name": _("Created by invoice import"),
             "quantity": 1.0,
             "price_unit": price_unit,
             "tax_ids": [(6, 0, tax_ids)],


### PR DESCRIPTION
## Resumen

El módulo tenía conceptos mezclados (español/inglés) en strings orientados al usuario, y varios mensajes no eran traducibles. Este PR deja el producto **bilingüe EN/ES completo**:

- **Fuente en inglés**: labels de campos, `_description` de modelos, botones del wizard, nombres de acciones y títulos.
- **Traducible**: se envuelven en `_()` los `UserError`/notificaciones que estaban hardcodeados sin envolver (en `afip_import_wizard.py` y `account_import_summary.py` ni siquiera se importaba `_`).
- **Traducciones ES** completas en `i18n/es.po` + `i18n/l10n_ar_import_bill.pot` actualizado.

## No se tocó

- **Identificadores de columnas del Excel de ARCA** (`"Fecha"`, `"Nro. Doc. Receptor"`, `"Tipo Cambio"`, etc.): son claves del formato del archivo externo, no UI. Traducirlos rompería la lectura del `.xlsx`.
- Comentarios y docstrings en español (no son user-facing).

## Test plan

- `python -m py_compile` OK en los 4 módulos Python.
- `.pot` y `es.po` parsean OK (validado con `polib`): 84 entradas, msgids idénticos entre ambos, sin traducciones vacías y placeholders (`%s`, `%(...)s`) consistentes entre msgid/msgstr.
- Verificar en UI con `lang=es` que el wizard de importación (ventas/compras desde ARCA) muestra todo en español, y en inglés con `lang=en`.

Task: 65994