### PR TITLE
[FIX] account_accountant_ux: settlement entry by VAT group, not a single company

### DIFF
--- a/account_accountant_ux/models/account_report.py
+++ b/account_accountant_ux/models/account_report.py
@@ -97,6 +97,13 @@ class AccountReport(models.Model):
                     "action": "action_closure_journal_entry",
                 }
             )
+            # Sin esto, el botón (al no declarar branch_allowed) exige tener
+            # seleccionada TODA la jerarquía de branches del árbol para habilitarse.
+            # Con esto, account.report lo habilita ya con solo el grupo de compañías
+            # que comparten CUIT (ver res.company._get_branches_with_same_vat), que es
+            # el mismo criterio que usamos abajo en action_closure_journal_entry — así
+            # ambos gates (el nativo y el nuestro) piden lo mismo.
+            options["enable_export_buttons_for_common_vat_in_branches"] = True
 
     def action_closure_journal_entry(self, options):
         """Abre el wizard de liquidación para que el usuario elija el diario."""
@@ -115,8 +122,27 @@ class AccountReport(models.Model):
             )
             .mapped("company_id")
         )
-        if len(companies) != 1:
-            raise ValidationError(_("La liquidación se debe realizar filtrando por 1 y solo 1 compañía en el reporte"))
+        if not companies:
+            raise ValidationError(_("No se encontraron diarios para liquidar en este reporte."))
+
+        # La liquidación es por grupo de CUIT, no por una sola compañía ni por todo el
+        # árbol de branches: "ser hija en el árbol de parent_id" y "compartir CUIT" son
+        # cosas distintas (ver res.company._get_branches_with_same_vat). Antes de este
+        # fix, exigir "exactamente 1 compañía" acá contradecía al gate nativo de arriba,
+        # que (al no declarar branch_allowed) exige seleccionar TODA la jerarquía de
+        # branches — no había ninguna selección que satisficiera a los dos a la vez.
+        same_vat_companies = companies[:1]._get_branches_with_same_vat()
+        if companies - same_vat_companies:
+            raise ValidationError(
+                _(
+                    "La liquidación se debe realizar filtrando por compañías que compartan "
+                    "el mismo CUIT (no se puede mezclar entidades fiscales distintas en un "
+                    "mismo asiento de liquidación)."
+                )
+            )
+        # Compañía "principal" del grupo de CUIT: la más cercana a la raíz del árbol,
+        # análoga a is_main_branch en account.return._can_return_exist.
+        main_company = min(companies, key=lambda company: len(company.parent_path.split("/")))
 
         action_name = "%s (BETA)" % self.settlement_title
         entry_ref = self.settlement_title
@@ -127,7 +153,7 @@ class AccountReport(models.Model):
             "default_report_id": self.id,
             "entry_ref": entry_ref,
             "skip_invoice_sync": True,
-            "default_company_id": companies.id,
+            "default_company_id": main_company.id,
         }
         view_id = self.env.ref("account_accountant_ux.view_account_tax_settlement_wizard_form").id
 

--- a/account_accountant_ux/tests/__init__.py
+++ b/account_accountant_ux/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_reconcile_wizard
 from . import test_change_lock_date
+from . import test_account_report_settlement_branches

