### PR TITLE
[IMP] l10n_ar_edi_ux: translate ARCA wizard labels to Spanish

### DIFF
--- a/l10n_ar_edi_ux/i18n/es.po
+++ b/l10n_ar_edi_ux/i18n/es.po
@@ -12,14 +12,12 @@ msgstr ""
 "POT-Creation-Date: 2026-06-19 19:14+0000\n"
 "PO-Revision-Date: 2026-05-28 00:25+0000\n"
 "Last-Translator: julia elizondo <jue@adhoc.inc>\n"
-"Language-Team: Spanish <https://translation.dev-adhoc.com/projects/odoo-"
-"argentina-ee-19-0/odoo-argentina-ee-19-0-l10n_ar_edi_ux/es/>\n"
+"Language-Team: Spanish <https://translation.dev-adhoc.com/projects/odoo-argentina-ee-19-0/odoo-argentina-ee-19-0-l10n_ar_edi_ux/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n != 0 && n % 1000000 == "
-"0) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n != 0 && n % 1000000 == 0) ? 1 : 2);\n"
 "X-Generator: Weblate 5.10.4\n"
 
 #. module: l10n_ar_edi_ux
@@ -66,27 +64,29 @@ msgstr ". Permiso de embarque inválidos: %s"
 #: model_terms:ir.ui.view,arch_db:l10n_ar_edi_ux.view_l10n_ar_arca_journal_wizard_form
 msgid ""
 "<strong>Automatic Journal Creation</strong><br/>\n"
-"                    This wizard will fetch your points of sale from ARCA and "
-"create journals automatically."
+"                    This wizard will fetch your points of sale from ARCA and create journals automatically."
 msgstr ""
+"<strong>Creación Automática de Diarios</strong><br/>\n"
+"                    Este asistente obtendrá sus puntos de venta desde ARCA y creará los diarios automáticamente."
 
 #. module: l10n_ar_edi_ux
 #: model_terms:ir.ui.view,arch_db:l10n_ar_edi_ux.view_l10n_ar_arca_connection_wizard_form
 msgid ""
 "<strong>Configure ARCA Web Services Connection</strong><br/>\n"
-"                    Upload your certificate and private key to connect to "
-"ARCA electronic invoicing services."
+"                    Upload your certificate and private key to connect to ARCA electronic invoicing services."
 msgstr ""
+"<strong>Configurar Conexión a los Servicios Web de ARCA</strong><br/>\n"
+"                    Suba su certificado y clave privada para conectarse a los servicios de facturación electrónica de ARCA."
 
 #. module: l10n_ar_edi_ux
 #: model_terms:ir.ui.view,arch_db:l10n_ar_edi_ux.view_l10n_ar_arca_connection_wizard_form
 msgid "<strong>Need help?</strong>"
-msgstr ""
+msgstr "<strong>¿Necesita ayuda?</strong>"
 
 #. module: l10n_ar_edi_ux
 #: model_terms:ir.ui.view,arch_db:l10n_ar_edi_ux.view_l10n_ar_arca_journal_wizard_form
 msgid "<strong>No points of sale loaded yet.</strong>"
-msgstr ""
+msgstr "<strong>Aún no hay puntos de venta cargados.</strong>"
 
 #. module: l10n_ar_edi_ux
 #: model:ir.model.fields,field_description:l10n_ar_edi_ux.field_res_partner__actividades_padron
@@ -279,20 +279,18 @@ msgstr "Certificado"
 #. odoo-python
 #: code:addons/l10n_ar_edi_ux/models/res_company.py:0
 msgid ""
-"Certificate CUIT differ from Company's doc type and number. You can only use "
-"the ARCA certificate if it matches\n"
+"Certificate CUIT differ from Company's doc type and number. You can only use the ARCA certificate if it matches\n"
 " * certificate %s\n"
 " * company %s %s"
 msgstr ""
-"El CUIT del certificado difiere del tipo y número de documento de la "
-"empresa. Solo puede usar el certificado ARCA si coincide\n"
+"El CUIT del certificado difiere del tipo y número de documento de la empresa. Solo puede usar el certificado ARCA si coincide\n"
 " * certificado %s\n"
 " * empresa %s %s"
 
 #. module: l10n_ar_edi_ux
 #: model_terms:ir.ui.view,arch_db:l10n_ar_edi_ux.view_l10n_ar_arca_connection_wizard_form
 msgid "Certificates must be in PEM format"
