### PR TITLE
[ADD] l10n_ar_account_loan: register Argentinian taken loans

### DIFF
--- a/l10n_ar_account_loan/README.rst
+++ b/l10n_ar_account_loan/README.rst
@@ -1,0 +1,141 @@
+=================
+Argentinian Loans
+=================
+
+Register taken loans (disbursement, monthly bills with taxes and standard
+payment) the Argentinian way.
+
+This module is a bridge over the Enterprise ``account_loans`` module. It does
+not modify it: for loans flagged as Argentinian it replaces the native monthly
+journal entries with a bank disbursement, a supplier bill per instalment (with
+VAT/perceptions) and a standard payment, so the interest tax credit is captured
+and the debt is tracked instalment by instalment using standard Odoo mechanisms.
+
+Características
+===============
+
+- Adds an **Argentinian Loan** toggle to each loan (defaulted on when the
+  company's fiscal country is Argentina). When enabled, the native monthly
+  entries are not generated.
+- **Register disbursement** (button on the loan): posts an entry in the bank
+  journal — debit the journal's liquidity account for the credited amount, and
+  one credit line per instalment on the loan payable account, with the
+  instalment's due date and the bank contact.
+- **Generate bill** (button per amortization line): creates a supplier bill to
+  the bank contact with the interest pre-loaded and the loan's default taxes
+  (VAT); perceptions/other charges are completed manually against the real
+  document.
+- **Standard payment**: capital and interest bills post to the same payable
+  account for the same contact, so a single standard payment reconciles them
+  together, independently of the bank statement reconciliation.
+- **Automatic close**: the loan moves to *Closed* once every instalment's
+  capital is fully reconciled; the outstanding balance decreases as the capital
+  is reconciled.
+- **Grace instalments** (principal = 0): generate no capital line but can still
+  be billed for their interest.
+- **Teardown**: cancelling, resetting to draft or deleting an Argentinian loan
+  reverses or unlinks its disbursement entry and bills, leaving no orphaned
+  posted entries.
+- Smart buttons for the disbursement entry and the generated bills; the native
+  *Posted Entries* button is hidden on Argentinian loans (it does not apply to
+  this flow).
+- The loan payable account defaults to the bank contact's payable account and
+  is validated to match it, so capital and bills always reconcile together.
+
+Detalles Técnicos
+=================
+
+**Modelos heredados**
+
+- ``account.loan``
+
+  - Fields: ``is_ar_loan``, ``partner_id`` (bank contact), ``bank_journal_id``,
+    ``loan_payable_account_id`` (computed-editable, defaults to the contact's
+    payable account), ``interest_account_id``, ``interest_tax_ids``,
+    ``disbursement_move_id``, ``is_disbursed`` (computed), ``invoice_count``
+    (computed).
+  - Overrides ``action_confirm`` (Argentinian loans only validate the schedule
+    and move to *running*, skipping the native monthly entries),
+    ``action_cancel``, ``action_set_to_draft`` and ``_compute_outstanding_balance``.
+  - Adds ``action_register_disbursement``, ``action_open_disbursement`` and
+    ``action_open_invoices``.
+  - Constraint ``_check_ar_payable_match`` (the loan payable account must match
+    the bank contact's payable account) and an ``@api.ondelete`` teardown.
+
+- ``account.loan.line``
+
+  - Fields: ``capital_move_line_id``, ``invoice_id``, ``is_grace_period``
+    (stored computed), ``capital_reconciled`` (stored related to the capital
+    move line's ``reconciled``), ``loan_is_ar_loan`` (related).
+  - Adds ``action_generate_invoice`` and ``action_open_invoice``.
+
+- ``account.move.line``
+
+  - Overrides ``reconcile`` to close an Argentinian loan once all of its capital
+    is reconciled.
+
+**Vistas incluidas**
+
+- Inherits the ``account.loan`` form: register-disbursement header button,
+  disbursement/bills smart buttons, Argentinian settings in the loan settings
+  column (hiding the native long/short-term, expense and journal fields), and
+  the ``is_ar_loan`` toggle.
+- Inherits the ``account.loan.line`` list: grace-period, capital-reconciled,
+  capital-move-line and bill columns, plus the *Generate Bill* / *View Bill*
+  buttons.
+
+No new models or security rules are added; the native ``account_loans`` access
+rights are reused.
+
+Uso
+===
+
+1. **Setup** — create a dedicated bank contact (e.g. "Bank X - LOAN") and set
+   its *Account Payable* to a reconcilable "Loans payable" account. For a real
+   Argentinian database, also set the contact's AFIP responsibility type.
+2. **Create the loan** — in Accounting, create a loan and its amortization
+   schedule as usual. Keep *Argentinian Loan* enabled and fill the bank contact,
+   bank journal, interest account and default VAT (the loan payable account is
+   filled from the contact).
+3. **Confirm** — the loan moves to *running* without generating the native
+   monthly entries.
+4. **Register the disbursement** — with the header button; the bank is debited
+   and the capital is credited per instalment on the payable account.
+5. **Generate the bill** — per instalment, with *Generate Bill*; complete the
+   document type/number, VAT and perceptions against the bank's document and
+   post it.
+6. **Pay** — register a standard payment to the bank contact for the full
+   instalment (capital + interest) and reconcile it against the capital line and
+   the bill. The loan closes once all capital is reconciled.
+
+Arquitectura
+============
+
+The module extends ``account_loans`` without modifying it. The central design
+piece is a dedicated bank contact whose payable account holds both the capital
+(from the disbursement entry) and the interest bills, so a single standard
+payment reconciles them.
+
+Because the Argentinian moves are linked through new fields
+(``disbursement_move_id`` on the loan and ``invoice_id`` on the loan line)
+rather than the native ``generating_loan_line_id``, this module overrides the
+teardown (cancel / set to draft / delete), the outstanding-balance computation
+and the closing logic (via ``account.move.line.reconcile``) so they account for
+the Argentinian moves.
+
+Dependencias
+============
+
+- ``account_loans``
+- ``l10n_ar``
+- ``account_invoice_tax``
+
+Autor
+=====
+
+ADHOC SA
+
+Licencia
+========
+
+AGPL-3

--- a/l10n_ar_account_loan/__init__.py
+++ b/l10n_ar_account_loan/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_ar_account_loan/__manifest__.py
+++ b/l10n_ar_account_loan/__manifest__.py
@@ -1,0 +1,20 @@
+{
+    "name": "Argentinian Loans",
+    "version": "19.0.1.0.0",
+    "category": "Localization/Argentina",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "summary": "Register taken loans (disbursement, monthly bills with taxes and standard payment) the Argentinian way",
+    "depends": [
+        "account_loans",
+        "l10n_ar",
+        "account_invoice_tax",
+    ],
+    "data": [
+        "views/account_loan_views.xml",
+    ],
+    "installable": True,
+    "auto_install": False,
+    "application": False,
+}

--- a/l10n_ar_account_loan/models/__init__.py
+++ b/l10n_ar_account_loan/models/__init__.py
@@ -1,0 +1,3 @@
+from . import account_loan
+from . import account_loan_line
+from . import account_move_line

--- a/l10n_ar_account_loan/models/account_loan.py
+++ b/l10n_ar_account_loan/models/account_loan.py
@@ -1,0 +1,268 @@
+from odoo import Command, _, api, fields, models
+from odoo.exceptions import UserError, ValidationError
+from odoo.tools import float_compare
+from odoo.tools.misc import format_date
+
+
+class AccountLoan(models.Model):
+    _inherit = "account.loan"
+
+    is_ar_loan = fields.Boolean(
+        string="Argentinian Loan",
+        default=lambda self: self.env.company.account_fiscal_country_id.code == "AR",
+        help="Enable the Argentinian flow: register the disbursement, generate a "
+        "supplier bill per instalment (with taxes) and cancel everything with a "
+        "standard payment against the bank contact. Disables the native monthly entries.",
+    )
+    partner_id = fields.Many2one(
+        comodel_name="res.partner",
+        string="Bank Contact",
+        help="Dedicated contact (e.g. 'Bank X - LOAN'). Its payable account ('Loans payable') "
+        "is where both the capital and the interest bills post, so a standard payment "
+        "reconciles them together. The capital account is taken from this contact.",
+    )
+    bank_journal_id = fields.Many2one(
+        comodel_name="account.journal",
+        string="Bank Journal",
+        domain="[('type', 'in', ('bank', 'cash'))]",
+        help="Journal used for the disbursement; its liquidity account receives the credited amount.",
+    )
+    loan_payable_account_id = fields.Many2one(
+        comodel_name="account.account",
+        string="Loan Payable Account",
+        compute="_compute_loan_payable_account",
+        store=True,
+        readonly=False,
+        domain="[('account_type', '=', 'liability_payable'), ('reconcile', '=', True)]",
+        help="Payable account where the capital posts. Defaults to the bank contact's payable "
+        "account and must match it, so capital and interest bills reconcile together.",
+    )
+    interest_account_id = fields.Many2one(
+        comodel_name="account.account",
+        string="Interest Account",
+        domain="[('account_type', 'in', ('expense', 'expense_depreciation', 'expense_other'))]",
+    )
+    interest_tax_ids = fields.Many2many(
+        comodel_name="account.tax",
+        string="Interest Taxes",
+        domain="[('type_tax_use', '=', 'purchase')]",
+        help="Default taxes (VAT) pre-loaded on the interest line of each bill.",
+    )
+    disbursement_move_id = fields.Many2one(
+        comodel_name="account.move",
+        string="Disbursement Entry",
+        readonly=True,
+        copy=False,
+    )
+    invoice_count = fields.Integer(compute="_compute_invoice_count")
+
+    @api.depends("partner_id", "company_id")
+    def _compute_loan_payable_account(self):
+        """Default to the bank contact's payable account (editable). Keeping this as the
+        default is what stops the payable-match constraint from tripping in the normal flow."""
+        for loan in self:
+            loan.loan_payable_account_id = loan.partner_id.with_company(loan.company_id).property_account_payable_id
+
+    @api.depends("line_ids.invoice_id")
+    def _compute_invoice_count(self):
+        for loan in self:
+            loan.invoice_count = len(loan.line_ids.invoice_id)
+
+    @api.depends(
+        "amount_borrowed",
+        "line_ids.principal",
+        "state",
+        "line_ids.is_payment_move_posted",
+        "line_ids.capital_reconciled",
+    )
+    def _compute_outstanding_balance(self):
+        """For AR loans the balance drops as each instalment's capital gets reconciled
+        (the native flow keys off ``is_payment_move_posted``, which AR moves never set)."""
+        ar_loans = self.filtered("is_ar_loan")
+        super(AccountLoan, self - ar_loans)._compute_outstanding_balance()
+        for loan in ar_loans:
+            balance = loan.amount_borrowed
+            if loan.state == "running":
+                balance -= sum(loan.line_ids.filtered("capital_reconciled").mapped("principal"))
+            loan.outstanding_balance = balance
+
+    @api.constrains("is_ar_loan", "partner_id", "loan_payable_account_id", "company_id")
+    def _check_ar_payable_match(self):
+        """Capital and interest bills only reconcile together with one payment if they land
+        in the same payable account for the same partner. The bills always use the contact's
+        payable account, so the loan payable account must match it. The compute defaults it
+        correctly; this guards against a manual override that would silently break reconciliation."""
+        for loan in self.filtered("is_ar_loan"):
+            if not loan.partner_id or not loan.loan_payable_account_id:
+                continue
+            partner_payable = loan.partner_id.with_company(loan.company_id).property_account_payable_id
+            if partner_payable != loan.loan_payable_account_id:
+                raise ValidationError(
+                    _(
+                        "The loan payable account (%(loan_account)s) must match the bank contact's "
+                        "payable account (%(partner_account)s) so capital and bills reconcile together.",
+                        loan_account=loan.loan_payable_account_id.display_name,
+                        partner_account=partner_payable.display_name or "-",
+                    )
+                )
+
+    # -------------------------------------------------------------------------
+    # Confirm
+    # -------------------------------------------------------------------------
+    def action_confirm(self):
+        """AR loans skip the native monthly entries; they only validate the
+        schedule and move to running. Money is registered later through the
+        disbursement + per-instalment bills + standard payment."""
+        ar_loans = self.filtered("is_ar_loan")
+        standard_loans = self - ar_loans
+        if standard_loans:
+            super(AccountLoan, standard_loans).action_confirm()
+        for loan in ar_loans:
+            loan._check_ar_schedule()
+            loan.state = "running"
+        return True
+
+    def _check_ar_schedule(self):
+        """Reuse the native schedule validations without requiring the LT/ST/expense accounts.
+
+        Native couples these checks with the account/journal checks and the monthly
+        entry generation inside ``action_confirm`` (no extractable hook), so we mirror
+        only the schedule half here. Keep in sync with ``account_loans`` action_confirm.
+        """
+        self.ensure_one()
+        rounding = self.currency_id.rounding
+        if not self.name:
+            raise UserError(_("The loan name should be set."))
+        if self.is_wrong_date:
+            raise UserError(_("The loan date should be earlier than the loan lines date."))
+        if float_compare(self.amount_borrowed_difference, 0.0, precision_rounding=rounding) != 0:
+            raise UserError(
+                _(
+                    "The loan amount %(loan_amount)s should be equal to the sum of the principals.",
+                    loan_amount=self.currency_id.format(self.amount_borrowed),
+                )
+            )
+        if float_compare(self.interest_difference, 0.0, precision_rounding=rounding) != 0:
+            raise UserError(_("The loan interest should be equal to the sum of the loan lines interest."))
+        if self.duration_difference != 0:
+            raise UserError(_("The loan duration should be equal to the number of loan lines."))
+
+    def _check_ar_config(self):
+        self.ensure_one()
+        if not self.partner_id:
+            raise UserError(_("Set the bank contact on the loan."))
+        if not self.bank_journal_id:
+            raise UserError(_("Set the bank journal used for the disbursement."))
+        if not self.loan_payable_account_id:
+            raise UserError(
+                _(
+                    "Set the loan payable account. It defaults to the bank contact's payable "
+                    "account — the contact '%s' has none set, so configure it there or pick one here.",
+                    self.partner_id.display_name,
+                )
+            )
+        if not self.bank_journal_id.default_account_id:
+            raise UserError(_("The bank journal %s has no liquidity account.", self.bank_journal_id.display_name))
+
+    # -------------------------------------------------------------------------
+    # US1 - Disbursement
+    # -------------------------------------------------------------------------
+    def action_register_disbursement(self):
+        self.ensure_one()
+        if self.disbursement_move_id:
+            raise UserError(_("The disbursement was already registered."))
+        self._check_ar_schedule()
+        self._check_ar_config()
+
+        payable_account = self.loan_payable_account_id
+        capital_lines = self.line_ids.filtered(lambda l: not l.is_grace_period)
+        if self.skip_until_date:
+            # Mirror native: periods already booked by hand are not re-recorded.
+            capital_lines = capital_lines.filtered(lambda l: l.date >= self.skip_until_date)
+        disbursed_amount = sum(capital_lines.mapped("principal"))
+        line_commands = [
+            Command.create(
+                {
+                    "account_id": self.bank_journal_id.default_account_id.id,
+                    "debit": disbursed_amount,
+                    "name": _("Loan disbursement - %s", self.name),
+                }
+            ),
+            *(
+                Command.create(
+                    {
+                        "account_id": payable_account.id,
+                        "partner_id": self.partner_id.id,
+                        "credit": line.principal,
+                        "date_maturity": line.date,
+                        "name": _(
+                            "%(loan)s - Capital %(date)s",
+                            loan=self.name,
+                            date=format_date(self.env, line.date, date_format="MM/y"),
+                        ),
+                    }
+                )
+                for line in capital_lines
+            ),
+        ]
+        move = (
+            self.env["account.move"]
+            .with_company(self.company_id)
+            .create(
+                {
+                    "move_type": "entry",
+                    "company_id": self.company_id.id,
+                    "journal_id": self.bank_journal_id.id,
+                    "date": self.date,
+                    "ref": _("Loan disbursement - %s", self.name),
+                    "line_ids": line_commands,
+                }
+            )
+        )
+        move.action_post()
+
+        # Match each instalment to its capital line by maturity date (each schedule
+        # line has a distinct date) rather than by position in the recordset.
+        amls_by_date = {aml.date_maturity: aml for aml in move.line_ids if aml.account_id == payable_account}
+        for line in capital_lines:
+            line.capital_move_line_id = amls_by_date.get(line.date)
+        self.disbursement_move_id = move
+        return self.action_open_disbursement()
+
+    # -------------------------------------------------------------------------
+    # Smart buttons
+    # -------------------------------------------------------------------------
+    def action_open_disbursement(self):
+        self.ensure_one()
+        return self.disbursement_move_id._get_records_action(name=_("Disbursement Entry"))
+
+    def action_open_invoices(self):
+        self.ensure_one()
+        return self.line_ids.invoice_id._get_records_action(name=_("Loan Bills"))
+
+    # -------------------------------------------------------------------------
+    # Teardown — the AR moves link via disbursement_move_id / line.invoice_id,
+    # not the native generating_loan_line_id, so the native cancel/draft/unlink
+    # (which only touch line_ids.generated_move_ids) would leave them orphaned.
+    # -------------------------------------------------------------------------
+    def _ar_teardown_moves(self):
+        for loan in self.filtered("is_ar_loan"):
+            moves = loan.disbursement_move_id | loan.line_ids.invoice_id
+            moves.filtered(lambda m: m.state != "cancel")._unlink_or_reverse()
+            loan.disbursement_move_id = False
+            loan.line_ids.write({"capital_move_line_id": False, "invoice_id": False})
+
+    def action_cancel(self):
+        self._ar_teardown_moves()
+        return super().action_cancel()
+
+    def action_set_to_draft(self):
+        self._ar_teardown_moves()
+        return super().action_set_to_draft()
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_ar_loan(self):
+        for loan in self.filtered("is_ar_loan"):
+            (loan.disbursement_move_id | loan.line_ids.invoice_id).filtered(
+                lambda m: m.state != "cancel"
+            )._unlink_or_reverse()

--- a/l10n_ar_account_loan/models/account_loan_line.py
+++ b/l10n_ar_account_loan/models/account_loan_line.py
@@ -1,0 +1,76 @@
+from odoo import Command, _, api, fields, models
+from odoo.exceptions import UserError
+from odoo.tools.misc import format_date
+
+
+class AccountLoanLine(models.Model):
+    _inherit = "account.loan.line"
+
+    capital_move_line_id = fields.Many2one(
+        comodel_name="account.move.line",
+        string="Capital Entry Line",
+        readonly=True,
+        copy=False,
+        help="Payable line of the disbursement entry for this instalment's capital (empty on grace instalments).",
+    )
+    invoice_id = fields.Many2one(
+        comodel_name="account.move",
+        string="Bill",
+        readonly=True,
+        copy=False,
+    )
+    is_grace_period = fields.Boolean(compute="_compute_is_grace_period", store=True)
+    capital_reconciled = fields.Boolean(related="capital_move_line_id.reconciled", store=True)
+    loan_is_ar_loan = fields.Boolean(related="loan_id.is_ar_loan")
+
+    @api.depends("principal", "currency_id")
+    def _compute_is_grace_period(self):
+        for line in self:
+            line.is_grace_period = line.currency_id.is_zero(line.principal)
+
+    # -------------------------------------------------------------------------
+    # US2 - Bill per instalment
+    # -------------------------------------------------------------------------
+    def action_generate_invoice(self):
+        self.ensure_one()
+        loan = self.loan_id
+        if self.invoice_id:
+            raise UserError(_("This instalment already has a bill."))
+        if loan.currency_id.is_zero(self.interest):
+            raise UserError(_("This instalment has no interest to bill."))
+        if not loan.partner_id or not loan.interest_account_id:
+            raise UserError(_("Set the bank contact and the interest account on the loan."))
+
+        move = (
+            self.env["account.move"]
+            .with_company(loan.company_id)
+            .create(
+                {
+                    "move_type": "in_invoice",
+                    "company_id": loan.company_id.id,
+                    "partner_id": loan.partner_id.id,
+                    "invoice_date": self.date,
+                    "invoice_line_ids": [
+                        Command.create(
+                            {
+                                "name": _(
+                                    "%(loan)s - Interest %(date)s",
+                                    loan=loan.name,
+                                    date=format_date(self.env, self.date, date_format="MM/y"),
+                                ),
+                                "quantity": 1.0,
+                                "price_unit": self.interest,
+                                "account_id": loan.interest_account_id.id,
+                                "tax_ids": [Command.set(loan.interest_tax_ids.ids)],
+                            }
+                        )
+                    ],
+                }
+            )
+        )
+        self.invoice_id = move
+        return self.action_open_invoice()
+
+    def action_open_invoice(self):
+        self.ensure_one()
+        return self.invoice_id._get_records_action(name=_("Loan Bill"))

--- a/l10n_ar_account_loan/models/account_move_line.py
+++ b/l10n_ar_account_loan/models/account_move_line.py
@@ -1,0 +1,22 @@
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    def reconcile(self):
+        res = super().reconcile()
+        # Close an AR loan once every capital instalment is fully reconciled. The
+        # native close (account_move._post) keys off generating_loan_line_id, which
+        # AR moves never set, so it never fires for this flow.
+        # reconcile() runs on every reconciliation in the system, so cheaply skip the
+        # search unless a payable line was actually fully reconciled here.
+        candidates = self.filtered(lambda l: l.reconciled and l.account_id.account_type == "liability_payable")
+        if not candidates:
+            return res
+        loans = self.env["account.loan.line"].search([("capital_move_line_id", "in", candidates.ids)]).loan_id
+        for loan in loans.filtered(lambda l: l.is_ar_loan and l.state == "running"):
+            capital_lines = loan.line_ids.filtered(lambda l: not l.is_grace_period)
+            if capital_lines and all(line.capital_move_line_id.reconciled for line in capital_lines):
+                loan.state = "closed"
+        return res

--- a/l10n_ar_account_loan/tests/__init__.py
+++ b/l10n_ar_account_loan/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_l10n_ar_account_loan

--- a/l10n_ar_account_loan/tests/test_l10n_ar_account_loan.py
+++ b/l10n_ar_account_loan/tests/test_l10n_ar_account_loan.py
@@ -1,0 +1,174 @@
+from dateutil.relativedelta import relativedelta
+from odoo import Command, fields
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.exceptions import UserError, ValidationError
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestArAccountLoan(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.payable_account = cls.company_data["default_account_payable"]  # liability_payable, reconcile
+        cls.bank_journal = cls.company_data["default_journal_bank"]
+        cls.interest_account = cls.company_data["default_account_expense"]
+        cls.tax_purchase = cls.company_data["default_tax_purchase"]
+        cls.bank_partner = cls.env["res.partner"].create(
+            {
+                "name": "Bank X - LOAN",
+                "property_account_payable_id": cls.payable_account.id,
+            }
+        )
+        # 3 capital instalments (400 each) + 1 grace instalment (principal 0, interest 50)
+        date = "2024-01-01"
+        cls.loan = cls.env["account.loan"].create(
+            {
+                "name": "Prestamo ARG",
+                "date": date,
+                "duration": 4,
+                "amount_borrowed": 1200,
+                "interest": 350,
+                "is_ar_loan": True,
+                "partner_id": cls.bank_partner.id,
+                "bank_journal_id": cls.bank_journal.id,
+                "interest_account_id": cls.interest_account.id,
+                "interest_tax_ids": [Command.set(cls.tax_purchase.ids)],
+                "line_ids": [
+                    Command.create(
+                        {
+                            "date": fields.Date.to_date(date) + relativedelta(months=m),
+                            "principal": principal,
+                            "interest": 100,
+                        }
+                    )
+                    for m, principal in enumerate([400, 400, 400])
+                ]
+                + [
+                    Command.create(
+                        {
+                            "date": fields.Date.to_date(date) + relativedelta(months=3),
+                            "principal": 0,
+                            "interest": 50,
+                        }
+                    )
+                ],
+            }
+        )
+
+    def test_confirm_skips_native_entries(self):
+        self.loan.action_confirm()
+        self.assertEqual(self.loan.state, "running")
+        self.assertFalse(self.loan.line_ids.generated_move_ids, "AR loans must not create the native monthly entries")
+
+    def test_disbursement(self):
+        self.loan.action_confirm()
+        self.loan.action_register_disbursement()
+        move = self.loan.disbursement_move_id
+        self.assertTrue(move)
+        self.assertEqual(move.state, "posted")
+        self.assertEqual(move.company_id, self.loan.company_id)
+
+        bank_line = move.line_ids.filtered(lambda l: l.account_id == self.bank_journal.default_account_id)
+        self.assertEqual(bank_line.debit, 1200, "bank debit equals the credited capital")
+
+        payable_lines = move.line_ids.filtered(lambda l: l.account_id == self.payable_account)
+        self.assertEqual(len(payable_lines), 3, "one payable line per capital instalment, grace excluded")
+        self.assertEqual(sum(payable_lines.mapped("credit")), 1200)
+        self.assertTrue(all(l.partner_id == self.bank_partner for l in payable_lines))
+
+        capital_lines = self.loan.line_ids.filtered(lambda l: l.principal > 0)
+        self.assertTrue(all(l.capital_move_line_id for l in capital_lines))
+        # each instalment is linked to the payable line with its own maturity date
+        self.assertTrue(all(l.capital_move_line_id.date_maturity == l.date for l in capital_lines))
+        grace_line = self.loan.line_ids.filtered("is_grace_period")
+        self.assertFalse(grace_line.capital_move_line_id, "grace instalment has no capital line")
+
+        with self.assertRaises(UserError):
+            self.loan.action_register_disbursement()
+
+    def test_generate_bill(self):
+        self.loan.action_confirm()
+        line = self.loan.line_ids[0]
+        line.action_generate_invoice()
+        bill = line.invoice_id
+        self.assertEqual(bill.move_type, "in_invoice")
+        self.assertEqual(bill.partner_id, self.bank_partner)
+        self.assertEqual(bill.amount_untaxed, 100)
+        self.assertEqual(bill.company_id, self.loan.company_id)
+        with self.assertRaises(UserError):
+            line.action_generate_invoice()
+
+    def test_cancel_tears_down_ar_moves(self):
+        self.loan.action_confirm()
+        self.loan.action_register_disbursement()
+        self.loan.line_ids[0].action_generate_invoice()
+        disbursement = self.loan.disbursement_move_id
+
+        self.loan.action_cancel()
+
+        self.assertEqual(self.loan.state, "cancelled")
+        self.assertFalse(self.loan.disbursement_move_id, "disbursement link cleared on cancel")
+        self.assertFalse(self.loan.line_ids.capital_move_line_id)
+        self.assertFalse(self.loan.line_ids.invoice_id)
+        # disbursement must not survive as an orphaned posted entry: it is either
+        # unlinked (deleted) or reversed/cancelled.
+        if disbursement.exists():
+            self.assertTrue(disbursement.state == "cancel" or disbursement.reversal_move_ids)
+
+    def test_payable_defaults_to_contact(self):
+        # the loan payable account defaults (computed-editable) to the bank contact's payable
+        self.assertEqual(self.loan.loan_payable_account_id, self.bank_partner.property_account_payable_id)
+
+    def test_payable_mismatch_blocked(self):
+        other_payable = self.env["account.account"].create(
+            {
+                "name": "Other payable",
+                "code": "OTHERPAY",
+                "account_type": "liability_payable",
+                "reconcile": True,
+            }
+        )
+        with self.assertRaises(ValidationError):
+            self.loan.loan_payable_account_id = other_payable
+
+    def test_missing_payable_account_raises(self):
+        self.loan.loan_payable_account_id = False
+        self.loan.action_confirm()
+        with self.assertRaises(UserError):
+            self.loan.action_register_disbursement()
+
+    def test_close_on_full_capital_reconcile(self):
+        self.loan.action_confirm()
+        self.loan.action_register_disbursement()
+        self.assertEqual(self.loan.outstanding_balance, 1200)
+        capital_amls = self.loan.line_ids.capital_move_line_id
+
+        # counterpart entry that cancels the whole capital (same account + partner)
+        counterpart = self.env["account.move"].create(
+            {
+                "move_type": "entry",
+                "line_ids": [
+                    Command.create(
+                        {
+                            "account_id": self.payable_account.id,
+                            "partner_id": self.bank_partner.id,
+                            "debit": 1200,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "account_id": self.bank_journal.default_account_id.id,
+                            "credit": 1200,
+                        }
+                    ),
+                ],
+            }
+        )
+        counterpart.action_post()
+        counterpart_payable = counterpart.line_ids.filtered(lambda l: l.account_id == self.payable_account)
+
+        (capital_amls + counterpart_payable).reconcile()
+
+        self.assertTrue(all(capital_amls.mapped("reconciled")))
+        self.assertEqual(self.loan.state, "closed", "loan closes once all capital is reconciled")

--- a/l10n_ar_account_loan/views/account_loan_views.xml
+++ b/l10n_ar_account_loan/views/account_loan_views.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="account_loan_form_view" model="ir.ui.view">
+        <field name="name">account.loan.form.l10n_ar</field>
+        <field name="model">account.loan</field>
+        <field name="inherit_id" ref="account_loans.account_loan_form_view"/>
+        <field name="arch" type="xml">
+
+            <!-- Header: register disbursement -->
+            <xpath expr="//header/field[@name='state']" position="before">
+                <button name="action_register_disbursement" type="object"
+                        string="Register Disbursement" class="oe_highlight"
+                        invisible="not is_ar_loan or state == 'draft' or disbursement_move_id"/>
+            </xpath>
+
+            <!-- Smart buttons -->
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button name="action_open_disbursement" type="object"
+                        class="oe_stat_button" icon="fa-bank"
+                        invisible="not disbursement_move_id">
+                    <span class="o_stat_text">Disbursement</span>
+                </button>
+                <button name="action_open_invoices" type="object"
+                        class="oe_stat_button" icon="fa-file-text-o"
+                        invisible="invoice_count == 0">
+                    <field name="invoice_count" widget="statinfo" string="Bills"/>
+                </button>
+            </xpath>
+
+            <!-- Native "Posted Entries" counts generated_move_ids (empty for AR loans, so
+                 always 0). AR moves are shown by the Disbursement / Bills buttons instead. -->
+            <xpath expr="//field[@name='nb_posted_entries']/.." position="attributes">
+                <attribute name="invisible">is_ar_loan or state == 'draft'</attribute>
+            </xpath>
+
+            <!-- AR flag on top of the loan settings -->
+            <xpath expr="//field[@name='amount_borrowed']" position="before">
+                <field name="is_ar_loan"/>
+                <field name="disbursement_move_id" invisible="1"/>
+            </xpath>
+
+            <!-- AR settings live in the same settings column (no separate group),
+                 replacing the native ones which only feed the disabled monthly entries -->
+            <xpath expr="//group[@name='loan_settings_column1']" position="inside">
+                <field name="partner_id" invisible="not is_ar_loan" readonly="disbursement_move_id"/>
+                <field name="bank_journal_id" invisible="not is_ar_loan" readonly="disbursement_move_id"/>
+                <field name="loan_payable_account_id" invisible="not is_ar_loan" readonly="disbursement_move_id"/>
+                <field name="interest_account_id" invisible="not is_ar_loan"/>
+                <field name="interest_tax_ids" widget="many2many_tags" invisible="not is_ar_loan"/>
+            </xpath>
+
+            <!-- Native settings drive the monthly entries the AR flow disables → hide them in AR -->
+            <xpath expr="//field[@name='long_term_account_id']" position="attributes">
+                <attribute name="invisible">is_ar_loan</attribute>
+            </xpath>
+            <xpath expr="//field[@name='short_term_account_id']" position="attributes">
+                <attribute name="invisible">is_ar_loan</attribute>
+            </xpath>
+            <xpath expr="//field[@name='expense_account_id']" position="attributes">
+                <attribute name="invisible">is_ar_loan</attribute>
+            </xpath>
+            <xpath expr="//field[@name='journal_id']" position="attributes">
+                <attribute name="invisible">is_ar_loan</attribute>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="account_loan_line_list_view" model="ir.ui.view">
+        <field name="name">account.loan.line.list.l10n_ar</field>
+        <field name="model">account.loan.line</field>
+        <field name="inherit_id" ref="account_loans.account_loan_line_list_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='payment']" position="after">
+                <field name="loan_is_ar_loan" column_invisible="1"/>
+                <field name="is_grace_period" optional="show"/>
+                <field name="capital_reconciled" optional="show"/>
+                <field name="capital_move_line_id" optional="hide"/>
+                <field name="invoice_id" optional="show"/>
+                <button name="action_generate_invoice" type="object"
+                        string="Generate Bill" icon="fa-file-text-o"
+                        invisible="not loan_is_ar_loan or invoice_id or interest == 0 or loan_state != 'running'"/>
+                <button name="action_open_invoice" type="object"
+                        string="View Bill" icon="fa-external-link"
+                        invisible="not invoice_id"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## What

New bridge module `l10n_ar_account_loan` over `account_loans` (Enterprise), extending it for the Argentinian flow **without touching upstream**.

`account_loans` builds the amortization schedule but does not register the money nor the taxes. This module lets you run a taken loan end to end using standard Odoo mechanisms:

- **Disbursement (US1):** button on the loan posts an entry in the bank journal — debit the journal liquidity account, one credit line per instalment (`principal > 0`) on the loan payable account, with `date_maturity` and the bank contact.
- **Bill per instalment (US2):** button per schedule line creates a supplier bill to the bank contact with the interest pre-loaded from the schedule; VAT/perceptions/fees are added manually against the real document.
- **Payment (US3):** fully standard `register payment` to the bank contact cancels capital + bill through native reconciliation (same payable account + same partner), independent of bank statement reconciliation.
- **Traceability:** each schedule line links its capital move line, bill and payment; the bill links back to the schedule line and loan.
- **Grace instalments (US5):** `principal = 0` lines are supported (no capital line, still billable).

For AR loans the native monthly entries are disabled — the disbursement + bills + standard payment replace them.

## Setup requirement

A dedicated bank contact whose payable account (`property_account_payable_id`) is the loan payable account ("Loans payable", type *payable*, reconcilable). That is what makes capital and bills share account + partner so a single payment reconciles both.

## Tests

`models` + `tests` included. Covered: confirm skips native entries, disbursement (one payable line per capital instalment, grace excluded, capital lines linked, idempotent), bill generation (linked to line, correct interest, idempotent). Local run: 3 tests, 0 failed, 0 errors.

## Notes

- Long/short-term reclassification (US4) is intentionally left out of this first cut (optional per spec; capital sits in a single payable account under the AR flow). Can be a follow-up.
- Task 63901.
