### PR TITLE
[IMP] l10n_ar_edi_ux: unique ARCA POS number per company and POS system

### DIFF
--- a/l10n_ar_edi_ux/i18n/es.po
+++ b/l10n_ar_edi_ux/i18n/es.po
@@ -905,6 +905,20 @@ msgstr "Probar Conexiones"
 
 #. module: l10n_ar_edi_ux
 #. odoo-python
+#: code:addons/l10n_ar_edi_ux/models/account_journal.py:0
+msgid ""
+"The ARCA POS number %(pos_number)s is already used by the electronic "
+"journal \"%(journal)s\". Two electronic journals cannot share the same POS "
+"number because they would share the invoice numbering and ARCA would reject"
+" the documents (error 10016)."
+msgstr ""
+"El número de punto de venta ARCA %(pos_number)s ya está siendo usado por el"
+" diario electrónico \"%(journal)s\". Dos diarios electrónicos no pueden "
+"compartir el mismo número de punto de venta porque compartirían la "
+"numeración de los comprobantes y ARCA los rechazaría (error 10016)."
+
+#. module: l10n_ar_edi_ux
+#. odoo-python
 #: code:addons/l10n_ar_edi_ux/models/account_move.py:0
 msgid ""
 "The partner %s does not have an ARCA Responsibility configured. Please set "

--- a/l10n_ar_edi_ux/i18n/es.po
+++ b/l10n_ar_edi_ux/i18n/es.po
@@ -908,13 +908,14 @@ msgstr "Probar Conexiones"
 #: code:addons/l10n_ar_edi_ux/models/account_journal.py:0
 msgid ""
 "The ARCA POS number %(pos_number)s is already used by the journal "
-"\"%(journal)s\". Two sale journals cannot share the same POS number because"
-" they would share the document numbering."
+"\"%(journal)s\", which has the same POS system. Two sale journals cannot "
+"share the POS number and POS system because they would share the document "
+"numbering."
 msgstr ""
 "El número de punto de venta ARCA %(pos_number)s ya está siendo usado por el"
-" diario \"%(journal)s\". Dos diarios de venta no pueden compartir el mismo "
-"número de punto de venta porque compartirían la numeración de los "
-"comprobantes."
+" diario \"%(journal)s\", que tiene el mismo sistema de punto de venta. Dos "
+"diarios de venta no pueden compartir el número y el sistema de punto de "
+"venta porque compartirían la numeración de los comprobantes."
 
 #. module: l10n_ar_edi_ux
 #. odoo-python

--- a/l10n_ar_edi_ux/i18n/es.po
+++ b/l10n_ar_edi_ux/i18n/es.po
@@ -907,15 +907,14 @@ msgstr "Probar Conexiones"
 #. odoo-python
 #: code:addons/l10n_ar_edi_ux/models/account_journal.py:0
 msgid ""
-"The ARCA POS number %(pos_number)s is already used by the electronic "
-"journal \"%(journal)s\". Two electronic journals cannot share the same POS "
-"number because they would share the invoice numbering and ARCA would reject"
-" the documents (error 10016)."
+"The ARCA POS number %(pos_number)s is already used by the journal "
+"\"%(journal)s\". Two sale journals cannot share the same POS number because"
+" they would share the document numbering."
 msgstr ""
 "El número de punto de venta ARCA %(pos_number)s ya está siendo usado por el"
-" diario electrónico \"%(journal)s\". Dos diarios electrónicos no pueden "
-"compartir el mismo número de punto de venta porque compartirían la "
-"numeración de los comprobantes y ARCA los rechazaría (error 10016)."
+" diario \"%(journal)s\". Dos diarios de venta no pueden compartir el mismo "
+"número de punto de venta porque compartirían la numeración de los "
+"comprobantes."
 
 #. module: l10n_ar_edi_ux
 #. odoo-python

--- a/l10n_ar_edi_ux/models/account_journal.py
+++ b/l10n_ar_edi_ux/models/account_journal.py
@@ -9,50 +9,49 @@ class AccountJournal(models.Model):
     _inherit = "account.journal"
 
     def copy_data(self, default=None):
