### PR TITLE
[IMP] account_balance_import: make user messages translatable

### DIFF
--- a/account_balance_import/i18n/account_balance_import.pot
+++ b/account_balance_import/i18n/account_balance_import.pot
@@ -19,17 +19,12 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account_balance_import.account_balance_import_wizard
 msgid ""
 "<span class=\"fa fa-download\" title=\"download\"/>\n"
-"                                    Descargar Plantilla de Importación de Saldos de Partners"
+"                                    Download Partner Balances Import Template"
 msgstr ""
 
 #. module: account_balance_import
 #: model_terms:ir.ui.view,arch_db:account_balance_import.account_balance_import_wizard
 msgid "<span class=\"fa fa-info\" aria-label=\"info\"/>"
-msgstr ""
-
-#. module: account_balance_import
-#: model:ir.model.fields.selection,name:account_balance_import.selection__account_balance_import_wizard__partner_balance_type__payable
-msgid "A Pagar"
 msgstr ""
 
 #. module: account_balance_import
@@ -40,14 +35,14 @@ msgstr ""
 
 #. module: account_balance_import
 #: model:ir.model.fields.selection,name:account_balance_import.selection__account_balance_import_wizard__import_type__absolute
-msgid "Absoluto"
+msgid "Absolute"
 msgstr ""
 
 #. module: account_balance_import
 #: model:ir.model.fields,help:account_balance_import.field_account_balance_import_wizard__import_type
 msgid ""
-"Absoluto: genera asientos directamente con los valores importados.\n"
-"Ajuste: calcula la diferencia entre el saldo actual del partner y el valor importado."
+"Absolute: generates entries directly with the imported values.\n"
+"Adjustment: calculates the difference between the partner's current balance and the imported value."
 msgstr ""
 
 #. module: account_balance_import
@@ -71,8 +66,13 @@ msgid "Account import summary view"
 msgstr ""
 
 #. module: account_balance_import
+#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__accounting_date
+msgid "Accounting Date"
+msgstr ""
+
+#. module: account_balance_import
 #: model:ir.model.fields.selection,name:account_balance_import.selection__account_balance_import_wizard__import_type__adjust
-msgid "Ajuste"
+msgid "Adjustment"
 msgstr ""
 
 #. module: account_balance_import
@@ -81,30 +81,8 @@ msgid "Amount in Account Currency"
 msgstr ""
 
 #. module: account_balance_import
-#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__file
-msgid "Archivo de Importación"
-msgstr ""
-
-#. module: account_balance_import
-#: model:ir.model.fields,field_description:account_balance_import.field_account_import_summary__account_opening_move_id
-msgid "Asiento de Apertura"
-msgstr ""
-
-#. module: account_balance_import
-#. odoo-javascript
-#: code:addons/account_balance_import/static/src/xml/account_import.xml:0
-msgid "Asiento de Apertura:"
-msgstr ""
-
-#. module: account_balance_import
-#: model:ir.model.fields,help:account_balance_import.field_account_import_summary__account_opening_move_id
-msgid ""
-"Asiento que contiene el balance inicial de todas las cuentas de la compañía"
-msgstr ""
-
-#. module: account_balance_import
 #: model_terms:ir.ui.view,arch_db:account_balance_import.account_balance_import_wizard
-msgid "Cancelar"
+msgid "Cancel"
 msgstr ""
 
 #. module: account_balance_import
@@ -125,18 +103,13 @@ msgstr ""
 
 #. module: account_balance_import
 #: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__company_id
-msgid "Compañía"
+msgid "Company"
 msgstr ""
 
 #. module: account_balance_import
 #. odoo-javascript
 #: code:addons/account_balance_import/static/src/xml/account_import.xml:0
 msgid "Complete your accounting setup using these configuration steps."
-msgstr ""
-
-#. module: account_balance_import
-#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__reconcile_debt
-msgid "Conciliar deuda"
 msgstr ""
 
 #. module: account_balance_import
@@ -155,6 +128,11 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/account_balance_import/static/src/xml/account_import.xml:0
 msgid "Configure fiscal years and periods."
+msgstr ""
+
+#. module: account_balance_import
+#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__counterpart_account_id
+msgid "Counterpart Account"
 msgstr ""
 
 #. module: account_balance_import
@@ -179,27 +157,13 @@ msgid "Credit Card"
 msgstr ""
 
 #. module: account_balance_import
-#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__counterpart_account_id
-msgid "Cuenta de Contrapartida"
-msgstr ""
-
-#. module: account_balance_import
 #: model:ir.model,name:account_balance_import.model_res_currency
 msgid "Currency"
 msgstr ""
 
 #. module: account_balance_import
-#: model_terms:ir.ui.view,arch_db:account_balance_import.account_balance_import_wizard
-msgid ""
-"Descargue la plantilla de importación siguiendo el link\n"
-"                            y edítelo manteniendo la estructura del archivo.<br/>\n"
-"                            Una vez finalizada la edición, suba el archivo modificado\n"
-"                            y haga click en el botón \"Importar\" ubicado más abajo."
-msgstr ""
-
-#. module: account_balance_import
-#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__journal_id
-msgid "Diario"
+#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__partner_balance_type
+msgid "Debt Type"
 msgstr ""
 
 #. module: account_balance_import
@@ -214,13 +178,22 @@ msgid "Display Name"
 msgstr ""
 
 #. module: account_balance_import
-#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__export_partners
-msgid "Exportar Partners"
+#: model_terms:ir.ui.view,arch_db:account_balance_import.account_balance_import_wizard
+msgid ""
+"Download the import template using the link\n"
+"                            and edit it while keeping the file structure.<br/>\n"
+"                            Once you finish editing, upload the modified file\n"
+"                            and click the \"Import\" button below."
 msgstr ""
 
 #. module: account_balance_import
-#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__accounting_date
-msgid "Fecha Contable"
+#: model:ir.model.fields,help:account_balance_import.field_account_import_summary__account_opening_move_id
+msgid "Entry containing the opening balance of all the company's accounts"
+msgstr ""
+
+#. module: account_balance_import
+#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__export_partners
+msgid "Export Partners"
 msgstr ""
 
 #. module: account_balance_import
@@ -241,6 +214,46 @@ msgid "ID"
 msgstr ""
 
 #. module: account_balance_import
