### PR TITLE
[FIX] ‎l10n_ar_account_reports: Número del comprobante en txt retenciones de sircar

### DIFF
--- a/l10n_ar_account_reports/models/sircar_report.py
+++ b/l10n_ar_account_reports/models/sircar_report.py
@@ -120,7 +120,7 @@ class L10n_ArSircarReportHandler(models.AbstractModel):
                     content.append("2")
 
                 # 4 Número del comprobante
-                content.append("%012d" % int(re.sub("[^0-9]", "", line.payment_id.name or "")))
+                content.append("%012d" % int(re.sub("[^0-9]", "", line.name or "")))
 
                 # 5 Cuit del contribuyene
                 content.append(line.partner_id.ensure_vat())
@@ -152,7 +152,7 @@ class L10n_ArSircarReportHandler(models.AbstractModel):
 
                 # 11 Jurisdicción: código en Convenio Multilateral de la
                 # jurisdicción a la cual está presentando la DDJJ
-                if not tax.l10n_ar_state_id.jurisdiction_code or not tax.l10n_ar_state_id.jurisdiction_code:
+                if not tax.l10n_ar_state_id or not tax.l10n_ar_state_id.jurisdiction_code:
                     raise RedirectWarning(
                         message=_(
                             'There is no jurisdiction set in the tax "%(tax_name)s" or it does not have a jurisdiction code.',
@@ -246,7 +246,7 @@ class L10n_ArSircarReportHandler(models.AbstractModel):
 
                 # 11 Jurisdicción: código en Convenio Multilateral de la
                 # jurisdicción a la cual está presentando la DDJJ
-                if not tax.l10n_ar_state_id.jurisdiction_code or not tax.l10n_ar_state_id.jurisdiction_code:
+                if not tax.l10n_ar_state_id or not tax.l10n_ar_state_id.jurisdiction_code:
                     raise RedirectWarning(
                         message=_(
                             'There is no jurisdiction set in the tax "%(tax_name)s" or it does not have a jurisdiction code.',


### PR DESCRIPTION
Ver página 5 de la especificación https://github.com/ingadhoc/odoo-argentina-ee/blob/19.0/l10n_ar_account_reports/doc/sircar/Anexo_Registros.pdf el campo 4 dice "Número de comprobante". En versíon 18 estamos llevando el número de retención, pero en 19 estamos llevando la numeración del pago. En este pull request hacemos la corrección para que en la versión 19 también se lleve el número de retención al igual que en versión 18 y no haya diferencias al momento de descargar el txt en ambas versiones.
Ticket: 123653