--- a/account_accountant_ux/tests/test_account_report_settlement_branches.py
+++ b/account_accountant_ux/tests/test_account_report_settlement_branches.py
@@ -1,0 +1,74 @@
+# © ADHOC SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.exceptions import ValidationError
+from odoo.tests import common, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSettlementJournalEntryBranches(common.TransactionCase):
+    """El asiento de liquidación tenía dos gates de compañía contradictorios: el gate
+    nativo (branch_allowed ausente) exige toda la jerarquía de branches seleccionada,
+    el propio exigía exactamente 1 compañía. El criterio correcto es el grupo de
+    compañías que comparten CUIT (res.company._get_branches_with_same_vat)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.parent_company = cls.env.company
+        cls.same_vat_branch = cls.env["res.company"].create(
+            {"name": "Sucursal mismo CUIT", "parent_id": cls.parent_company.id}
+        )
+        cls.diff_vat_branch = cls.env["res.company"].create(
+            {
+                "name": "Empresa relacionada CUIT distinto",
+                "parent_id": cls.parent_company.id,
+                "vat": "30-22222222-3",
+            }
+        )
+        cls.report = cls.env["account.report"].create(
+            {
+                "name": "Test Settlement Report",
+                "allow_settlement": True,
+                "settlement_title": "Liquidar Test",
+            }
+        )
+        cls.parent_journal = cls.env["account.journal"].create(
+            {"name": "General Padre", "type": "general", "company_id": cls.parent_company.id}
+        )
+        cls.same_vat_journal = cls.env["account.journal"].create(
+            {"name": "General Sucursal mismo CUIT", "type": "general", "company_id": cls.same_vat_branch.id}
+        )
+        cls.diff_vat_journal = cls.env["account.journal"].create(
+            {"name": "General Empresa CUIT distinto", "type": "general", "company_id": cls.diff_vat_branch.id}
+        )
+
+    def _options(self, journals):
+        return {"journals": [{"id": journal.id, "model": "account.journal"} for journal in journals]}
+
+    def test_settlement_allows_same_vat_branches(self):
+        """Diarios de padre + hija con mismo CUIT: debe habilitar, usando la padre
+        (raíz del grupo) como compañía del asiento."""
+        options = self._options(self.parent_journal + self.same_vat_journal)
+        action = self.report.action_closure_journal_entry(options)
+        self.assertEqual(action["res_model"], "account.tax.settlement.wizard")
+        self.assertEqual(action["context"]["default_company_id"], self.parent_company.id)
+
+    def test_settlement_blocks_different_vat_branches(self):
+        """Diarios de padre + hija con CUIT distinto: debe bloquear, no mezclar
+        entidades fiscales distintas en un mismo asiento."""
+        options = self._options(self.parent_journal + self.diff_vat_journal)
+        with self.assertRaises(ValidationError):
+            self.report.action_closure_journal_entry(options)
+
+    def test_settlement_still_works_single_company(self):
+        """El caso sin branches (una sola compañía) sigue funcionando igual que antes."""
+        options = self._options(self.parent_journal)
+        action = self.report.action_closure_journal_entry(options)
+        self.assertEqual(action["context"]["default_company_id"], self.parent_company.id)
+
+    def test_settlement_enables_common_vat_option_on_buttons(self):
+        """_init_options_buttons debe levantar el gate nativo de branches para el
+        grupo de mismo CUIT, no solo agregar el botón."""
+        options = {}
+        self.report._init_options_buttons(options, {})
+        self.assertTrue(options.get("enable_export_buttons_for_common_vat_in_branches"))


### PR DESCRIPTION
`action_closure_journal_entry` required "exactly 1 company" among the report's journals, while the button that triggers it (not declaring `branch_allowed`) already forces Odoo to require the whole branch hierarchy to be selected. In a client with branches there was no selection that satisfied both gates at once — the button was effectively unusable.

The correct criterion is the group of companies sharing the same VAT (`res.company._get_branches_with_same_vat`), not a single company nor the whole `parent_id`/`child_ids` tree. Both sides are adjusted:

- `_init_options_buttons` now sets `enable_export_buttons_for_common_vat_in_branches`, the native hook that enables report buttons when the selection matches the same-VAT group instead of requiring the full branch tree.
- `action_closure_journal_entry` validates against that same group, and uses the company closest to the root of the group (not just the first one) as `default_company_id` for the settlement entry — analogous to `is_main_branch` in `account.return._can_return_exist`.

## Test plan

New `tests/test_account_report_settlement_branches.py`:
- parent + same-VAT branch → allowed, settlement company resolves to the root.
- parent + different-VAT branch → blocked with `ValidationError`.
- single company (no branches) → unchanged behavior.
- `_init_options_buttons` sets the native common-VAT option.

All 7 tests in `account_accountant_ux` pass locally (3 pre-existing + 4 new).