+#: model:ir.model.fields,help:account_balance_import.field_account_balance_import_wizard__export_partners
+msgid ""
+"If enabled, the template will include existing customers or vendors "
+"according to the selected Debt Type."
+msgstr ""
+
+#. module: account_balance_import
+#: model:ir.model.fields,help:account_balance_import.field_account_balance_import_wizard__reconcile_debt
+msgid ""
+"If you check this option, it will automatically reconcile with the oldest "
+"debt."
+msgstr ""
+
+#. module: account_balance_import
+#: model_terms:ir.ui.view,arch_db:account_balance_import.account_balance_import_wizard
+msgid "Import"
+msgstr ""
+
+#. module: account_balance_import
+#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__file
+msgid "Import File"
+msgstr ""
+
+#. module: account_balance_import
+#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__mode
+msgid "Import Mode"
+msgstr ""
+
+#. module: account_balance_import
+#. odoo-python
+#: code:addons/account_balance_import/models/account_import_summary.py:0
+msgid "Import Partner Balance"
+msgstr ""
+
+#. module: account_balance_import
+#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__import_type
+msgid "Import Type"
+msgstr ""
+
+#. module: account_balance_import
 #: model:ir.ui.menu,name:account_balance_import.menu_account_import_wizard
 msgid "Import Wizard"
 msgstr ""
@@ -252,14 +265,14 @@ msgid "Import initial balances for your partners."
 msgstr ""
 
 #. module: account_balance_import
-#: model_terms:ir.ui.view,arch_db:account_balance_import.account_balance_import_wizard
-msgid "Importar"
-msgstr ""
-
-#. module: account_balance_import
 #. odoo-javascript
 #: code:addons/account_balance_import/static/src/xml/account_import.xml:0
 msgid "Initial Setup Options"
+msgstr ""
+
+#. module: account_balance_import
+#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__journal_id
+msgid "Journal"
 msgstr ""
 
 #. module: account_balance_import
@@ -284,11 +297,6 @@ msgid "Last Updated on"
 msgstr ""
 
 #. module: account_balance_import
-#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__mode
-msgid "Modo de Importación"
-msgstr ""
-
-#. module: account_balance_import
 #: model:ir.model,name:account_balance_import.model_onboarding_onboarding
 msgid "Onboarding"
 msgstr ""
@@ -299,21 +307,46 @@ msgid "Opening Balance of Financial Year"
 msgstr ""
 
 #. module: account_balance_import
+#: model:ir.model.fields,field_description:account_balance_import.field_account_import_summary__account_opening_move_id
+msgid "Opening Entry"
+msgstr ""
+
+#. module: account_balance_import
+#. odoo-javascript
+#: code:addons/account_balance_import/static/src/xml/account_import.xml:0
+msgid "Opening Entry:"
+msgstr ""
+
+#. module: account_balance_import
+#: model:ir.model.fields.selection,name:account_balance_import.selection__account_balance_import_wizard__mode__partner_balance
+msgid "Partner Balances"
+msgstr ""
+
+#. module: account_balance_import
 #. odoo-javascript
 #: code:addons/account_balance_import/static/src/xml/account_import.xml:0
 msgid "Partners Balance"
 msgstr ""
 
 #. module: account_balance_import
-#: model:ir.model.fields.selection,name:account_balance_import.selection__account_balance_import_wizard__partner_balance_type__receivable
-msgid "Por Cobrar"
+#: model:ir.model.fields.selection,name:account_balance_import.selection__account_balance_import_wizard__partner_balance_type__payable
+msgid "Payable"
 msgstr ""
 
 #. module: account_balance_import
-#: model:ir.model.fields,help:account_balance_import.field_account_balance_import_wizard__counterpart_account_id
-msgid ""
-"Recomendamos utilizar la misma cuenta de contrapartida para todos los "
-"asientos iniciales"
+#. odoo-python
+#: code:addons/account_balance_import/wizards/account_balance_import.py:0
+msgid "Please upload an Excel file to import."
+msgstr ""
+
+#. module: account_balance_import
+#: model:ir.model.fields.selection,name:account_balance_import.selection__account_balance_import_wizard__partner_balance_type__receivable
+msgid "Receivable"
+msgstr ""
+
+#. module: account_balance_import
+#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__reconcile_debt
+msgid "Reconcile Debt"
 msgstr ""
 
 #. module: account_balance_import
@@ -347,8 +380,53 @@ msgid "Review your chart and setup end of year balances."
 msgstr ""
 
 #. module: account_balance_import
-#: model:ir.model.fields.selection,name:account_balance_import.selection__account_balance_import_wizard__mode__partner_balance
-msgid "Saldos de Partners"
+#. odoo-python
+#: code:addons/account_balance_import/wizards/account_balance_import.py:0
+msgid "Row %(row)s: No partner was found for the entered text (%(text)s)."
+msgstr ""
+
+#. module: account_balance_import
+#. odoo-python
+#: code:addons/account_balance_import/wizards/account_balance_import.py:0
+msgid ""
+"Row %(row)s: One of the accounts associated with partner %(partner)s does "
+"not belong to company (%(company)s)"
+msgstr ""
+
+#. module: account_balance_import
+#. odoo-python
+#: code:addons/account_balance_import/wizards/account_balance_import.py:0
+msgid ""
+"Row %(row)s: Several partners were found for the entered text (%(text)s). "
+"Please review the loaded data!"
+msgstr ""
+
+#. module: account_balance_import
+#. odoo-python
+#: code:addons/account_balance_import/wizards/account_balance_import.py:0
+msgid ""
+"Row %(row)s: The account associated with partner %(partner)s is deprecated."
+msgstr ""
+
+#. module: account_balance_import
+#. odoo-python
+#: code:addons/account_balance_import/wizards/account_balance_import.py:0
+msgid ""
+"Row %s: If you set another currency you must indicate the amount in that "
+"other currency"
+msgstr ""
+
+#. module: account_balance_import
+#. odoo-python
+#: code:addons/account_balance_import/wizards/account_balance_import.py:0
+msgid "Row %s: The amount is not numeric."
+msgstr ""
+
+#. module: account_balance_import
+#. odoo-python
+#: code:addons/account_balance_import/wizards/account_balance_import.py:0
+msgid ""
+"Row %s: Unknown due date format. Make sure the column has a date format."
 msgstr ""
 
 #. module: account_balance_import
@@ -364,20 +442,23 @@ msgid "Set your Partners Balance"
 msgstr ""
 
 #. module: account_balance_import
-#: model:ir.model.fields,help:account_balance_import.field_account_balance_import_wizard__export_partners
+#. odoo-python
+#: code:addons/account_balance_import/models/account_import_summary.py:0
+msgid "Set your company data"
+msgstr ""
+
+#. module: account_balance_import
+#. odoo-python
+#: code:addons/account_balance_import/wizards/account_balance_import.py:0
 msgid ""
