### PR TITLE
[IMP] l10n_ar_account_reports: add perceptions and VAT withholdings to SICORE TXT

### DIFF
--- a/l10n_ar_account_reports/data/sicore_report.xml
+++ b/l10n_ar_account_reports/data/sicore_report.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="l10n_ar_sicore_report" model="account.report">
-        <field name="name">SICORE Profits</field>
+        <field name="name">SICORE (Agente)</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>
         <field name="country_id" ref="base.ar"/>
         <field name="filter_hierarchy">never</field>
@@ -19,13 +19,23 @@
         <field name="line_ids">
             <record id="l10n_ar_sicore_report_profits_line" model="account.report.line">
                 <field name="name">Purchase Profits Withholdings</field>
-                <field name="domain_formula">-sum([("tax_line_id.l10n_ar_tax_type", "in", ["earnings", "earnings_scale"]), ("tax_line_id.l10n_ar_withholding_payment_type", "=", "supplier"), ("tax_line_id.country_code", "=", "AR")])</field>
+                <field name="domain_formula">-sum([("tax_line_id.l10n_ar_tax_type", "in", ["earnings", "earnings_scale"]), ("tax_line_id.l10n_ar_withholding_payment_type", "=", "supplier"), ("tax_line_id.l10n_ar_state_id", "=", False), ("tax_line_id.country_code", "=", "AR"), ("balance", "!=", 0)])</field>
+            </record>
+            <record id="l10n_ar_sicore_report_vat_withholding_line" model="account.report.line">
+                <field name="name">Purchase VAT Withholdings</field>
+                <field name="hide_if_zero" eval="True"/>
+                <field name="domain_formula">-sum([("tax_line_id.l10n_ar_tribute_afip_code", "=", "06"), ("tax_line_id.l10n_ar_withholding_payment_type", "=", "supplier"), ("tax_line_id.l10n_ar_state_id", "=", False), ("tax_line_id.country_code", "=", "AR"), ("balance", "!=", 0)])</field>
+            </record>
+            <record id="l10n_ar_sicore_report_vat_perception_line" model="account.report.line">
+                <field name="name">Sale VAT Perceptions</field>
+                <field name="hide_if_zero" eval="True"/>
+                <field name="domain_formula">-sum([("tax_line_id.type_tax_use", "=", "sale"), ("tax_line_id.l10n_ar_state_id", "=", False), ("tax_line_id.l10n_ar_tribute_afip_code", "=", "06"), ("tax_line_id.country_code", "=", "AR"), ("balance", "!=", 0)])</field>
             </record>
         </field>
     </record>
 
     <record id="sicore_return_type" model="account.return.type">
-        <field name="name">SICORE Ganancias (Agente)</field>
+        <field name="name">SICORE (Agente)</field>
         <field name="report_id" ref="l10n_ar_account_reports.l10n_ar_sicore_report"/>
         <field name="default_deadline_periodicity">fortnightly</field>
         <field name="auto_generate" eval="False"/>

--- a/l10n_ar_account_reports/i18n/es.po
+++ b/l10n_ar_account_reports/i18n/es.po
@@ -317,7 +317,7 @@ msgid ""
 msgstr ""
 "Cuenta que se utilizará para el asiento de cierre de este tipo de "
 "declaración. Si no se configura, se utilizará la cuenta de cuentas por pagar "
-"o por cobrar del socio."
+"o por cobrar del contacto."
 
 #. module: l10n_ar_account_reports
 #: model:ir.model,name:l10n_ar_account_reports.model_account_return
@@ -596,8 +596,15 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
 #: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
+#: code:addons/l10n_ar_account_reports/models/sicore_report.py:0
 msgid "Edit contact"
 msgstr "Editar contacto"
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sicore_report.py:0
+msgid "Edit identification type"
+msgstr "Editar tipo de identificación"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
@@ -1005,6 +1012,11 @@ msgid "Purchase Profits Withholdings"
 msgstr "Retenciones sobre las ganancias por compra"
 
 #. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_sicore_report_vat_withholding_line