-msgstr ""
+msgstr "Los certificados deben estar en formato PEM"
 
 #. module: l10n_ar_edi_ux
 #: model:ir.model.fields,help:l10n_ar_edi_ux.field_res_config_settings__arba_cit
@@ -338,8 +336,8 @@ msgstr "Companía"
 #. odoo-python
 #: code:addons/l10n_ar_edi_ux/models/res_company.py:0
 msgid ""
-"Company \"%s\" has no ARCA certificate and no ancestor sharing the same CUIT "
-"was found. Please configure a certificate in the accounting settings."
+"Company \"%s\" has no ARCA certificate and no ancestor sharing the same CUIT"
+" was found. Please configure a certificate in the accounting settings."
 msgstr ""
 "La empresa \"%s\" no tiene certificado ARCA y no se encontró ningún padre "
 "con el mismo CUIT. Por favor configure un certificado en los ajustes de "
@@ -382,7 +380,8 @@ msgstr "Prueba de Conexión"
 #: code:addons/l10n_ar_edi_ux/wizards/l10n_ar_arca_connection_wizard.py:0
 msgid "Connection status has been updated. Check the status below."
 msgstr ""
-"El estado de la conexión fue actualizado. Verifique el estado a continuación."
+"El estado de la conexión fue actualizado. Verifique el estado a "
+"continuación."
 
 #. module: l10n_ar_edi_ux
 #: model:ir.model,name:l10n_ar_edi_ux.model_res_partner
@@ -586,12 +585,12 @@ msgstr "Finalizado"
 #. module: l10n_ar_edi_ux
 #: model_terms:ir.ui.view,arch_db:l10n_ar_edi_ux.view_l10n_ar_arca_connection_wizard_form
 msgid "For production, obtain your certificate from the ARCA portal"
-msgstr ""
+msgstr "Para producción, obtenga su certificado desde el portal de ARCA"
 
 #. module: l10n_ar_edi_ux
 #: model_terms:ir.ui.view,arch_db:l10n_ar_edi_ux.view_l10n_ar_arca_connection_wizard_form
 msgid "For testing, you can use demo certificates from ARCA"
-msgstr ""
+msgstr "Para pruebas, puede usar certificados de demo de ARCA"
 
 #. module: l10n_ar_edi_ux
 #: model_terms:ir.ui.view,arch_db:l10n_ar_edi_ux.view_account_journal_form
@@ -635,7 +634,8 @@ msgstr "ID (identificación)"
 #. module: l10n_ar_edi_ux
 #: model:ir.model.fields,help:l10n_ar_edi_ux.field_l10n_ar_arca_journal_wizard_line__shared_to_branches
 msgid "If checked, this journal will be shared with all branches."
-msgstr "Si está marcado, este diario será compartido con todas las sucursales."
+msgstr ""
+"Si está marcado, este diario será compartido con todas las sucursales."
 
 #. module: l10n_ar_edi_ux
 #: model:ir.model.fields,help:l10n_ar_edi_ux.field_l10n_ar_arca_connection_wizard__has_valid_certificate
@@ -746,13 +746,11 @@ msgstr ""
 msgid ""
 "No valid ARCA certificate found.\n"
 "\n"
-"Please configure your certificate in the ARCA Connection Setup before "
-"fetching points of sale."
+"Please configure your certificate in the ARCA Connection Setup before fetching points of sale."
 msgstr ""
 "No se encontró un certificado ARCA válido.\n"
 "\n"
-"Por favor configure su certificado en la Configuración de Conexión ARCA "
-"antes de obtener los puntos de venta."
+"Por favor configure su certificado en la Configuración de Conexión ARCA antes de obtener los puntos de venta."
 
 #. module: l10n_ar_edi_ux
 #. odoo-python