-"Si se activa, la plantilla incluirá los clientes o proveedores existentes "
-"según el Tipo de Deuda seleccionado."
+"The number of columns (%(actual)s) does not match the expected number (%(expected)s).\n"
+"Expected fields: %(fields)s"
 msgstr ""
 
 #. module: account_balance_import
-#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__partner_balance_type
-msgid "Tipo de Deuda"
-msgstr ""
-
-#. module: account_balance_import
-#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__import_type
-msgid "Tipo de Importación"
+#: model:ir.model.fields,help:account_balance_import.field_account_balance_import_wizard__counterpart_account_id
+msgid ""
+"We recommend using the same counterpart account for all initial entries"
 msgstr ""
 
 #. module: account_balance_import
@@ -389,7 +470,10 @@ msgid ""
 msgstr ""
 
 #. module: account_balance_import
-#: model:ir.model.fields,help:account_balance_import.field_account_balance_import_wizard__reconcile_debt
+#. odoo-python
+#: code:addons/account_balance_import/models/account_import_summary.py:0
 msgid ""
-"si marca esta opción se conciliará automáticamente con la deuda más vieja."
+"You must set fiscal periods before importing partner balances.\n"
+"\n"
+"Please click 'Set Periods' to configure the opening date and the fiscal periods."
 msgstr ""

--- a/account_balance_import/i18n/es.po
+++ b/account_balance_import/i18n/es.po
@@ -12,37 +12,27 @@ msgstr ""
 "POT-Creation-Date: 2026-06-12 13:15+0000\n"
 "PO-Revision-Date: 2026-04-13 22:41+0000\n"
 "Last-Translator: carla spiaggi <sca@adhoc.inc>\n"
-"Language-Team: Spanish <https://translation.dev-adhoc.com/projects/"
-"enterprise-extensions-19-0/enterprise-extensions-19-0-account_balance_import/"
-"es/>\n"
+"Language-Team: Spanish <https://translation.dev-adhoc.com/projects/enterprise-extensions-19-0/enterprise-extensions-19-0-account_balance_import/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n != 0 && n % 1000000 == "
-"0) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n != 0 && n % 1000000 == 0) ? 1 : 2);\n"
 "X-Generator: Weblate 5.10.4\n"
 
 #. module: account_balance_import
 #: model_terms:ir.ui.view,arch_db:account_balance_import.account_balance_import_wizard
 msgid ""
 "<span class=\"fa fa-download\" title=\"download\"/>\n"
-"                                    Descargar Plantilla de Importación de "
-"Saldos de Partners"
+"                                    Download Partner Balances Import Template"
 msgstr ""
-"<span class=\"fa fa-download\" title=\"download\"/>\n"
-"                                    Descargar Plantilla de Importación de "
-"Saldos de Partners"
+"<span class=\"fa fa-download\" title=\"Descargar\"/>\n"
+"                                    Descargar Plantilla de Importación de Saldos de Partners"
 
 #. module: account_balance_import
 #: model_terms:ir.ui.view,arch_db:account_balance_import.account_balance_import_wizard
 msgid "<span class=\"fa fa-info\" aria-label=\"info\"/>"
 msgstr "<span class=\"fa fa-info\" aria-label=\"info\"/>"
-
-#. module: account_balance_import
-#: model:ir.model.fields.selection,name:account_balance_import.selection__account_balance_import_wizard__partner_balance_type__payable
-msgid "A Pagar"
-msgstr "A Pagar"
 
 #. module: account_balance_import
 #. odoo-javascript
@@ -52,19 +42,17 @@ msgstr "Conexión ARCA"
 
 #. module: account_balance_import
 #: model:ir.model.fields.selection,name:account_balance_import.selection__account_balance_import_wizard__import_type__absolute
-msgid "Absoluto"
+msgid "Absolute"
 msgstr "Absoluto"
 
 #. module: account_balance_import
 #: model:ir.model.fields,help:account_balance_import.field_account_balance_import_wizard__import_type
 msgid ""
-"Absoluto: genera asientos directamente con los valores importados.\n"
-"Ajuste: calcula la diferencia entre el saldo actual del partner y el valor "
-"importado."
+"Absolute: generates entries directly with the imported values.\n"
+"Adjustment: calculates the difference between the partner's current balance and the imported value."
 msgstr ""
 "Absoluto: genera asientos directamente con los valores importados.\n"
-"Ajuste: calcula la diferencia entre el saldo actual del partner y el valor "
-"importado."
+"Ajuste: calcula la diferencia entre el saldo actual del contacto y el valor importado."
 
 #. module: account_balance_import
 #: model:ir.model,name:account_balance_import.model_account_account
@@ -87,8 +75,13 @@ msgid "Account import summary view"
 msgstr "Vista de resumen de importación de cuenta"
 
 #. module: account_balance_import
+#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__accounting_date
+msgid "Accounting Date"
+msgstr "Fecha Contable"
+
+#. module: account_balance_import
 #: model:ir.model.fields.selection,name:account_balance_import.selection__account_balance_import_wizard__import_type__adjust
-msgid "Ajuste"
+msgid "Adjustment"
 msgstr "Ajuste"
 
 #. module: account_balance_import
@@ -97,31 +90,8 @@ msgid "Amount in Account Currency"
 msgstr "Importe en la moneda de la cuenta"
 
 #. module: account_balance_import
-#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__file
-msgid "Archivo de Importación"
-msgstr "Archivo de Importación"
-
-#. module: account_balance_import
-#: model:ir.model.fields,field_description:account_balance_import.field_account_import_summary__account_opening_move_id
-msgid "Asiento de Apertura"
-msgstr "Asiento de Apertura"
-
-#. module: account_balance_import
-#. odoo-javascript
-#: code:addons/account_balance_import/static/src/xml/account_import.xml:0
-msgid "Asiento de Apertura:"
-msgstr "Asiento de Apertura:"
-
-#. module: account_balance_import
-#: model:ir.model.fields,help:account_balance_import.field_account_import_summary__account_opening_move_id
-msgid ""
-"Asiento que contiene el balance inicial de todas las cuentas de la compañía"
-msgstr ""
-"Asiento que contiene el balance inicial de todas las cuentas de la compañía"
-
-#. module: account_balance_import
 #: model_terms:ir.ui.view,arch_db:account_balance_import.account_balance_import_wizard
-msgid "Cancelar"
+msgid "Cancel"
 msgstr "Cancelar"
 
 #. module: account_balance_import
