### PR TITLE
[FIX] account_accountant_ux: show partner detail when require_custom_filter is on

### DIFF
--- a/account_accountant_ux/models/account_partner_ledger.py
+++ b/account_accountant_ux/models/account_partner_ledger.py
@@ -34,3 +34,13 @@ class PartnerLedgerCustomHandler(models.AbstractModel):
         )
         line["amount_residual"] = aml_query_result.get("amount_residual", 0.0)
         return line
+
+    def _get_aml_values(self, options, partner_ids, offset=0, limit=None):
+        # Core pops options['partner_ids'] before querying here, so our
+        # require_custom_filter override sees no partner filter and blanks the
+        # domain, returning zero lines. We already know the partners, so
+        # bypass the gate like "Show All" would.
+        report = self.env["account.report"].browse(options.get("report_id"))
+        if report.require_custom_filter and partner_ids:
+            options = {**options, "show_all_custom": True}
+        return super()._get_aml_values(options, partner_ids, offset=offset, limit=limit)


### PR DESCRIPTION
## Summary

- `account.partner.ledger.report.handler._get_aml_values` pops `options['partner_ids']` before building its query (it scopes to the given `partner_ids` via a raw SQL clause instead, to also pick up lines reconciled indirectly through a partner-less entry).
- Our `require_custom_filter` override (`account_report.py`) only detects an active partner filter by checking `options['partner_ids']`. Once it's popped, it sees an apparently unfiltered request and blanks the domain — silently returning zero journal items for a partner row the user explicitly filtered on and asked to expand, even though the summary/total row (computed elsewhere, without the pop) shows the correct non-zero balance.
- Fix: in our own `_get_aml_values` override, bypass the gate (same as "Show All" would) when we already know the specific partners being targeted.
- Note: `_get_sums_without_partner` has the same pop pattern and could hit the same issue, but it only affects the correction for partner-less lines reconciled against a partnered one — left untouched here since it's outside the reported symptom.

## Test plan

- Report with `require_custom_filter`/`filter_show_all_custom` enabled (a Partner Ledger variant).
- Filter by a specific contact (without "Show All").
- Before this PR: the partner row shows the correct total, but clicking to expand shows nothing — no journal items.
- After this PR: clicking correctly fetches and displays the underlying journal items for that partner.

Ref: ticket https://www.adhoc.inc/odoo/my-tickets/123801 (internal).