@@ -838,13 +836,13 @@ msgstr ""
 #. module: l10n_ar_edi_ux
 #: model_terms:ir.ui.view,arch_db:l10n_ar_edi_ux.view_l10n_ar_arca_connection_wizard_form
 msgid "Save & Close"
-msgstr ""
+msgstr "Guardar y Cerrar"
 
 #. module: l10n_ar_edi_ux
 #: model:ir.model.fields,help:l10n_ar_edi_ux.field_l10n_ar_arca_journal_wizard_line__branch_id
 msgid ""
-"Select a branch to assign this journal to a specific branch. Leave empty for "
-"the main company."
+"Select a branch to assign this journal to a specific branch. Leave empty for"
+" the main company."
 msgstr ""
 "Seleccione una sucursal para asignar este diario. Deje vacío para la "
 "compañía principal."
@@ -927,8 +925,8 @@ msgid ""
 "cannot automatically update the ARCA Responsibility field. Please check the "
 "corresponding data and add it manually."
 msgstr ""
-"Posiblemente este contacto tenga declarada alguna actividad dentro del rubro "
-"inmobiliario. En este caso, no podemos actualizar automáticamente el campo "
+"Posiblemente este contacto tenga declarada alguna actividad dentro del rubro"
+" inmobiliario. En este caso, no podemos actualizar automáticamente el campo "
 "Responsabilidad ARCA. Por favor, consulte el dato correspondiente y "
 "agréguelo manualmente"
 
@@ -981,7 +979,7 @@ msgstr ""
 #. module: l10n_ar_edi_ux
 #: model_terms:ir.ui.view,arch_db:l10n_ar_edi_ux.view_l10n_ar_arca_journal_wizard_form
 msgid "Type"
-msgstr ""
+msgstr "Tipo"
 
 #. module: l10n_ar_edi_ux
 #: model_terms:ir.ui.view,arch_db:l10n_ar_edi_ux.view_base_partner_update_from_padron_form
@@ -1153,7 +1151,7 @@ msgstr ""
 #. module: l10n_ar_edi_ux
 #: model_terms:ir.ui.view,arch_db:l10n_ar_edi_ux.view_l10n_ar_arca_connection_wizard_form
 msgid "📚 View ARCA Documentation"
-msgstr ""
+msgstr "📚 Ver Documentación de ARCA"
 
 #~ msgid "Automatic Journal Creation"
 #~ msgstr "Creación Automática de Diarios"
@@ -1162,8 +1160,8 @@ msgstr ""
 #~ "This wizard will fetch your points of sale from ARCA and create journals "
 #~ "automatically."
 #~ msgstr ""
-#~ "Este asistente obtendrá sus puntos de venta desde ARCA y creará los "
-#~ "diarios automáticamente."
+#~ "Este asistente obtendrá sus puntos de venta desde ARCA y creará los diarios "
+#~ "automáticamente."
 
 #~ msgid "No points of sale loaded yet."
 #~ msgstr "No hay puntos de venta cargados aún."


### PR DESCRIPTION
## Resumen

En el wizard de diarios ARCA (y el wizard de conexión ARCA) varias etiquetas se mostraban en **inglés** aun con el idioma del usuario en español.

## Causa

El código fuente ya está correctamente en inglés y existe `es.po`. El problema: esas etiquetas están envueltas en markup inline en el XML (`<strong>...</strong>`, `<p>...</p>`). Cuando un término de vista tiene markup inline, Odoo extrae como término traducible el contenido **completo, con las etiquetas** (ej. `<strong>Automatic Journal Creation</strong><br/>...`), no el texto pelado.

Al agregarse ese markup en algún momento, el `msgid` cambió: las traducciones de texto pelado quedaron **obsoletas** (`#~`) y los términos con markup quedaron **sin traducir**, por lo que se mostraban en inglés.

## Cambio

Solo `i18n/es.po`: se completan las traducciones al español de los 10 términos de vista de los wizards ARCA (diarios + conexión). No hay cambios de código (el fuente está bien en inglés).

## Test plan

- pre-commit `.po[t]` check en verde; placeholders validados con `polib`.
- Verificar en UI con `lang=es`: el wizard de diarios ARCA ("Puntos de venta") y el de conexión muestran las etiquetas en español.

Task: 65994