-        """Duplicating creates the record right away (there is no edit step before saving),
-        so a copied electronic journal would always collide with the original's POS number.
-        Assign the next free POS number instead; the user must review it afterwards."""
+        """Reset the POS number on duplicated journals: real ARCA POS numbers are not
+        necessarily consecutive, so suggesting one would hide misconfigurations. The user
+        must consciously fill in the number ARCA actually assigned."""
         vals_list = super().copy_data(default=default)
-        assigned = set()
         for journal, vals in zip(self, vals_list):
-            if "l10n_ar_afip_pos_number" in (default or {}) or not (journal.l10n_ar_is_pos and journal.l10n_ar_afip_ws):
-                continue
-            used = (
-                set(
-                    self.search(
-                        [
-                            ("company_id", "=", vals.get("company_id", journal.company_id.id)),
-                            ("l10n_ar_is_pos", "=", True),
-                        ]
-                    ).mapped("l10n_ar_afip_pos_number")
-                )
-                | assigned
-            )
-            vals["l10n_ar_afip_pos_number"] = next(n for n in range(1, 100000) if n not in used)
-            assigned.add(vals["l10n_ar_afip_pos_number"])
+            if journal.l10n_ar_is_pos and "l10n_ar_afip_pos_number" not in (default or {}):
+                vals["l10n_ar_afip_pos_number"] = 0
         return vals_list
+
+    def copy(self, default=None):
+        """Duplicating creates the record right away (there is no edit step before saving),
+        so the zero POS number set by copy_data must be allowed at that precise moment."""
+        return super(AccountJournal, self.with_context(l10n_ar_journal_copy=True)).copy(default)
+
+    @api.constrains("l10n_ar_afip_pos_number")
+    def _check_afip_pos_number(self):
+        """Allow the zero POS number on freshly duplicated journals (see copy)."""
+        if self.env.context.get("l10n_ar_journal_copy"):
+            self = self.filtered("l10n_ar_afip_pos_number")
+        return super(AccountJournal, self)._check_afip_pos_number()
 
     @api.constrains(
         "l10n_ar_afip_pos_number", "l10n_ar_afip_pos_system", "company_id", "type", "l10n_latam_use_documents"
     )
     def _check_l10n_ar_afip_pos_number_unique(self):
