### PR TITLE
[FIX] l10n_ar_account_tax_settlement: txt percepciones de ARBA, compobante sin letra

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -1723,7 +1723,11 @@ class AccountJournal(models.Model):
                 or "R"
             )
             # Letra Comprobante (long 1, desde 25 hasta 25. Valores A,B,C, o “ ” (blanco)).
-            content += line.l10n_latam_document_type_id.l10n_ar_letter
+            content += (
+                line.l10n_latam_document_type_id.l10n_ar_letter
+                if line.l10n_latam_document_type_id and line.l10n_latam_document_type_id.l10n_ar_letter
+                else " "
+            )
             document_parts = move._get_document_number_parts()
             pto_venta = "{:0>5d}".format(document_parts["point_of_sale"])[-5:]
             nro_documento = "{:0>8d}".format(document_parts["invoice_number"])[-8:]


### PR DESCRIPTION
Cuando intenta descargar el archivo txt de percepciones de ARBA, si el comprobante no tiene letra se recibe un error. Se agrega un condicional para que si no tiene letra, se agregue un espacio en blanco en lugar de letra del comprobante tal como lo indica la especificación ( https://github.com/ingadhoc/odoo-argentina-ee/blob/19.0/l10n_ar_account_reports/doc/ARBA%20(pba)/Dise%C3%B1o%20desde%2001032026/Nuevo%20Disenio%20de%20Registro%20ARWeb%20Prod.pdf https://github.com/ingadhoc/odoo-argentina-ee/blob/19.0/l10n_ar_account_reports/README.rst?plain=1#L44 ). De esta manera se va a poder descargar el archivo txt de percepciones de ARBA sin recibir un error. Ticket: 122654