### PR TITLE
[FIX] l10n_ar_arba_ws: recover DDJJ open on ARBA WS failure

### DIFF
--- a/l10n_ar_arba_ws/models/l10n_ar_dj_arba.py
+++ b/l10n_ar_arba_ws/models/l10n_ar_dj_arba.py
@@ -208,15 +208,21 @@ class L10nArDjArba(models.Model):
     def _ensure_dj(self, wh_date, company):
         """Encontrar la declaracion jurada que corresponde, que este en el mismo periodo de la retención.
 
+        Reusamos cualquier DDJJ existente del período (abierta o borrador) en lugar de crear una nueva.
+        Esto evita violar la constraint unique(company, period, state) y dejar borradores huérfanos cuando
+        un intento previo de abrir contra ARBA falló (ej. caída intermitente del webservice), lo que dejaba
+        al usuario bloqueado para informar cualquier retención de ese período.
+
         :return: DDJJ ARBA recordset of the matching DDJJ for the given period"""
         from_date, to_date = self._find_dates(wh_date)
         dj_arba = self.search(
             [
                 ("company_id", "=", company.id),
-                ("state", "=", "open"),
                 ("date", ">=", from_date),
                 ("date", "<=", to_date),
             ],
+            # Priorizamos una DDJJ ya abierta ('open') por sobre una en borrador ('draft')
+            order="state desc",
             limit=1,
         )
         if not dj_arba:
@@ -226,6 +232,7 @@ class L10nArDjArba(models.Model):
                     "date": wh_date,
                 }
             )
+        if dj_arba.state == "draft":
             dj_arba.action_open()
         return dj_arba
 
@@ -401,7 +408,12 @@ class L10nArDjArba(models.Model):
         )
         error_prefix = self.env._("Error opening the declaration: DDJJ ID number was not generated")
         if error:
-            self._process_arba_error(error, error_prefix)
+            # ARBA puede ya tener abierta la DDJJ del período (ej. un intento previo cuya respuesta se
+            # perdió por una caída intermitente del webservice). Intentamos recuperarla linkeando la DDJJ
+            # existente en ARBA en lugar de dejar el borrador colgado y bloquear el período.
+            self.action_find_existing()
+            if not self.name:
+                self._process_arba_error(error, error_prefix)
             return
 
         if response.get("id"):


### PR DESCRIPTION
### Problema

Cuando la apertura de una DDJJ contra el webservice de ARBA (A122R) falla —típicamente por una caída intermitente del WS que devuelve un connection reset— quedaba una DDJJ en estado borrador y el reintento creaba una **segunda** para el mismo período. Eso choca con la constraint `unique(company, period, state)` y deja al usuario **bloqueado para informar cualquier retención de esa quincena**, incluso después de que ARBA se recupera.

### Cambios

- `_ensure_dj` ahora reusa **cualquier** DDJJ existente del período (abierta o borrador) en vez de matchear solo `open`, priorizando `open` sobre `draft`. Así no crea duplicados ni deja borradores huérfanos que traben el período.
- `action_open` hace fallback a `action_find_existing` cuando el POST de apertura falla, para **linkear** una DDJJ que ARBA ya haya abierto (respuesta perdida por el corte) en lugar de dejar el período bloqueado.

Con esto, una caída puntual de ARBA ya no deja un deadlock permanente: al reintentar —o al recuperarse ARBA— el flujo reusa el borrador, lo abre o lo vincula, y sigue.

### Test plan

- Simular un fallo del WS en la apertura y verificar que el reintento **no** crea una segunda DDJJ ni dispara la constraint de unicidad.
- Con ARBA disponible, confirmar que una DDJJ ya abierta del lado de ARBA se vincula vía el fallback a `action_find_existing`.

Ticket interno: 123273