### PR TITLE
[FIX] l10n_ar_account_reports: SIRCAR percepciones keep sign on credit notes

### DIFF
--- a/l10n_ar_account_reports/models/sircar_report.py
+++ b/l10n_ar_account_reports/models/sircar_report.py
@@ -207,13 +207,13 @@ class L10n_ArSircarReportHandler(models.AbstractModel):
                 content.append(fields.Date.from_string(line.date).strftime("%d/%m/%Y"))
 
                 # 7 Monto sujeto a percepción
-                content.append(format_amount(abs(get_line_tax_base(line)), 12, 2, "."))
+                content.append(format_amount(-get_line_tax_base(line), 12, 2, "."))
 
                 # 8 alicuota de la percepcion
                 content.append(format_amount(alicuot, 6, 2, "."))
 
                 # 9 Monto percibido
-                content.append(format_amount(abs(line.balance), 12, 2, "."))
+                content.append(format_amount(-line.balance, 12, 2, "."))
 
                 # 10 Tipo de Régimen de Percepción
                 # (código correspondiente según tabla definida por la jurisdicción)


### PR DESCRIPTION
### Problema

El TXT de percepciones del reporte SIRCAR exporta los montos de las notas de crédito con signo **positivo**, igual que las facturas. El formato AFIP/SIRCAR espera que las notas de crédito lleven signo **negativo** (facturas positivas, NC negativas).

### Causa

En la sección `perc` de `_get_sircar_txt_content`, los campos **7 (Monto sujeto a percepción)** y **9 (Monto percibido)** se exportaban con `abs(...)`, aplastando el signo:

```python
content.append(format_amount(abs(get_line_tax_base(line)), 12, 2, "."))
...
content.append(format_amount(abs(line.balance), 12, 2, "."))
```

`format_amount` ya emite el `-` cuando el monto es negativo, pero el `abs()` lo impide. El `balance` de la línea de percepción es negativo en facturas de venta y positivo en notas de crédito, con lo cual ambas terminaban positivas.

### Fix

Usar el valor con signo, igual que ya hace la sección de **retenciones** (`-line.balance`):

```python
content.append(format_amount(-get_line_tax_base(line), 12, 2, "."))
...
content.append(format_amount(-line.balance, 12, 2, "."))
```

Resultado: facturas positivas y notas de crédito negativas, coincidiendo con el TXT de referencia generado en 18.0.

### Verificación

- [x] Generar TXT Percepciones con una factura y una NC de venta con percepción IIBB y validar los signos contra el formato v18.