+msgid "Purchase VAT Withholdings"
+msgstr "Retenciones de IVA por compra"
+
+#. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_caba_report_caba_withholdings_line
 #: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_mendoza_report_mendoza_withholdings_line
 #: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_misiones_report_misiones_withholdings_line
@@ -1076,20 +1088,22 @@ msgstr ""
 "pendientes al cierre del período."
 
 #. module: l10n_ar_account_reports
-#: model:account.return.type,name:l10n_ar_account_reports.sicore_return_type
-msgid "SICORE Ganancias (Agente)"
-msgstr ""
-
-#. module: l10n_ar_account_reports
 #: model:account.report,name:l10n_ar_account_reports.l10n_ar_sicore_report
-msgid "SICORE Profits"
-msgstr "SICORE Ganancias"
+#: model:account.return.type,name:l10n_ar_account_reports.sicore_return_type
+msgid "SICORE (Agente)"
+msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/sicore_report.py:0
-msgid "SICORE_profits_withholdings.txt"
-msgstr "SICORE_ganancias_retenciones.txt"
+msgid "SICORE Aplicado.txt"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sicore_report.py:0
+msgid "SICORE TXT"
+msgstr "TXT SICORE"
 
 #. module: l10n_ar_account_reports
 #: model:account.report,name:l10n_ar_account_reports.l10n_ar_sifere_report
@@ -1114,6 +1128,11 @@ msgid "Sale Perceptions"
 msgstr "Percepciones de Venta"
 
 #. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_sicore_report_vat_perception_line
+msgid "Sale VAT Perceptions"
+msgstr "Percepciones de IVA por venta"
+
+#. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_sifere_report_sifere_withholdings_line
 msgid "Sale Withholdings"
 msgstr "Retenciones de Venta"
@@ -1122,12 +1141,6 @@ msgstr "Retenciones de Venta"
 #: model_terms:ir.ui.view,arch_db:l10n_ar_account_reports.inflation_adjustment_index_search
 msgid "Search Description"
 msgstr "Buscar Descripción"
-
-#. module: l10n_ar_account_reports
-#. odoo-python
-#: code:addons/l10n_ar_account_reports/models/sicore_report.py:0
-msgid "Sicore Profits Withholdings TXT"
-msgstr "TXT SICORE Retenciones Ganancias"
 
 #. module: l10n_ar_account_reports
 #. odoo-python
@@ -1275,14 +1288,25 @@ msgid ""
 "The partner \"%(partner_name)s\" (id %(partner_id)s) does not have the vat "
 "set."
 msgstr ""
-"El socio «%(partner_name)s» (id %(partner_id)s) no tiene configurado el IVA."
+"El contacto «%(partner_name)s» (id %(partner_id)s) no tiene configurado el número de identificación."
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/account_return.py:0
 msgid "The partner '%s' has no %s account configured for company '%s'."
 msgstr ""
-"El socio «%s» no tiene ninguna cuenta %s configurada para la empresa «%s»."
+"El contacto «%s» no tiene ninguna cuenta %s configurada para la empresa «%s»."
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sicore_report.py:0
+msgid ""
+"The payment \"%(payment_name)s\" (id %(payment_id)s) has a withholding tax "
+"that is not linked to a withholding, so its base amount cannot be reported."
+msgstr ""
+"El pago «%(payment_name)s» (id %(payment_id)s) tiene un impuesto de "
+"retención que no está vinculado a una retención, así que no se puede "
+"informar su base de cálculo."
 
 #. module: l10n_ar_account_reports
 #. odoo-python
@@ -1311,8 +1335,8 @@ msgid ""
 "The return type '%s' has no payment partner configured. Please set a Payment "
 "Partner on the return type."
 msgstr ""