@@ -142,8 +112,8 @@ msgstr "Compañias"
 
 #. module: account_balance_import
 #: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__company_id
-msgid "Compañía"
-msgstr "Empresa"
+msgid "Company"
+msgstr "Compañía"
 
 #. module: account_balance_import
 #. odoo-javascript
@@ -151,11 +121,6 @@ msgstr "Empresa"
 msgid "Complete your accounting setup using these configuration steps."
 msgstr ""
 "Complete su configuración contable siguiendo estos pasos de configuración."
-
-#. module: account_balance_import
-#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__reconcile_debt
-msgid "Conciliar deuda"
-msgstr "Conciliar deuda"
 
 #. module: account_balance_import
 #. odoo-javascript
@@ -174,6 +139,11 @@ msgstr "Configure la conexión de Servicios Web con ARCA."
 #: code:addons/account_balance_import/static/src/xml/account_import.xml:0
 msgid "Configure fiscal years and periods."
 msgstr "Configurar años y periodos fiscales."
+
+#. module: account_balance_import
+#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__counterpart_account_id
+msgid "Counterpart Account"
+msgstr "Cuenta de Contrapartida"
 
 #. module: account_balance_import
 #. odoo-javascript
@@ -197,38 +167,14 @@ msgid "Credit Card"
 msgstr "Tarjeta de Crédito"
 
 #. module: account_balance_import
-#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__counterpart_account_id
-msgid "Cuenta de Contrapartida"
-msgstr "Cuenta de Contrapartida"
-
-#. module: account_balance_import
 #: model:ir.model,name:account_balance_import.model_res_currency
 msgid "Currency"
 msgstr "Moneda"
 
 #. module: account_balance_import
-#: model_terms:ir.ui.view,arch_db:account_balance_import.account_balance_import_wizard
-msgid ""
-"Descargue la plantilla de importación siguiendo el link\n"
-"                            y edítelo manteniendo la estructura del archivo."
-"<br/>\n"
-"                            Una vez finalizada la edición, suba el archivo "
-"modificado\n"
-"                            y haga click en el botón \"Importar\" ubicado "
-"más abajo."
-msgstr ""
-"Descargue la plantilla de importación siguiendo el link\n"
-"                            y edítelo manteniendo la estructura del archivo."
-"<br/>\n"
-"                            Una vez finalizada la edición, suba el archivo "
-"modificado\n"
-"                            y haga click en el botón \"Importar\" ubicado "
-"más abajo."
-
-#. module: account_balance_import
-#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__journal_id
-msgid "Diario"
-msgstr "Diario"
+#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__partner_balance_type
+msgid "Debt Type"
+msgstr "Tipo de Deuda"
 
 #. module: account_balance_import
 #: model:ir.model.fields,field_description:account_balance_import.field_account_account__display_name
@@ -242,14 +188,28 @@ msgid "Display Name"
 msgstr "Nombre para mostrar"
 
 #. module: account_balance_import
-#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__export_partners
-msgid "Exportar Partners"
-msgstr "Exportar Partners"
+#: model_terms:ir.ui.view,arch_db:account_balance_import.account_balance_import_wizard
+msgid ""
+"Download the import template using the link\n"
+"                            and edit it while keeping the file structure.<br/>\n"
+"                            Once you finish editing, upload the modified file\n"
+"                            and click the \"Import\" button below."
+msgstr ""
+"Descargue la plantilla de importación siguiendo el enlace\n"
+"                            y edítelo manteniendo la estructura del archivo.<br/>\n"
+"                            Una vez finalizada la edición, suba el archivo modificado\n"
+"                            y haga click en el botón \"Importar\" ubicado más abajo."
 
 #. module: account_balance_import
-#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__accounting_date
-msgid "Fecha Contable"
-msgstr "Fecha Contable"
+#: model:ir.model.fields,help:account_balance_import.field_account_import_summary__account_opening_move_id
+msgid "Entry containing the opening balance of all the company's accounts"
+msgstr ""
+"Asiento que contiene el balance inicial de todas las cuentas de la compañía"
+
+#. module: account_balance_import
+#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__export_partners
+msgid "Export Partners"
+msgstr "Exportar Partners"
 
 #. module: account_balance_import
 #. odoo-javascript
@@ -269,6 +229,49 @@ msgid "ID"
 msgstr "ID"
 
 #. module: account_balance_import
+#: model:ir.model.fields,help:account_balance_import.field_account_balance_import_wizard__export_partners
+msgid ""
+"If enabled, the template will include existing customers or vendors "
+"according to the selected Debt Type."
+msgstr ""
+"Si se activa, la plantilla incluirá los clientes o proveedores existentes "
+"según el Tipo de Deuda seleccionado."
+
+#. module: account_balance_import
+#: model:ir.model.fields,help:account_balance_import.field_account_balance_import_wizard__reconcile_debt
+msgid ""
+"If you check this option, it will automatically reconcile with the oldest "
+"debt."
+msgstr ""
+"Si marca esta opción se conciliará automáticamente con la deuda más vieja."
+
+#. module: account_balance_import
+#: model_terms:ir.ui.view,arch_db:account_balance_import.account_balance_import_wizard
+msgid "Import"
+msgstr "Importar"
+
+#. module: account_balance_import
+#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__file
+msgid "Import File"
+msgstr "Archivo de Importación"
+
+#. module: account_balance_import
+#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__mode
+msgid "Import Mode"
+msgstr "Modo de Importación"
+
+#. module: account_balance_import
+#. odoo-python
+#: code:addons/account_balance_import/models/account_import_summary.py:0
+msgid "Import Partner Balance"
+msgstr "Importar Saldo de Contactos"
+
+#. module: account_balance_import
+#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__import_type
+msgid "Import Type"
+msgstr "Tipo de Importación"
+
+#. module: account_balance_import
 #: model:ir.ui.menu,name:account_balance_import.menu_account_import_wizard
 msgid "Import Wizard"
 msgstr "Asistente de Importación"
@@ -280,15 +283,15 @@ msgid "Import initial balances for your partners."
 msgstr "Importar saldos iniciales para sus partners."
 
 #. module: account_balance_import
-#: model_terms:ir.ui.view,arch_db:account_balance_import.account_balance_import_wizard
-msgid "Importar"
-msgstr "Importar"
-
-#. module: account_balance_import
 #. odoo-javascript
 #: code:addons/account_balance_import/static/src/xml/account_import.xml:0
 msgid "Initial Setup Options"
 msgstr "Opciones de Configuración Inicial"
