### PR TITLE
[FIX] l10n_ar_account_reports: filter out zero and unlabeled SICORE lines

### DIFF
--- a/l10n_ar_account_reports/__manifest__.py
+++ b/l10n_ar_account_reports/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Accounting Reports Customized for Argentina",
-    "version": "19.0.1.18.0",
+    "version": "19.0.1.19.0",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",

--- a/l10n_ar_account_reports/data/sicore_report.xml
+++ b/l10n_ar_account_reports/data/sicore_report.xml
@@ -19,7 +19,7 @@
         <field name="line_ids">
             <record id="l10n_ar_sicore_report_profits_line" model="account.report.line">
                 <field name="name">Purchase Profits Withholdings</field>
-                <field name="domain_formula">-sum([("tax_line_id.l10n_ar_tax_type", "in", ["earnings", "earnings_scale"]), ("tax_line_id.l10n_ar_withholding_payment_type", "=", "supplier"), ("tax_line_id.country_code", "=", "AR")])</field>
+                <field name="domain_formula">-sum([("tax_line_id.l10n_ar_tax_type", "in", ["earnings", "earnings_scale"]), ("tax_line_id.l10n_ar_withholding_payment_type", "=", "supplier"), ("tax_line_id.country_code", "=", "AR"), ("name", "!=", "/"), ("balance", "&lt;", 0)])</field>
             </record>
         </field>
     </record>

--- a/l10n_ar_account_reports/models/sicore_report.py
+++ b/l10n_ar_account_reports/models/sicore_report.py
@@ -54,6 +54,8 @@ class L10n_ArSicoreReportHandler(models.AbstractModel):
             ("tax_line_id.l10n_ar_tax_type", "in", ["earnings", "earnings_scale"]),
             ("tax_line_id.l10n_ar_withholding_payment_type", "=", "supplier"),
             ("tax_line_id.country_code", "=", "AR"),
+            ("name", "!=", "/"),
+            ("balance", "<", 0),
         ] + get_standard_lines_domain(self.env["account.report"].get_report_company_ids(options), options)
         return self.env["account.move.line"].search(domain, order="date asc, name asc, id asc")
 


### PR DESCRIPTION
## Contexto

Ticket de helpdesk **121440** — "Error al descargar SICORE". El reporte SICORE Ganancias (y su export TXT) listaba todas las líneas de retención de ganancias a proveedor, incluyendo:

- líneas sin etiqueta real (`name = "/"`), y
- líneas con importe de retención en cero.

Eso metía ruido en el reporte y generaba entradas espurias en el TXT que se sube a SICORE.

## Cambios

- `data/sicore_report.xml`: se restringe el `domain_formula` de la línea del reporte a `name != "/"` y `balance < 0`.
- `models/sicore_report.py`: mismo filtro en el dominio del export TXT (`_sicore_book_get_txt_lines`), para que reporte y archivo descargado queden consistentes.
- Bump de versión `19.0.1.18.0` → `19.0.1.19.0`.

`balance < 0` representa "importe mayor a cero" porque el reporte negá el balance (`-sum(...)`) — las retenciones reales son créditos (balance negativo).

## Cómo probar

1. En una base con retenciones de ganancias a proveedor, generar el reporte **SICORE Ganancias**.
2. Verificar que ya no aparecen líneas con etiqueta `/` ni líneas en cero.
3. Exportar el TXT y confirmar que contiene únicamente las retenciones reales.