### PR TITLE
[FIX] account_balance_import_checks: tolerar importes con formato es_AR/en_US

### DIFF
--- a/account_balance_import_checks/tests/test_account_balance_import_checks.py
+++ b/account_balance_import_checks/tests/test_account_balance_import_checks.py
@@ -345,3 +345,61 @@ class TestAccountBalanceImportChecks(TransactionCase):
         self.assertEqual(check_3.amount, 8000.0, "Check amount should be 8000")
         self.assertEqual(check_3.payment_date, datetime.date(2025, 2, 10), "Check payment date should be 02/10/25")
         self.assertEqual(check_3.bank_id, self.bank, "Check bank should be Test Bank")
+
+    def test_parse_check_amount_formats(self):
+        """The amount parser must tolerate es_AR/en_US separators and native numbers."""
+        wizard = self.env["account.balance_import_wizard"].create(
+            {
+                "company_id": self.company.id,
+                "mode": "check_balance",
+                "check_type": "issue_check",
+                "journal_id": self.bank_journal.id,
+                "counterpart_account_id": self.counterpart_account.id,
+                "accounting_date": datetime.date(2025, 1, 1),
+            }
+        )
+        cases = [
+            ("791.666,00", 791666.00),  # es_AR: dot thousands, comma decimal
+            ("1.234.567,89", 1234567.89),
+            ("791,666.00", 791666.00),  # en_US: comma thousands, dot decimal
+            ("1234,56", 1234.56),  # lone comma -> decimal
+            ("791666.00", 791666.00),  # plain dot decimal
+            (10000, 10000.0),  # native int
+            (15000.5, 15000.5),  # native float
+            ("", 0.0),  # empty cell
+            (None, 0.0),
+        ]
+        for raw, expected in cases:
+            self.assertEqual(wizard._parse_check_amount(raw), expected, f"Wrong parse for {raw!r}")
+
+    def test_check_balance_import_ar_string_amount(self):
+        """Importing amounts as es_AR strings (e.g. '791.666,00') must not crash."""
+        data = {
+            "Número": [12345, 67890],
+            "Importe": ["791.666,00", "10.000,50"],
+            "Fecha de Pago": [datetime.date(2025, 2, 1), datetime.date(2025, 2, 15)],
+            "Nombre / CUIT / Referencia Interna": ["Test Partner 1", "Test Partner 2"],
+            "Otra Moneda (Opcional)": ["", ""],
+            "Importe en Otra moneda (Opcional)": ["", ""],
+        }
+        excel_file = base64.b64encode(generate_xls(data))
+        wizard = self.env["account.balance_import_wizard"].create(
+            {
+                "company_id": self.company.id,
+                "mode": "check_balance",
+                "check_type": "issue_check",
+                "journal_id": self.bank_journal.id,
+                "counterpart_account_id": self.counterpart_account.id,
+                "accounting_date": datetime.date(2025, 1, 1),
+                "file": excel_file,
+            }
+        )
+        result = wizard.action_import()
+        payment_ids = result.get("res_id") or result.get("domain")[0][2]
+        generated_payments = self.env["account.payment"].browse(payment_ids)
+        self.assertEqual(len(generated_payments), 2, "Should have created 2 payments")
+
+        payment_1 = generated_payments.filtered(lambda p: p.partner_id == self.partner_1)
+        self.assertEqual(payment_1.l10n_latam_new_check_ids[0].amount, 791666.00)
+        payment_2 = generated_payments.filtered(lambda p: p.partner_id == self.partner_2)
+        self.assertEqual(payment_2.l10n_latam_new_check_ids[0].amount, 10000.50)

--- a/account_balance_import_checks/wizard/account_balance_import.py
+++ b/account_balance_import_checks/wizard/account_balance_import.py
@@ -88,6 +88,27 @@ class AccountBalanceImport(models.TransientModel):
         rows = [row for row in rows if any(cell is not None and cell != "" for cell in row)]
         return rows, workbook_datemode
 
+    def _parse_check_amount(self, value):
+        """Return a float from a cell value, tolerating es_AR/en_US thousands and
+        decimal separators (e.g. '791.666,00' or '791,666.00' or a native float).
+
+        When both separators are present, the last one is taken as the decimal
+        separator; a lone comma is treated as the decimal separator.
+        """
+        if value is None or value == "":
+            return 0.0
+        if isinstance(value, numbers.Number):
+            return float(value)
+        value = str(value).strip().replace(" ", "")
+        if "," in value and "." in value:
+            if value.rfind(",") > value.rfind("."):  # coma decimal -> AR: 791.666,00
+                value = value.replace(".", "").replace(",", ".")
+            else:  # punto decimal -> US: 791,666.00
+                value = value.replace(",", "")
+        elif "," in value:  # solo coma -> decimal
+            value = value.replace(",", ".")
+        return float(value)
+
     def _parse_check_payment_date(self, date_val, workbook_datemode):
         """Return a date object from a cell value (datetime, date, or xlrd float)."""
         if isinstance(date_val, datetime.datetime):
@@ -153,6 +174,15 @@ class AccountBalanceImport(models.TransientModel):
             # Parse name as string to prevent CUIT being read as float
             if isinstance(dict_data["name"], numbers.Number):
                 dict_data["name"] = str(int(dict_data["name"])).strip()
+
+            # Parse amounts tolerating es_AR/en_US formats (e.g. '791.666,00')
+            try:
+                dict_data["amount"] = self._parse_check_amount(dict_data["amount"])
+                dict_data["amount_company_currency"] = self._parse_check_amount(dict_data["amount_company_currency"])
+            except ValueError:
+                errors.append(f"Fila {str(row_no + 1)}: Importe inválido ({dict_data['amount']}).")
+                continue
+
             # Locate Partner
             domain = [
                 "|",


### PR DESCRIPTION

Al importar el Excel de saldos iniciales de cheques, si la celda de importe venía como texto en notación argentina (miles con '.' y decimal con ',', ej. '791.666,00') el valor viajaba como string hasta el campo amount del cheque y Odoo fallaba con:

    ValueError: could not convert string to float: '791.666,00'

Se agrega _parse_check_amount() que normaliza el importe aceptando número nativo y strings en formato es_AR ('791.666,00') o en_US ('791,666.00'), y se aplica a amount y amount_company_currency antes de crear el pago. Importes inválidos ahora reportan error de fila en vez de un traceback.

Ticket: 121963