+
+#. module: account_balance_import
+#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__journal_id
+msgid "Journal"
+msgstr "Diario"
 
 #. module: account_balance_import
 #: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__journal_domain
@@ -312,11 +315,6 @@ msgid "Last Updated on"
 msgstr "Última actualización el"
 
 #. module: account_balance_import
-#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__mode
-msgid "Modo de Importación"
-msgstr "Modo de Importación"
-
-#. module: account_balance_import
 #: model:ir.model,name:account_balance_import.model_onboarding_onboarding
 msgid "Onboarding"
 msgstr "Incorporación"
@@ -327,24 +325,47 @@ msgid "Opening Balance of Financial Year"
 msgstr "Saldo de Apertura del Ejercicio Fiscal"
 
 #. module: account_balance_import
+#: model:ir.model.fields,field_description:account_balance_import.field_account_import_summary__account_opening_move_id
+msgid "Opening Entry"
+msgstr "Asiento de Apertura"
+
+#. module: account_balance_import
+#. odoo-javascript
+#: code:addons/account_balance_import/static/src/xml/account_import.xml:0
+msgid "Opening Entry:"
+msgstr "Asiento de Apertura:"
+
+#. module: account_balance_import
+#: model:ir.model.fields.selection,name:account_balance_import.selection__account_balance_import_wizard__mode__partner_balance
+msgid "Partner Balances"
+msgstr "Saldos de Contactos"
+
+#. module: account_balance_import
 #. odoo-javascript
 #: code:addons/account_balance_import/static/src/xml/account_import.xml:0
 msgid "Partners Balance"
-msgstr "Saldos de Partners"
+msgstr "Saldos de Contactos"
+
+#. module: account_balance_import
+#: model:ir.model.fields.selection,name:account_balance_import.selection__account_balance_import_wizard__partner_balance_type__payable
+msgid "Payable"
+msgstr "A Pagar"
+
+#. module: account_balance_import
+#. odoo-python
+#: code:addons/account_balance_import/wizards/account_balance_import.py:0
+msgid "Please upload an Excel file to import."
+msgstr "Por favor, cargue un archivo Excel para importar."
 
 #. module: account_balance_import
 #: model:ir.model.fields.selection,name:account_balance_import.selection__account_balance_import_wizard__partner_balance_type__receivable
-msgid "Por Cobrar"
+msgid "Receivable"
 msgstr "Por Cobrar"
 
 #. module: account_balance_import
-#: model:ir.model.fields,help:account_balance_import.field_account_balance_import_wizard__counterpart_account_id
-msgid ""
-"Recomendamos utilizar la misma cuenta de contrapartida para todos los "
-"asientos iniciales"
-msgstr ""
-"Recomendamos utilizar la misma cuenta de contrapartida para todos los "
-"asientos iniciales"
+#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__reconcile_debt
+msgid "Reconcile Debt"
+msgstr "Conciliar deuda"
 
 #. module: account_balance_import
 #. odoo-javascript
@@ -377,9 +398,66 @@ msgid "Review your chart and setup end of year balances."
 msgstr "Revise su plan y configure los saldos de cierre de ejercicio."
 
 #. module: account_balance_import
-#: model:ir.model.fields.selection,name:account_balance_import.selection__account_balance_import_wizard__mode__partner_balance
-msgid "Saldos de Partners"
-msgstr "Saldos de Partners"
+#. odoo-python
+#: code:addons/account_balance_import/wizards/account_balance_import.py:0
+msgid "Row %(row)s: No partner was found for the entered text (%(text)s)."
+msgstr ""
+"Fila %(row)s: No se encontró ningún contacto para el texto ingresado "
+"(%(text)s)."
+
+#. module: account_balance_import
+#. odoo-python
+#: code:addons/account_balance_import/wizards/account_balance_import.py:0
+msgid ""
+"Row %(row)s: One of the accounts associated with partner %(partner)s does "
+"not belong to company (%(company)s)"
+msgstr ""
+"Fila %(row)s: Una de las cuentas asociadas al contacto %(partner)s no "
+"pertenece a la compañía (%(company)s)"
+
+#. module: account_balance_import
+#. odoo-python
+#: code:addons/account_balance_import/wizards/account_balance_import.py:0
+msgid ""
+"Row %(row)s: Several partners were found for the entered text (%(text)s). "
+"Please review the loaded data!"
+msgstr ""
+"Fila %(row)s: Se encontraron varios contactos para el texto ingresado "
+"(%(text)s). ¡Revise los datos cargados!"
+
+#. module: account_balance_import
+#. odoo-python
+#: code:addons/account_balance_import/wizards/account_balance_import.py:0
+msgid ""
+"Row %(row)s: The account associated with partner %(partner)s is deprecated."
+msgstr ""
+"Fila %(row)s: La cuenta asociada al contacto %(partner)s se encuentra "
+"depreciada."
+
+#. module: account_balance_import
+#. odoo-python
+#: code:addons/account_balance_import/wizards/account_balance_import.py:0
+msgid ""
+"Row %s: If you set another currency you must indicate the amount in that "
+"other currency"
+msgstr ""
+"Fila %s: Si le establece otra moneda debe indicar el importe en esa otra "
+"moneda"
+
+#. module: account_balance_import
+#. odoo-python
+#: code:addons/account_balance_import/wizards/account_balance_import.py:0
+msgid "Row %s: The amount is not numeric."
+msgstr "Fila %s: El monto no es numérico."
+
+#. module: account_balance_import
+#. odoo-python
+#: code:addons/account_balance_import/wizards/account_balance_import.py:0
+msgid ""
+"Row %s: Unknown due date format. Make sure the column has a date format."
+msgstr ""
+"Fila %s: Formato de fecha de vencimiento desconocido. Asegúrese de que la "
+"columna posee formato de fecha."
 
 #. module: account_balance_import
 #. odoo-javascript
@@ -394,80 +472,79 @@ msgid "Set your Partners Balance"
 msgstr "Establezca sus Saldos de Partners"
 
 #. module: account_balance_import
-#: model:ir.model.fields,help:account_balance_import.field_account_balance_import_wizard__export_partners
+#. odoo-python
+#: code:addons/account_balance_import/models/account_import_summary.py:0
+msgid "Set your company data"
+msgstr "Configure los datos de su empresa"
+
+#. module: account_balance_import
+#. odoo-python
+#: code:addons/account_balance_import/wizards/account_balance_import.py:0
 msgid ""