-"El tipo de devolución «%s» no tiene ningún socio de pago configurado. "
-"Configure un socio de pago para el tipo de devolución."
+"El tipo de devolución «%s» no tiene ningún contacto de pago configurado. "
+"Configure un contacto de pago para el tipo de devolución."
 
 #. module: l10n_ar_account_reports
 #. odoo-python
@@ -1412,6 +1436,12 @@ msgstr ""
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_sales
 msgid "Ventas netas de bienes y servicios"
 msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sicore_report.py:0
+msgid "View payment"
+msgstr "Ver pago"
 
 #. module: l10n_ar_account_reports
 #. odoo-python

--- a/l10n_ar_account_reports/i18n/l10n_ar_account_reports.pot
+++ b/l10n_ar_account_reports/i18n/l10n_ar_account_reports.pot
@@ -531,7 +531,14 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/caba_report.py:0
 #: code:addons/l10n_ar_account_reports/models/santa_fe_report.py:0
+#: code:addons/l10n_ar_account_reports/models/sicore_report.py:0
 msgid "Edit contact"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sicore_report.py:0
+msgid "Edit identification type"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -929,6 +936,11 @@ msgid "Purchase Profits Withholdings"
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_sicore_report_vat_withholding_line
+msgid "Purchase VAT Withholdings"
+msgstr ""
+
+#. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_caba_report_caba_withholdings_line
 #: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_mendoza_report_mendoza_withholdings_line
 #: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_misiones_report_misiones_withholdings_line
@@ -998,19 +1010,21 @@ msgid ""
 msgstr ""
 
 #. module: l10n_ar_account_reports
-#: model:account.return.type,name:l10n_ar_account_reports.sicore_return_type
-msgid "SICORE Ganancias (Agente)"
-msgstr ""
-
-#. module: l10n_ar_account_reports
 #: model:account.report,name:l10n_ar_account_reports.l10n_ar_sicore_report
-msgid "SICORE Profits"
+#: model:account.return.type,name:l10n_ar_account_reports.sicore_return_type
+msgid "SICORE (Agente)"
 msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/sicore_report.py:0
-msgid "SICORE_profits_withholdings.txt"
+msgid "SICORE Aplicado.txt"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sicore_report.py:0
+msgid "SICORE TXT"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -1036,6 +1050,11 @@ msgid "Sale Perceptions"
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_sicore_report_vat_perception_line
+msgid "Sale VAT Perceptions"
+msgstr ""
+
+#. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.l10n_ar_sifere_report_sifere_withholdings_line
 msgid "Sale Withholdings"
 msgstr ""
@@ -1043,12 +1062,6 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #: model_terms:ir.ui.view,arch_db:l10n_ar_account_reports.inflation_adjustment_index_search
 msgid "Search Description"
-msgstr ""
-
-#. module: l10n_ar_account_reports
-#. odoo-python
-#: code:addons/l10n_ar_account_reports/models/sicore_report.py:0
-msgid "Sicore Profits Withholdings TXT"
 msgstr ""
 
 #. module: l10n_ar_account_reports
@@ -1177,6 +1190,14 @@ msgstr ""
 
 #. module: l10n_ar_account_reports
 #. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sicore_report.py:0
+msgid ""
+"The payment \"%(payment_name)s\" (id %(payment_id)s) has a withholding tax "
+"that is not linked to a withholding, so its base amount cannot be reported."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
 #: code:addons/l10n_ar_account_reports/models/sifere_report.py:0
 msgid ""
 "The perception %s (id: %d) of the document \"%s\" (id: %d) has no associated"
@@ -1289,6 +1310,12 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #: model:account.report.line,name:l10n_ar_account_reports.account_financial_report_l10n_ar_estado_resultados_line_sales
 msgid "Ventas netas de bienes y servicios"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/sicore_report.py:0
+msgid "View payment"
 msgstr ""
 
 #. module: l10n_ar_account_reports

