### PR TITLE
[FIX] l10n_ar_edi_ux: QR code crash when identification type has no ARCA code

### DIFF
--- a/l10n_ar_edi_ux/models/account_move.py
+++ b/l10n_ar_edi_ux/models/account_move.py
@@ -56,6 +56,13 @@ class AccountMove(models.Model):
             return original_entry and original_entry[0] or res
         return res
 
+    def _get_partner_code_id(self, partner):
+        # Odoo 19.0 returns an implicit None when the partner's identification type
+        # has no ARCA code (e.g. generic "VAT" on foreign partners of export invoices),
+        # crashing int() in _compute_l10n_ar_afip_qr_code. Restore the 17.0/18.0
+        # behavior of returning a falsy value that int() accepts.
+        return super()._get_partner_code_id(partner) or False
+
     def _check_vat_condition(self):
         """Return the AFIP code of the VAT condition of the partner"""
         self.ensure_one()

--- a/l10n_ar_edi_ux/tests/__init__.py
+++ b/l10n_ar_edi_ux/tests/__init__.py
@@ -1,2 +1,3 @@
+from . import test_afip_qr_code
 from . import test_padron_afip
 from . import test_afip_connection_w_branches

--- a/l10n_ar_edi_ux/tests/test_afip_qr_code.py
+++ b/l10n_ar_edi_ux/tests/test_afip_qr_code.py
@@ -1,0 +1,47 @@
+import base64
+import json
+
+from odoo import Command
+from odoo.addons.l10n_ar.tests.common import TestArCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestAfipQrCode(TestArCommon):
+    def test_qr_code_partner_identification_without_afip_code(self):
+        """Export invoices for foreign partners whose identification type has no
+        ARCA code (e.g. the generic "VAT" type) must still render the QR code.
+
+        Odoo 19.0 _get_partner_code_id returns an implicit None in that case,
+        crashing int() in _compute_l10n_ar_afip_qr_code when printing."""
+        partner = self.res_partner_barcelona_food
+        partner.write(
+            {
+                "l10n_latam_identification_type_id": self.env.ref("l10n_latam_base.it_vat").id,
+                "vat": "ESA12345674",
+            }
+        )
+
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": partner.id,
+                "journal_id": self.sale_expo_journal_ri.id,
+                "l10n_latam_document_type_id": self.document_type["invoice_e"].id,
+                "invoice_date": "2026-08-04",
+                "invoice_line_ids": [Command.create({"name": "Test product", "quantity": 1, "price_unit": 100.0})],
+            }
+        )
+        invoice.l10n_latam_document_number = "00002-00000001"
+        # Simulate an ARCA validated invoice (these values are normally set by the ws)
+        invoice.write(
+            {
+                "l10n_ar_afip_auth_mode": "CAE",
+                "l10n_ar_afip_auth_code": "12345678901234",
+            }
+        )
+
+        qr_code = invoice.l10n_ar_afip_qr_code
+        self.assertTrue(qr_code)
+        qr_data = json.loads(base64.b64decode(qr_code.split("?p=")[1]))
+        self.assertEqual(qr_data["tipoDocRec"], 0)


### PR DESCRIPTION
## Problem

Printing any posted electronic invoice whose commercial partner has an identification type **without** ARCA code (typically the generic "VAT" type used on foreign partners of export invoices) fails with:

```
File ".../l10n_ar_edi/models/account_move.py", line 161, in _compute_l10n_ar_afip_qr_code
    data.update({'tipoDocRec': int(rec._get_partner_code_id(commercial_partner_id))})
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```

## Root cause

Upstream 19.0 regression: odoo/enterprise `bb8e6fda72ae` ("[FIX] l10n_ar_edi: return the correct ARCA code when final consumer") reordered `_get_partner_code_id` and dropped the final `return partner_id_code`. In 17.0/18.0 that fallback returned `False`, which `int()` accepts (→ `tipoDocRec: 0` in the QR); in 19.0 the method now returns an implicit `None` and `int(None)` raises.

## Fix

Override `_get_partner_code_id` to return a falsy-but-castable value (`or False`), restoring the 17.0/18.0 behavior. The other callers use `partner_id_code or 0` / truthiness, so they are unaffected.

Includes a test reproducing the crash (export invoice, foreign partner with "VAT" identification type, simulated CAE): it raises the exact TypeError without the fix and passes with it.

A fix was also proposed upstream to odoo/enterprise (this override remains as protection until it lands).

Internal ticket: https://www.adhoc.inc/odoo/helpdesk/124637