-"Si se activa, la plantilla incluirá los clientes o proveedores existentes "
-"según el Tipo de Deuda seleccionado."
+"The number of columns (%(actual)s) does not match the expected number (%(expected)s).\n"
+"Expected fields: %(fields)s"
 msgstr ""
-"Si se activa, la plantilla incluirá los clientes o proveedores existentes "
-"según el Tipo de Deuda seleccionado."
+"La cantidad de columnas (%(actual)s) no coincide con la cantidad esperada (%(expected)s).\n"
+"Campos esperados: %(fields)s"
 
 #. module: account_balance_import
-#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__partner_balance_type
-msgid "Tipo de Deuda"
-msgstr "Tipo de Deuda"
-
-#. module: account_balance_import
-#: model:ir.model.fields,field_description:account_balance_import.field_account_balance_import_wizard__import_type
-msgid "Tipo de Importación"
-msgstr "Tipo de Importación"
+#: model:ir.model.fields,help:account_balance_import.field_account_balance_import_wizard__counterpart_account_id
+msgid ""
+"We recommend using the same counterpart account for all initial entries"
+msgstr ""
+"Recomendamos utilizar la misma cuenta de contrapartida para todos los "
+"asientos iniciales"
 
 #. module: account_balance_import
 #. odoo-python
 #: code:addons/account_balance_import/models/account_account.py:0
 msgid ""
-"You cannot set an amount in currency for accounts that don't have a specific "
-"currency defined or use the same currency as the company."
+"You cannot set an amount in currency for accounts that don't have a specific"
+" currency defined or use the same currency as the company."
 msgstr ""
 "No se puede establecer un importe en una divisa para cuentas que no tengan "
 "definida una divisa específica o que no utilicen la misma divisa que la "
 "empresa."
 
 #. module: account_balance_import
-#: model:ir.model.fields,help:account_balance_import.field_account_balance_import_wizard__reconcile_debt
+#. odoo-python
+#: code:addons/account_balance_import/models/account_import_summary.py:0
 msgid ""
-"si marca esta opción se conciliará automáticamente con la deuda más vieja."
+"You must set fiscal periods before importing partner balances.\n"
+"\n"
+"Please click 'Set Periods' to configure the opening date and the fiscal periods."
 msgstr ""
-"si marca esta opción se conciliará automáticamente con la deuda más vieja."
-
-#~ msgid "Payments"
-#~ msgstr "Pagos"
-
-#~ msgid ""
-#~ "<span class=\"fa fa-download\" title=\"download\"/>\n"
-#~ "                                Descargar Plantilla de Importación de "
-#~ "Cheques Propios"
-#~ msgstr ""
-#~ "<span class=\"fa fa-download\" title=\"download\"/>\n"
-#~ "                                Descargar Plantilla de Importación de "
-#~ "Cheques Propios"
+"Debe configurar los períodos fiscales antes de importar saldos de contactos.\n"
+"\n"
+"Por favor, haga clic en 'Configurar Periodos' para configurar la fecha de apertura y los períodos fiscales."
 
 #~ msgid ""
 #~ "<span class=\"fa fa-download\" title=\"download\"/>\n"
-#~ "                                Descargar Plantilla de Importación de "
-#~ "Cheques de Terceros"
+#~ "                                Descargar Plantilla de Importación de Cheques Propios"
 #~ msgstr ""
 #~ "<span class=\"fa fa-download\" title=\"download\"/>\n"
-#~ "                                Descargar Plantilla de Importación de "
-#~ "Cheques de Terceros"
+#~ "                                Descargar Plantilla de Importación de Cheques Propios"
 
 #~ msgid ""
 #~ "<span class=\"fa fa-download\" title=\"download\"/>\n"
-#~ "                                Descargar Plantilla de Importación de "
-#~ "Saldos Contables"
+#~ "                                Descargar Plantilla de Importación de Cheques de Terceros"
 #~ msgstr ""
 #~ "<span class=\"fa fa-download\" title=\"download\"/>\n"
-#~ "                                Descargar Plantilla de Importación de "
-#~ "Saldos Contables"
+#~ "                                Descargar Plantilla de Importación de Cheques de Terceros"
 
 #~ msgid ""
 #~ "<span class=\"fa fa-download\" title=\"download\"/>\n"
-#~ "                                Descargar Plantilla de Importación de "
-#~ "Saldos de Partners"
+#~ "                                Descargar Plantilla de Importación de Saldos Contables"
 #~ msgstr ""
 #~ "<span class=\"fa fa-download\" title=\"download\"/>\n"
-#~ "                                Descargar Plantilla de Importación de "
-#~ "Saldos de Partners"
+#~ "                                Descargar Plantilla de Importación de Saldos Contables"
+
+#~ msgid ""
+#~ "<span class=\"fa fa-download\" title=\"download\"/>\n"
+#~ "                                Descargar Plantilla de Importación de Saldos de Partners"
+#~ msgstr ""
+#~ "<span class=\"fa fa-download\" title=\"download\"/>\n"
+#~ "                                Descargar Plantilla de Importación de Saldos de Partners"
 
 #~ msgid "Account Balance Import"
 #~ msgstr "Alta Inicial de Saldos de Cuentas"
@@ -520,6 +597,9 @@ msgstr ""
 #~ msgid "Partner Balance Import"
 #~ msgstr "Alta Inicial de Saldos de Contactos"
 
+#~ msgid "Payments"
+#~ msgstr "Pagos"
+
 #~ msgid "Propios"
 #~ msgstr "Propios"
 
@@ -531,27 +611,21 @@ msgstr ""
 
 #~ msgid ""
 #~ "Use this wizard to import your checks from an Excel file.\n"
-#~ "                Download the template, fill it with your data, and upload "
-#~ "it back."
+#~ "                Download the template, fill it with your data, and upload it back."
 #~ msgstr ""
 #~ "Usa este asistente para importar tus cheques desde un archivo de Excel.\n"
 #~ "                Descarga la plantilla, complétala con tus datos y cárgala."
 
 #~ msgid ""
-#~ "Use this wizard to import your initial account balances from an Excel "
-#~ "file.\n"
-#~ "                Download the template, fill it with your data, and upload "
-#~ "it back."
+#~ "Use this wizard to import your initial account balances from an Excel file.\n"
+#~ "                Download the template, fill it with your data, and upload it back."
 #~ msgstr ""
-#~ "Usa este asistente para importar los saldos iniciales de tus cuentas "
-#~ "desde un archivo de Excel.\n"
+#~ "Usa este asistente para importar los saldos iniciales de tus cuentas desde un archivo de Excel.\n"
 #~ "                Descarga la plantilla, complétala con tus datos y cárgala."
 
 #~ msgid ""
 #~ "Use this wizard to import your partner balances from an Excel file.\n"