--- a/l10n_ar_account_reports/models/account_return_type.py
+++ b/l10n_ar_account_reports/models/account_return_type.py
@@ -283,10 +283,24 @@ class AccountReturnType(models.Model):
                 ("tax_line_id.type_tax_use", "=", "purchase"),
             ]
         if external_id == "l10n_ar_account_reports.sicore_return_type":
+            # Unión de las tres líneas del reporte SICORE. Sin jurisdicción, que
+            # excluye IIBB (esas van a sus propias liquidaciones).
             return [
+                ("tax_line_id.country_code", "=", "AR"),
+                ("tax_line_id.l10n_ar_state_id", "=", False),
+                "|",
+                # Retenciones de ganancias practicadas en pagos a proveedores.
+                "&",
                 ("tax_line_id.l10n_ar_tax_type", "in", ["earnings", "earnings_scale"]),
                 ("tax_line_id.l10n_ar_withholding_payment_type", "=", "supplier"),
-                ("tax_line_id.country_code", "=", "AR"),
+                # IVA, identificado por el código de tributo ARCA "06" del grupo de
+                # impuestos: retenciones practicadas en pagos a proveedores y
+                # percepciones aplicadas en ventas.
+                "&",
+                ("tax_line_id.l10n_ar_tribute_afip_code", "=", "06"),
+                "|",
+                ("tax_line_id.l10n_ar_withholding_payment_type", "=", "supplier"),
+                ("tax_line_id.type_tax_use", "=", "sale"),
             ]
         return []
 

--- a/l10n_ar_account_reports/models/sicore_report.py
+++ b/l10n_ar_account_reports/models/sicore_report.py
@@ -2,7 +2,7 @@
 import re
 
 from odoo import _, fields, models
-from odoo.exceptions import UserError
+from odoo.exceptions import RedirectWarning, UserError
 
 from .helpers import get_standard_lines_domain
 
@@ -14,10 +14,10 @@ class L10n_ArSicoreReportHandler(models.AbstractModel):
 
     def _custom_options_initializer(self, report, options, previous_options):
         super()._custom_options_initializer(report, options, previous_options=previous_options)
