### PR TITLE
[FIX]l10n_ar_vat_book: add code 15 to partner_responsibility_code

### DIFF
--- a/l10n_ar_account_reports/models/l10n_ar_vat_book.py
+++ b/l10n_ar_account_reports/models/l10n_ar_vat_book.py
@@ -300,7 +300,7 @@ class L10n_ArTaxReportHandler(models.AbstractModel):
                         WHEN operation_type = %(exempt_op_type)s THEN ''
                         WHEN partner_responsibility_code = '1' THEN '1'
                         WHEN partner_responsibility_code IN ('6', '13') THEN '2'
-                        WHEN partner_responsibility_code IN ('4', '5', '7', '8', '9', '10', '16') THEN '3'
+                        WHEN partner_responsibility_code IN ('4', '5', '7', '8', '9', '10', '15', '16') THEN '3'
                         ELSE ''
                     END AS responsibility_type_code,
                     CASE


### PR DESCRIPTION
El código de responsabilidad AFIP '15' (IVA No Alcanzado) no estaba incluido en el CASE WHEN de `_vat_simple_build_sale_query`, lo que dejaba vacía la columna "Tipo de sujeto comprador" en el CSV de IVA Simple para partners con esa responsabilidad.

Se agrega '15' al bucket de exentos (→ valor '3'), junto a su par el código '16' (IVA No Alcanzado - Otro).