-        """Two electronic journals sharing the ARCA POS number would share the same
-        document numbering and ARCA would reject the documents (error 10016)."""
-        for journal in self.filtered(lambda j: j.l10n_ar_is_pos and j.l10n_ar_afip_ws and j.l10n_ar_afip_pos_number):
+        """Two sale journals sharing the ARCA POS number would share the same document
+        numbering; on electronic journals ARCA rejects the documents (error 10016)."""
+        for journal in self.filtered(lambda j: j.l10n_ar_is_pos and j.l10n_ar_afip_pos_number):
             duplicate = self.search(
                 [
                     ("id", "!=", journal.id),
                     ("company_id", "=", journal.company_id.id),
                     ("l10n_ar_is_pos", "=", True),
                     ("l10n_ar_afip_pos_number", "=", journal.l10n_ar_afip_pos_number),
-                ]
-            ).filtered("l10n_ar_afip_ws")[:1]
+                ],
+                limit=1,
+            )
             if duplicate:
                 raise ValidationError(
                     _(
-                        'The ARCA POS number %(pos_number)s is already used by the electronic journal "%(journal)s". '
-                        "Two electronic journals cannot share the same POS number because they would share the "
-                        "invoice numbering and ARCA would reject the documents (error 10016).",
+                        'The ARCA POS number %(pos_number)s is already used by the journal "%(journal)s". '
+                        "Two sale journals cannot share the same POS number because they would share "
+                        "the document numbering.",
                         pos_number=journal.l10n_ar_afip_pos_number,
                         journal=duplicate.display_name,
                     )

--- a/l10n_ar_edi_ux/models/account_journal.py
+++ b/l10n_ar_edi_ux/models/account_journal.py
@@ -9,33 +9,38 @@ class AccountJournal(models.Model):
     _inherit = "account.journal"
 
     def copy_data(self, default=None):
-        """Reset the POS number on duplicated journals: real ARCA POS numbers are not
-        necessarily consecutive, so suggesting one would hide misconfigurations. The user
-        must consciously fill in the number ARCA actually assigned."""
+        """Duplicating creates the record right away (there is no edit step before saving),
+        so a copied journal would always collide with the original's POS number. Assign the
+        next POS number free among every POS journal of the company instead; the user must
+        review it afterwards."""
         vals_list = super().copy_data(default=default)
+        assigned = set()
         for journal, vals in zip(self, vals_list):
-            if journal.l10n_ar_is_pos and "l10n_ar_afip_pos_number" not in (default or {}):
-                vals["l10n_ar_afip_pos_number"] = 0
+            if not journal.l10n_ar_is_pos or "l10n_ar_afip_pos_number" in (default or {}):
+                continue
+            used = (
+                set(
+                    self.search(
+                        [
+                            ("company_id", "=", vals.get("company_id", journal.company_id.id)),
+                            ("l10n_ar_is_pos", "=", True),
+                        ]
+                    ).mapped("l10n_ar_afip_pos_number")
+                )
+                | assigned
+            )
+            vals["l10n_ar_afip_pos_number"] = next(n for n in range(1, 100000) if n not in used)
+            assigned.add(vals["l10n_ar_afip_pos_number"])
         return vals_list
 
-    def copy(self, default=None):
-        """Duplicating creates the record right away (there is no edit step before saving),
-        so the zero POS number set by copy_data must be allowed at that precise moment."""
-        return super(AccountJournal, self.with_context(l10n_ar_journal_copy=True)).copy(default)
-
-    @api.constrains("l10n_ar_afip_pos_number")
-    def _check_afip_pos_number(self):
-        """Allow the zero POS number on freshly duplicated journals (see copy)."""
-        if self.env.context.get("l10n_ar_journal_copy"):
-            self = self.filtered("l10n_ar_afip_pos_number")
-        return super(AccountJournal, self)._check_afip_pos_number()
-
-    @api.constrains(
-        "l10n_ar_afip_pos_number", "l10n_ar_afip_pos_system", "company_id", "type", "l10n_latam_use_documents"
-    )
+    @api.constrains("l10n_ar_afip_pos_number", "company_id")
     def _check_l10n_ar_afip_pos_number_unique(self):
-        """Two sale journals sharing the ARCA POS number would share the same document
-        numbering; on electronic journals ARCA rejects the documents (error 10016)."""
+        """Two sale journals sharing the ARCA POS number and POS system would share the same
+        document numbering; on electronic journals ARCA rejects the documents (error 10016).
+        Sharing the number between different POS systems stays allowed: native and OBA demo
+        data legitimately do it, and so do databases migrated from pre-printed to electronic
+        invoicing. Only plain columns trigger the check on purpose: recomputes of stored
+        computed fields during installs and upgrades must not re-validate historical records."""
         for journal in self.filtered(lambda j: j.l10n_ar_is_pos and j.l10n_ar_afip_pos_number):
             duplicate = self.search(
                 [
@@ -43,15 +48,16 @@ class AccountJournal(models.Model):
                     ("company_id", "=", journal.company_id.id),
                     ("l10n_ar_is_pos", "=", True),
                     ("l10n_ar_afip_pos_number", "=", journal.l10n_ar_afip_pos_number),
+                    ("l10n_ar_afip_pos_system", "=", journal.l10n_ar_afip_pos_system),
                 ],
                 limit=1,
             )
             if duplicate:
                 raise ValidationError(
                     _(
-                        'The ARCA POS number %(pos_number)s is already used by the journal "%(journal)s". '
-                        "Two sale journals cannot share the same POS number because they would share "
-                        "the document numbering.",
+                        'The ARCA POS number %(pos_number)s is already used by the journal "%(journal)s", '
+                        "which has the same POS system. Two sale journals cannot share the POS number and "
+                        "POS system because they would share the document numbering.",
                         pos_number=journal.l10n_ar_afip_pos_number,
                         journal=duplicate.display_name,
                     )

--- a/l10n_ar_edi_ux/models/account_journal.py
+++ b/l10n_ar_edi_ux/models/account_journal.py
@@ -1,12 +1,62 @@
 import datetime
 
-from odoo import _, models
-from odoo.exceptions import UserError
+from odoo import _, api, models
+from odoo.exceptions import UserError, ValidationError
 from odoo.tools import format_date
 
 
 class AccountJournal(models.Model):
     _inherit = "account.journal"
+
+    def copy_data(self, default=None):
+        """Duplicating creates the record right away (there is no edit step before saving),
+        so a copied electronic journal would always collide with the original's POS number.
+        Assign the next free POS number instead; the user must review it afterwards."""
+        vals_list = super().copy_data(default=default)
+        assigned = set()
+        for journal, vals in zip(self, vals_list):
+            if "l10n_ar_afip_pos_number" in (default or {}) or not (journal.l10n_ar_is_pos and journal.l10n_ar_afip_ws):
+                continue
+            used = (
+                set(
+                    self.search(
+                        [
+                            ("company_id", "=", vals.get("company_id", journal.company_id.id)),
+                            ("l10n_ar_is_pos", "=", True),
+                        ]
+                    ).mapped("l10n_ar_afip_pos_number")
+                )
+                | assigned
+            )
+            vals["l10n_ar_afip_pos_number"] = next(n for n in range(1, 100000) if n not in used)
+            assigned.add(vals["l10n_ar_afip_pos_number"])
+        return vals_list
+
+    @api.constrains(
+        "l10n_ar_afip_pos_number", "l10n_ar_afip_pos_system", "company_id", "type", "l10n_latam_use_documents"
+    )
+    def _check_l10n_ar_afip_pos_number_unique(self):
+        """Two electronic journals sharing the ARCA POS number would share the same
+        document numbering and ARCA would reject the documents (error 10016)."""
+        for journal in self.filtered(lambda j: j.l10n_ar_is_pos and j.l10n_ar_afip_ws and j.l10n_ar_afip_pos_number):
+            duplicate = self.search(
+                [
+                    ("id", "!=", journal.id),
+                    ("company_id", "=", journal.company_id.id),
+                    ("l10n_ar_is_pos", "=", True),
+                    ("l10n_ar_afip_pos_number", "=", journal.l10n_ar_afip_pos_number),
+                ]
+            ).filtered("l10n_ar_afip_ws")[:1]
+            if duplicate:
+                raise ValidationError(
+                    _(
+                        'The ARCA POS number %(pos_number)s is already used by the electronic journal "%(journal)s". '
+                        "Two electronic journals cannot share the same POS number because they would share the "
+                        "invoice numbering and ARCA would reject the documents (error 10016).",
+                        pos_number=journal.l10n_ar_afip_pos_number,
+                        journal=duplicate.display_name,
+                    )
+                )
 
     def l10n_ar_check_afip_doc_types(self):
         """This method shows the valid document types for each Webservice."""


### PR DESCRIPTION
Two sale journals sharing the same ARCA POS number and POS system end up sharing the document numbering; on electronic journals ARCA rejects the documents with error 10016. Native Odoo only trips over the duplicated journal short code (`_code_company_uniq`), which is easily bypassed by editing the code — and always bypassed when duplicating, since the copy gets a uniquified code automatically.

Changes on `l10n_ar_edi_ux`:

- Constraint rejecting two sale journals with documents of the same company sharing both the POS number and the POS system. Sharing the number between *different* systems stays allowed on purpose: native and OBA demo data legitimately do it (pre-printed and FE journals sharing POS 1), and so do real databases migrated from pre-printed to electronic invoicing. The error message names the POS number and the conflicting journal instead of the journal code.
- The constraint triggers only on plain columns (`l10n_ar_afip_pos_number`, `company_id`): recomputes of stored computed fields during installs/upgrades re-validate historical records, so databases holding pre-existing duplicates must not fail to load or upgrade because of them (a previous iteration of this PR broke a full runbot build through the translation-loading recompute).
- `copy_data` override: duplicating a journal saves it instantly (there is no edit step before saving), so a copied journal would always collide with the original's POS number. The duplicate gets the next POS number free among every POS journal of the company; the user must review it afterwards.

Test plan (verified on a fresh database with demo data):

- Install with demo data works (POS 1 pre-printed + POS 1 FE, and POS 2 online expo + POS 2 FEX, coexist as before).
- Duplicating a journal (electronic or pre-printed) saves with the next free POS number; two consecutive duplicates get different numbers.
- Creating or editing a journal into an already-used POS number *of the same POS system* raises, for electronic and pre-printed journals alike.
- The same POS number on a different POS system is still accepted.
- Creating a journal with POS number 0 still raises the native error.

Task: https://www.adhoc.inc/odoo/project.task/71453