-        # TODO falta implementar percepciones aplicadas de iva
-        # Add export button
+        # SICORE es una única presentación: un solo TXT que combina las
+        # retenciones de ganancias e IVA con las percepciones de IVA.
         txt_export_button = {
-            "name": _("Sicore Profits Withholdings TXT"),
+            "name": _("SICORE TXT"),
             "sequence": 30,
             "action": "export_file",
             "action_param": "sicore_book_export_files_to_txt",
@@ -27,21 +27,116 @@ class L10n_ArSicoreReportHandler(models.AbstractModel):
 
         options["buttons"].append(txt_export_button)
 
+    # ==========================================================================
+    # Helpers comunes a retenciones y percepciones
+    # ==========================================================================
+
+    def _sicore_tax_code(self, tax):
+        """SICORE tax code (campo "Codigo de Impuesto", 4 dígitos).
+
+        "0217" para ganancias (identificadas por el tipo de retención) y "0767"
+        para IVA, que es el resto de lo que llega acá: las retenciones y
+        percepciones de IVA se reconocen por el código de tributo ARCA "06" de su
+        grupo de impuestos, no por el tipo de retención.
+        """
+        return "0217" if tax.l10n_ar_tax_type in ("earnings", "earnings_scale") else "0767"
+
+    def _sicore_regime(self, tax, tax_code, is_withholding):
+        """Devuelve (campo régimen [3], código de condición [2]) de un impuesto.
+
+        Ganancias: régimen tal cual (o "000" si falta), condición "01".
+        IVA: régimen del impuesto, con el 499 ("otros") como fallback solo en
+        retenciones; condición "01" salvo régimen 602 (13/14 según la alícuota)
+        o 214/493 ("00"), según las relaciones de códigos SICORE de
+        doc/Sicore/relaciones-codigos-sicore.csv.
+        """
+        regimen_code = "".join(filter(str.isdigit, str(tax.l10n_ar_code or "")))[:3]
+        if tax_code == "0217":
+            return (f"{regimen_code:0>3}" if regimen_code else "000"), "01"
+        if not regimen_code and is_withholding:
+            # 499 es el régimen "otros" de las retenciones de IVA; en percepciones
+            # no existe, así que el campo sale en cero.
+            regimen_code = "499"
+        regimen_field = f"{regimen_code:0>3}"
+        codcond = "01"
+        if regimen_code == "602":
+            codcond = "13" if (tax.amount_type == "percent" and tax.amount == 3) else "14"
+        elif regimen_code in ("214", "493"):
+            codcond = "00"
+        return regimen_field, codcond
+
+    def _sicore_check_partner(self, partner):
+        """Valida los datos del contacto que informa el registro SICORE.
+
+        Cada aviso redirige al registro donde se corrige el dato faltante: el
+        código ARCA está en el tipo de identificación y el CUIT en el contacto.
+        """
+        identification_type = partner.l10n_latam_identification_type_id
+        if not identification_type.l10n_ar_afip_code:
+            raise RedirectWarning(
+                message=_(
+                    'The identification type "%(identification_type)s" does not have ARCA code set.',
+                    identification_type=identification_type.name,
+                ),
+                action=identification_type.get_formview_action(),
+                button_text=_("Edit identification type"),
+            )
+        if not partner.vat:
+            raise RedirectWarning(
+                message=_(
+                    'The partner "%(partner_name)s" (id %(partner_id)s) does not have the vat set.',
+                    partner_name=partner.name,
+                    partner_id=partner.id,
+                ),
+                action=partner.get_formview_action(),
+                button_text=_("Edit contact"),
+            )
+
+    def _sicore_record_tail(self, partner, issue_date, amount):
+        """Tramo final común del registro SICORE (idéntico en retenciones y
+        percepciones): importe, porcentaje de exclusión, fecha de boletín,
+        documento del sujeto y número de certificado."""
+        content = ""
+        # Retención Pract. a Suj. ..     [ 1]
+        content += "0"
+        # Importe de Retencion / Percepcion (amount)          [14]
+        content += f"{abs(amount):014.2f}"
+        # Porcentaje de Exclusion (exclusion percentage)       [ 6]
+        content += "000.00"
+        # Fecha Emision Boletin          [10] (dd/mm/yyyy)
+        content += fields.Date.from_string(issue_date).strftime("%d/%m/%Y")
+        # Tipo Documento Retenido (document type code)       [ 2]
+        content += f"{int(partner.l10n_latam_identification_type_id.l10n_ar_afip_code):02d}"
+        # Numero Documento Retenido (vat)     [20]
+        # El campo espera el número sin separadores; el tipo va en el campo
+        # anterior. No usamos ensure_vat() porque solo devuelve el CUIT, y acá
+        # también hay que soportar DNI, CUIL y pasaporte.
+        content += re.sub(r"\D", "", partner.vat or "").ljust(20)
+        # Numero Certificado Original    [14]
+        content += f"{0:014d}"
+        content += "\r\n"
+        return content
+
+    # ==========================================================================
+    # Export (una sola presentación SICORE)
+    # ==========================================================================
+
     def sicore_book_export_files_to_txt(self, options):
         """Export method that lets us export the SICORE book to a txt file.
         It contains the file that we upload to SICORE application."""
         return {
-            "file_name": _("SICORE_profits_withholdings.txt"),
+            "file_name": _("SICORE Aplicado.txt"),
             "file_content": self._sicore_book_get_txt_files(options),
             "file_type": "txt",
         }
 
     def _sicore_book_get_txt_files(self, options):
-        """Returns SICORE txt content"""
-        move_lines = self._sicore_book_get_txt_lines(options)
-        return "".join(self._get_sicore_txt_content(move_lines)).encode("ISO-8859-1", "ignore")
+        """Returns SICORE txt content.
 
-    def _sicore_book_get_txt_lines(self, options):
+        SICORE es una única presentación: el TXT combina las retenciones de
+        ganancias e IVA con las percepciones de IVA en un solo archivo, con
+        todos los registros ordenados por fecha de emisión.
+        """
         state = options.get("all_entries") and "all" or "posted"
         if state != "posted":
             raise UserError(
@@ -50,38 +145,68 @@ class L10n_ArSicoreReportHandler(models.AbstractModel):
                     " Please remove Include unposted entries filter and try again"
                 )
             )