-#~ "                Download the template, fill it with your data, and upload "
-#~ "it back."
+#~ "                Download the template, fill it with your data, and upload it back."
 #~ msgstr ""
-#~ "Usa este asistente para importar los saldos de tus contactos desde un "
-#~ "archivo de Excel.\n"
+#~ "Usa este asistente para importar los saldos de tus contactos desde un archivo de Excel.\n"
 #~ "                Descarga la plantilla, complétala con tus datos y cárgala."

--- a/account_balance_import/models/account_import_summary.py
+++ b/account_balance_import/models/account_import_summary.py
@@ -1,4 +1,4 @@
-from odoo import fields, models
+from odoo import _, fields, models
 from odoo.exceptions import UserError
 
 
@@ -7,15 +7,15 @@ class AccountImportSummary(models.TransientModel):
 
     account_opening_move_id = fields.Many2one(
         "account.move",
-        string="Asiento de Apertura",
+        string="Opening Entry",
         default=lambda self: self.env.company.account_opening_move_id,
         readonly=True,
-        help="Asiento que contiene el balance inicial de todas las cuentas de la compañía",
+        help="Entry containing the opening balance of all the company's accounts",
     )
 
     def action_open_company_data_setup(self):
         return self.env.company._get_records_action(
-            name="Set your company data",
+            name=_("Set your company data"),
             target="new",
         )
 
@@ -32,8 +32,10 @@ class AccountImportSummary(models.TransientModel):
 
         if not self.env.company.account_opening_date:
             raise UserError(
-                "Debe configurar los períodos fiscales antes de importar saldos de partners.\n\n"
-                "Por favor, haga clic en 'Set Periods' para configurar la fecha de apertura y los períodos fiscales."
+                _(
+                    "You must set fiscal periods before importing partner balances.\n\n"
+                    "Please click 'Set Periods' to configure the opening date and the fiscal periods."
+                )
             )
 
         return (
@@ -43,7 +45,7 @@ class AccountImportSummary(models.TransientModel):
                 default_company_id=self.env.company.id,
             )
             ._get_records_action(
-                name="Import Partner Balance",
+                name=_("Import Partner Balance"),
                 target="new",
             )
         )

--- a/account_balance_import/static/src/xml/account_import.xml
+++ b/account_balance_import/static/src/xml/account_import.xml
@@ -82,9 +82,9 @@
 
                                             <!-- Mostrar link al asiento de apertura si existe -->
                                             <div t-if="accountOpeningMoveId" class="mt-3 alert alert-info" role="alert">
-                                                <strong>Asiento de Apertura:</strong>
+                                                <strong>Opening Entry:</strong>
                                                 <button type="button" class="btn btn-link p-0 align-baseline" t-on-click="() => this._openAccountOpeningMove()">
-                                                    <t t-esc="accountOpeningMoveId[1]"/>
+                                                    <t t-out="accountOpeningMoveId[1]"/>
                                                 </button>
                                             </div>
                                         </div>

--- a/account_balance_import/wizards/account_balance_import.py
+++ b/account_balance_import/wizards/account_balance_import.py
@@ -5,7 +5,7 @@ import logging
 import numbers
 
 import xlrd
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 from openpyxl import load_workbook
 
@@ -21,36 +21,34 @@ class AccountBalanceImport(models.TransientModel):
     # Common Fields
     company_id = fields.Many2one(
         "res.company",
-        string="Compañía",
+        string="Company",
         required=True,
         default=lambda self: self.env.company,
     )
 
     counterpart_account_id = fields.Many2one(
         "account.account",
-        string="Cuenta de Contrapartida",
+        string="Counterpart Account",
         default=lambda self: self.env.company.get_unaffected_earnings_account(),
-        help="Recomendamos utilizar la misma cuenta de contrapartida para todos los asientos iniciales",
+        help="We recommend using the same counterpart account for all initial entries",
         check_company=True,
     )
 
     mode = fields.Selection(
         [
-            ("partner_balance", "Saldos de Partners"),
+            ("partner_balance", "Partner Balances"),
         ],
-        string="Modo de Importación",
+        string="Import Mode",
         required=True,
         default="partner_balance",
         ondelete={"partner_balance": "set default"},
     )
-    accounting_date = fields.Date(
-        "Fecha Contable", required=True, compute="_compute_accounting_date", store=True, readonly=False
-    )
+    accounting_date = fields.Date(required=True, compute="_compute_accounting_date", store=True, readonly=False)
 
     # Company Balance Related Fields
     journal_id = fields.Many2one(
         "account.journal",
-        string="Diario",
+        string="Journal",
         domain="journal_domain",
         check_company=True,
     )
@@ -58,32 +56,29 @@ class AccountBalanceImport(models.TransientModel):
         compute="_compute_journal_domain",
     )
     partner_balance_type = fields.Selection(
-        [("receivable", "Por Cobrar"), ("payable", "A Pagar")],
-        "Tipo de Deuda",
+        [("receivable", "Receivable"), ("payable", "Payable")],
+        "Debt Type",
         default="receivable",
     )
     export_partners = fields.Boolean(
-        string="Exportar Partners",
         default=True,
-        help="Si se activa, la plantilla incluirá los clientes o proveedores existentes según el Tipo de Deuda seleccionado.",
+        help="If enabled, the template will include existing customers or vendors according to the selected Debt Type.",
     )
     import_type = fields.Selection(
         [
-            ("absolute", "Absoluto"),
-            ("adjust", "Ajuste"),
+            ("absolute", "Absolute"),
+            ("adjust", "Adjustment"),
         ],
-        string="Tipo de Importación",
         default="absolute",
         required=True,
-        help="Absoluto: genera asientos directamente con los valores importados.\n"
-        "Ajuste: calcula la diferencia entre el saldo actual del partner y el valor importado.",
+        help="Absolute: generates entries directly with the imported values.\n"
+        "Adjustment: calculates the difference between the partner's current balance and the imported value.",
     )
     reconcile_debt = fields.Boolean(
-        string="Conciliar deuda",
         default=True,
-        help="si marca esta opción se conciliará automáticamente con la deuda más vieja.",
+        help="If you check this option, it will automatically reconcile with the oldest debt.",
     )
-    file = fields.Binary("Archivo de Importación")
+    file = fields.Binary("Import File")
 
     @api.depends("mode")
     def _compute_journal_domain(self):
@@ -142,7 +137,7 @@ class AccountBalanceImport(models.TransientModel):
     def action_import(self):
         self.ensure_one()
         if not self.file:
