### PR TITLE
[FIX] l10n_ar_account_tax_settlement: use move_type in sircar txt

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -984,9 +984,9 @@ class AccountJournal(models.Model):
                 tipo_comprobante = letter == "E" and 106 or 102
             elif internal_type == "debit_note":
                 tipo_comprobante = letter == "E" and 6 or 2
-            elif line.move_id.type == "out_invoice":
+            elif line.move_id.move_type == "out_invoice":
                 tipo_comprobante = 20
-            elif line.move_id.type == "out_refund":
+            elif line.move_id.move_type == "out_refund":
                 tipo_comprobante = 120
             else:
                 raise ValidationError(_("Tipo de comprobante no reconocido"))


### PR DESCRIPTION
## Problema

El método `iibb_aplicado_sircar_files_values` en `l10n_ar_account_tax_settlement/models/account_journal.py` usaba `line.move_id.type`, atributo que ya no existe en `account.move` (fue renombrado a `move_type`). Al generar el txt de SIRCAR se producía `'account.move' object has no attribute 'type'`.

## Cambio

Reemplazo `line.move_id.type` por `line.move_id.move_type` en las dos ocurrencias (líneas 987 y 989).

## Test plan

- Generar el archivo txt de SIRCAR (IIBB aplicado) con comprobantes tipo `out_invoice` y `out_refund` y verificar que ya no se lanza el AttributeError y que el tipo de comprobante resultante es 20 y 120 respectivamente.

Ref: ticket 122101