+        # Cada builder devuelve tuplas (fecha, contenido) para poder intercalar
+        # retenciones y percepciones en un único archivo ordenado por fecha.
+        records = self._get_sicore_withholding_content(self._sicore_get_withholding_lines(options))
+        records += self._get_sicore_perception_content(self._sicore_get_perception_lines(options))
+        records.sort(key=lambda record: (record[0], record[1]))
+        return "".join(content for *_key, content in records).encode("ISO-8859-1", "ignore")
+
+    # ==========================================================================
+    # Retenciones (ganancias + IVA) — datos tomados del pago
+    # ==========================================================================
+
+    def _sicore_get_withholding_lines(self, options):
+        # Retenciones nacionales sobre pagos a proveedores (sin jurisdicción,
+        # que excluye IIBB). Cada tipo se identifica con lo que hay disponible en
+        # el impuesto:
+        # - Ganancias: tipo de retención earnings / earnings_scale.
+        # - IVA: código de tributo ARCA "06" en el grupo de impuestos. El tipo de
+        #   retención no sirve acá porque su selection no tiene opción de IVA.
+        # Restringimos a apuntes con pago para no procesar asientos manuales,
+        # de los que no podemos sacar ni el comprobante ni la base de cálculo.
         domain = [
-            ("tax_line_id.l10n_ar_tax_type", "in", ["earnings", "earnings_scale"]),
             ("tax_line_id.l10n_ar_withholding_payment_type", "=", "supplier"),
             ("tax_line_id.country_code", "=", "AR"),
+            ("tax_line_id.l10n_ar_state_id", "=", False),
+            "|",
+            ("tax_line_id.l10n_ar_tax_type", "in", ["earnings", "earnings_scale"]),
+            ("tax_line_id.l10n_ar_tribute_afip_code", "=", "06"),
         ] + get_standard_lines_domain(self.env["account.report"].get_report_company_ids(options), options)
-        return self.env["account.move.line"].search(domain, order="date asc, name asc, id asc")
+        return self.env["account.move.line"].search(domain, order="date asc, id asc")
 
-    def _get_sicore_txt_content(self, move_lines):
-        """Returns the lines to be printed in the txt file."""
+    def _get_sicore_withholding_content(self, move_lines):
+        """Returns (date, line id, content) tuples for the withholding lines (retenciones)."""
         lines = []
-        for line in move_lines.filtered("amount_currency").sorted(key=lambda r: (r.date, r.id)):
+        # Filtramos por balance, que es el importe que informa el registro y el
+        # que suman las líneas del reporte, para que el TXT y los totales del
+        for line in move_lines.filtered("balance"):
             content = ""
 
             partner = line.partner_id