-            raise ValidationError("Por favor, cargue un archivo Excel para importar.")
+            raise ValidationError(_("Please upload an Excel file to import."))
         if self.mode == "partner_balance":
             return self._partner_balance_import_xls()
 
@@ -275,27 +270,33 @@ class AccountBalanceImport(models.TransientModel):
 
             if other_currency and not dict_data.get("amount_company_currency"):
                 errors.append(
-                    f"Fila {str(row_no)}: Si le establece otra moneda debe indicar el importe en esa otra moneda"
+                    _("Row %s: If you set another currency you must indicate the amount in that other currency")
+                    % str(row_no)
                 )
                 continue
 
             # Skip if partner not found
             if not partner:
                 errors.append(
-                    f"Fila {str(row_no)}: No se encontró ningún partner para el texto ingresado ({dict_data['name']})."
+                    _("Row %(row)s: No partner was found for the entered text (%(text)s).")
+                    % {"row": str(row_no), "text": dict_data["name"]}
                 )
                 continue
 
             # Skip if more than one partner was found
             if len(partner) > 1:
                 errors.append(
-                    f"Fila {str(row_no)}: Se encontraron varios partners para el texto ingresado ({dict_data['name']}). ¡Revise los datos cargados!"
+                    _(
+                        "Row %(row)s: Several partners were found for the entered text (%(text)s). "
+                        "Please review the loaded data!"
+                    )
+                    % {"row": str(row_no), "text": dict_data["name"]}
                 )
                 continue
 
             # Skip if amount isn't numerical
             if not isinstance(dict_data["amount"], numbers.Number):
-                errors.append(f"Fila {str(row_no)}: El monto no es numérico.")
+                errors.append(_("Row %s: The amount is not numeric.") % str(row_no))
                 continue
 
             # Parse due_date
@@ -309,7 +310,7 @@ class AccountBalanceImport(models.TransientModel):
                         ).date()
                 except Exception:
                     errors.append(
-                        f"Fila {str(row_no)}: Formato de fecha de vencimiento desconocido. Asegúrese de que la columna posee formato de fecha."
+                        _("Row %s: Unknown due date format. Make sure the column has a date format.") % str(row_no)
                     )
                     continue
             else:
@@ -353,14 +354,19 @@ class AccountBalanceImport(models.TransientModel):
             # Skip if partner account account is obsolete
             if not partner_account.active:
                 errors.append(
-                    f"Fila {str(row_no)}: La cuenta asociada al partner {partner.name} se encuentra depreciada."
+                    _("Row %(row)s: The account associated with partner %(partner)s is deprecated.")
+                    % {"row": str(row_no), "partner": partner.name}
                 )
                 continue
 
             # Check if accounts have the same company
             if company.id not in partner_account.company_ids.ids:
                 errors.append(
-                    f"Fila {str(row_no)}: Una de las cuentas asociadas al partner {partner.name} no pertenece a la compañía ({company.name})"
+                    _(
+                        "Row %(row)s: One of the accounts associated with partner %(partner)s does not belong "
+                        "to company (%(company)s)"
+                    )
+                    % {"row": str(row_no), "partner": partner.name, "company": company.name}
                 )
                 continue
 
@@ -471,6 +477,13 @@ class AccountBalanceImport(models.TransientModel):
 
         if num_columns != expected_columns:
             raise ValidationError(
-                f"The number of columns ({num_columns}) does not match the expected number ({expected_columns}).\n"
-                f"Expected fields: {', '.join(expected_fields)}"
+                _(
+                    "The number of columns (%(actual)s) does not match the expected number (%(expected)s).\n"
+                    "Expected fields: %(fields)s"
+                )
+                % {
+                    "actual": num_columns,
+                    "expected": expected_columns,
+                    "fields": ", ".join(expected_fields),
+                }
             )

--- a/account_balance_import/wizards/account_balance_import_wizard.xml
+++ b/account_balance_import/wizards/account_balance_import_wizard.xml
@@ -14,10 +14,10 @@
                         </h1>
 
                         <p style="margin-bottom: 0px;">
-                            Descargue la plantilla de importación siguiendo el link
-                            y edítelo manteniendo la estructura del archivo.<br/>
-                            Una vez finalizada la edición, suba el archivo modificado
-                            y haga click en el botón "Importar" ubicado más abajo.
+                            Download the import template using the link
+                            and edit it while keeping the file structure.<br/>
+                            Once you finish editing, upload the modified file
+                            and click the "Import" button below.
                         </p>
                     </group>
 
@@ -31,7 +31,7 @@
                             <div name="files" colspan="2">
                                 <button name="action_generate_partner_balance_xls" type="object" class="btn btn-link" invisible="mode != 'partner_balance'" role="button">
                                     <span class="fa fa-download" title="download"></span>
-                                    Descargar Plantilla de Importación de Saldos de Partners
+                                    Download Partner Balances Import Template
                                 </button>
                             </div>
                             <field name="file"/>
@@ -46,8 +46,8 @@
                     </group>
                 </sheet>
                 <footer>
-                    <button type="object" name="action_import" class="btn btn-primary">Importar</button>
-                    <button special="cancel" string="Cancelar"/>
+                    <button type="object" name="action_import" class="btn btn-primary">Import</button>
+                    <button special="cancel" string="Cancel"/>
                 </footer>
             </form>
         </field>


### PR DESCRIPTION
## Resumen

El wizard de importación de saldos de partners tenía los textos fuente en español, sin traducción al inglés → usuarios en inglés veían español. Deja el módulo bilingüe EN/ES.

- **Fuente en inglés**: textos del wizard (form), labels y selections de campos, y el texto "Opening Entry" del guide de onboarding (OWL).
- **Traducible**: se envuelven en `_()` los `ValidationError` y nombres de acción que estaban hardcodeados sin envolver.
- **Traducciones ES** completas en `i18n/es.po` + `.pot` actualizado.

## Criterio (acordado)

Inglés + traducción siempre que el término sea traducible (todos los de este módulo lo son). Solo se dejaría en español algo que no se pueda hacer traducible de ninguna forma — no es el caso acá.

## Test plan

- `python -m py_compile` OK; pre-commit en verde (ruff, ruff-format, pylint_odoo, checks Odoo, `.po[t]`, xml).
- `es.po`/`.pot` validados con `polib`: msgids idénticos entre ambos, placeholders consistentes.
- Verificar en UI el wizard de importación de saldos en `lang=en` y `lang=es`.

Task: 65994