-            if not partner.l10n_latam_identification_type_id.l10n_ar_afip_code:
-                raise UserError(
-                    _(
-                        'The identification type "%(identification_type)s" does not have ARCA code set.',
-                        identification_type=partner.l10n_latam_identification_type_id.name,
-                    )
-                )
-            if not partner.vat:
-                raise UserError(
-                    _(
-                        'The partner "%(partner_name)s" (id %(partner_id)s) does not have the vat set.',
-                        partner_name=partner.name,
-                        partner_id=partner.id,
-                    )
+            self._sicore_check_partner(partner)
+            # Sin el registro de retención no tenemos de dónde sacar la base de
+            # cálculo, y el registro saldría con la base en cero sin que nadie
+            # se entere: el archivo queda bien formado y con un dato falso.
+            if not line.withholding_id:
+                raise RedirectWarning(
+                    message=_(
+                        'The payment "%(payment_name)s" (id %(payment_id)s) has a withholding tax that is not'
+                        " linked to a withholding, so its base amount cannot be reported.",
+                        payment_name=line.payment_id.display_name,
+                        payment_id=line.payment_id.id,
+                    ),
+                    action=line.payment_id.get_formview_action(),
+                    button_text=_("View payment"),
                 )
 
             payment = line.payment_id
             move = line.move_id
+            tax = line._get_settlement_tax(date=line.date)
+            tax_code = self._sicore_tax_code(tax)
+            regimen_field, codcond = self._sicore_regime(tax, tax_code, is_withholding=True)
+            # payment.date es la fecha de emisión que informa el layout.
+            issue_date = payment.date
 
             # Codigo del Comprobante (document code)        [ 2]
             content += (
@@ -93,54 +218,109 @@ class L10n_ArSicoreReportHandler(models.AbstractModel):
             # Numero Comprobante (document number)           [16]
             content += f"{re.sub(r'[^0-9]', '', move.l10n_latam_document_number):0>16}"
 
-            # Fecha de pago del comprobante (document amount)
-            issue_date = payment.date
-
             # Importe Comprobante (document amount)           [16]
             content += f"{abs(payment.payment_total):016.2f}"
+
             # Codigo de Impuesto (tax code)            [ 4]
+            content += tax_code
             # Codigo de Regimen (regime code)             [ 3]
+            content += regimen_field
 
-            content += "0217"
-            tax = line._get_settlement_tax(date=line.date)
-            regimen = tax.l10n_ar_code
-
-            content += f"{''.join(filter(str.isdigit, str(regimen))):0>3}" if regimen else "000"
-
-            # Codigo de Operacion (operation code)           [ 1]
+            # Codigo de Operacion (operation code)           [ 1] -> 1 retención
             content += "1"
 
             # Base de Calculo (base amount)               [14]
             content += f"{abs(line.withholding_id.base_amount):014.2f}"
 
-            # Fecha Emision Retencion (move line date)        [10] (dd/mm/yyyy)
+            # Fecha Emision Retencion (payment date)          [10] (dd/mm/yyyy)
             content += fields.Date.from_string(issue_date).strftime("%d/%m/%Y")
 
             # Codigo de Condicion (condition code)           [ 2]
-            content += "01"
+            content += codcond
 
-            # Retención Pract. a Suj. ..     [ 1]
-            content += "0"
+            # Tramo final común del registro.
+            content += self._sicore_record_tail(partner, issue_date, line.balance)
 
-            # Importe de Retencion (withholding amount)          [14]
-            content += f"{abs(line.balance):014.2f}"
+            # La clave de orden es la fecha de emisión de la retención (issue_date =
+            # payment.date), que es la que se informa en el layout, más el id del
+            # apunte para desempatar dentro de la misma fecha.
+            lines.append((issue_date, line.id, content))
+        return lines
 
-            # Porcentaje de Exclusion (exclusion percentage)       [ 6]
-            content += "000.00"
+    # ==========================================================================
+    # Percepciones de IVA — datos tomados del comprobante
+    # ==========================================================================
 
-            # Fecha Emision Boletin          [10] (dd/mm/yyyy)
+    def _sicore_get_perception_lines(self, options):
+        # Percepciones de IVA aplicadas en ventas: impuestos de venta, sin
+        # jurisdicción, cuyo grupo tiene código de tributo ARCA "06".
+        # Las percepciones de ganancias no se informan en esta presentación.
+        # Restringimos a comprobantes de venta (facturas/NC/ND) para no procesar
+        # asientos manuales sin fecha ni número de comprobante.
+        domain = [
+            ("tax_line_id.type_tax_use", "=", "sale"),
+            ("tax_line_id.l10n_ar_state_id", "=", False),
+            ("tax_line_id.l10n_ar_tribute_afip_code", "=", "06"),
+            ("tax_line_id.country_code", "=", "AR"),
+        ] + get_standard_lines_domain(self.env["account.report"].get_report_company_ids(options), options)
+        return self.env["account.move.line"].search(domain, order="date asc, id asc")
+
+    def _get_sicore_perception_content(self, move_lines):
+        """Returns (date, line id, content) tuples for the perception lines (percepciones)."""
+        lines = []
+        for line in move_lines.filtered("balance"):
+            content = ""
+            partner = line.partner_id
+            self._sicore_check_partner(partner)
+
+            move = line.move_id
+            internal_type = move.l10n_latam_document_type_id.internal_type
+            is_credit_note = internal_type == "credit_note"
+
+            issue_date = move.invoice_date
+            tax = line._get_settlement_tax(date=issue_date)
+            # Solo informamos percepciones de IVA en esta presentación.
+            tax_code = "0767"
+            regimen_field, codcond = self._sicore_regime(tax, tax_code, is_withholding=False)
+
+            # Codigo del Comprobante (document code)        [ 2]
+            content += {"invoice": "01", "credit_note": "03", "debit_note": "04"}.get(internal_type, "05")
+
+            # Fecha Emision Comprobante (invoice date)      [10] (dd/mm/yyyy)
             content += fields.Date.from_string(issue_date).strftime("%d/%m/%Y")
 
-            # Tipo Documento Retenido (document type code)       [ 2]
-            content += f"{int(partner.l10n_latam_identification_type_id.l10n_ar_afip_code):02d}"
+            # Numero Comprobante (document number)          [16] (5 punto de venta + 11 número)
+            document_parts = move._l10n_ar_get_document_number_parts(
+                move.l10n_latam_document_number, move.l10n_latam_document_type_id.code
+            )
+            content += "{:0>5d}".format(document_parts["point_of_sale"])
+            content += "{:0>11d}".format(document_parts["invoice_number"])
 
-            # Numero Documento Retenido (vat)     [20]
-            content += partner.vat.ljust(20)
+            # Importe Comprobante (document amount)         [16]
+            content += f"{abs(move.amount_total_signed):016.2f}"
 
-            # Numero Certificado Original    [14]
-            content += f"{0:014d}"
+            # Codigo de Impuesto (tax code)                 [ 4]
+            content += tax_code
+            # Codigo de Regimen (regime code)               [ 3]
+            content += regimen_field
 
-            content += "\r\n"
+            # Codigo de Operacion (operation code)          [ 1] -> 2 percepción
+            content += "2"
 
-            lines.append(content)
+            # Base de Calculo (base amount)                 [14]
+            # En notas de crédito informamos el importe de la percepción como base
+            # para resolver la inconsistencia detectada en el ticket 61671.
+            base_amount = line.balance if is_credit_note else line.tax_base_amount
+            content += f"{abs(base_amount):014.2f}"
+
+            # Fecha Emision Retencion (invoice date)        [10] (dd/mm/yyyy)
+            content += fields.Date.from_string(issue_date).strftime("%d/%m/%Y")
+
+            # Codigo de Condicion (condition code)          [ 2]
+            content += codcond
+
+            # Tramo final común del registro.
+            content += self._sicore_record_tail(partner, issue_date, line.balance)
+
+            lines.append((issue_date, line.id, content))
         return lines


### PR DESCRIPTION
Agregamos la posibilidad de descargar retenciones y percepciones de iva en el archivo txt de sicore. Para que se descarguen las retenciones o percepciones de iva dichos impuestos deben tener establecido "06" en el campo l10n_ar_tribute_afip_code ("Tribute ARCA Code") de su grupo de impuestos ('06' representa que es impuesto de percepción o retención de iva).

Task: 70765
