### PR TITLE
[FIX] l10n_ar_account_tax_settlement: avoid timeout on VAT book export

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_move.py
+++ b/l10n_ar_account_tax_settlement/models/account_move.py
@@ -12,6 +12,23 @@ from odoo.exceptions import ValidationError
 class AccountMove(models.Model):
     _inherit = "account.move"
 
+    def _get_vat(self, base_lines=None):
+        """Reuse the VAT breakdown when the caller provides a cache in the context.
+
+        Building it means going through `_get_rounded_base_and_tax_lines()`, which
+        rebuilds the base lines of the invoice and is the most expensive part of the VAT
+        book export. The export needs the same breakdown more than once per invoice, so
+        a caller can pass an empty dict in `l10n_ar_vat_book_vat_cache` to compute it
+        only once. We hand out copies so that no caller can alter what the next one gets.
+        """
+        cache = self.env.context.get("l10n_ar_vat_book_vat_cache")
+        if cache is None or base_lines is not None:
+            return super()._get_vat(base_lines=base_lines)
+        self.ensure_one()
+        if self.id not in cache:
+            cache[self.id] = super()._get_vat()
+        return [dict(vat_tax) for vat_tax in cache[self.id]]
+
     def _get_document_number_parts(self):
         """Wrapper around _l10n_ar_get_document_number_parts for single-record use.
         Callers should invoke _validate_document_number_parts() on the full recordset

--- a/l10n_ar_account_tax_settlement/models/l10n_ar_vat_book.py
+++ b/l10n_ar_account_tax_settlement/models/l10n_ar_vat_book.py
@@ -48,7 +48,34 @@ class ArgentinianReportCustomHandler(models.AbstractModel):
                     )
         return res
 
+    def _vat_book_prefetch_invoice_lines(self, invoices):
+        """Warm up the ORM cache for every invoice line in a couple of queries.
+
+        The txt generation walks the invoices one by one and rebuilds the base lines of
+        each of them (`_get_rounded_base_and_tax_lines()`). Odoo prefetches per invoice,
+        so without this each invoice triggers its own SELECTs, and a whole month of
+        invoices adds up to thousands of round trips to the database. That is what makes
+        the export time out (the request dies before returning the zip).
+        """
+        lines = invoices.line_ids
+        if not lines:
+            return
+        # every stored column of every line, in a single SELECT
+        lines.fetch(
+            [name for name, field in lines._fields.items() if field.store and field.column_type and field.prefetch]
+        )
+        # x2many fields are not columns, so `fetch()` does not cover them. We read the ones
+        # the tax computation walks: `tax_ids` on the base lines, and `sale_line_ids`, which
+        # `sale_loyalty` reads on every line to detect discount lines.
+        lines.mapped("tax_ids")
+        if "sale_line_ids" in lines._fields:
+            lines.mapped("sale_line_ids")
+
     def _vat_book_get_REGINFO_CV_ALICUOTAS(self, options, tax_type, invoices):
+        self._vat_book_prefetch_invoice_lines(invoices)
+        # our check and the standard implementation below both need the VAT breakdown of
+        # every invoice. Sharing a cache computes it once instead of twice.
+        invoices = invoices.with_context(l10n_ar_vat_book_vat_cache={})
         error = self._check_invoices(invoices)
 
         # Download the file only id: 1) if there not error, 2) We a are saas support user with active dev mode


### PR DESCRIPTION
## Problema

El export del Libro de IVA no llega a devolver el archivo: el worker se cae por `limit_time_real` (300s). Según el proxy que atienda, el navegador ve un 405 o un 503.

Logs del servidor:

```
2026-08-06 18:22:38,385 1 ERROR odoo odoo.service.server: WorkerHTTP (28) timeout after 300s
2026-08-06 18:22:38,385 1 ERROR odoo odoo.service.server: WorkerHTTP (28) timeout after 300s
2026-08-06 18:22:38,387 1 ERROR odoo odoo.service.server: WorkerHTTP (28) timeout after 300s
2026-08-06 18:22:38,453 46 INFO odoo odoo.service.server: Worker WorkerHTTP (46) alive
2026-08-06 18:22:41,503 36 INFO odoo werkzeug: <ip> - - [06/Aug/2026 18:22:41] "POST /web/dataset/call_kw/documents.document/can_upload_traceback HTTP/1.1" 200 -  [SQL=4 | 0.059s] [PY=0.008s]
[{
  "error": {
    "code": 503,
    "message": "The service is currently unavailable.",
    "status": "UNAVAILABLE"
  }
}
```

Y en la interfaz:

```
RPC_ERROR

Arbitrary Uncaught Python Exception

Occured on <instancia> on 2026-08-06 18:22:41 GMT

503
upstream connect error or disconnect/reset before headers. reset reason: connection termination

The above server error caused the following client error:
RPC_ERROR: Arbitrary Uncaught Python Exception
    RPC_ERROR
        at makeErrorFromResponse (https://<instancia>/web/assets/61cd6d8/web.assets_web_dark.min.js:3175:165)
        at decoder.onload (https://<instancia>/web/assets/61cd6d8/web.assets_web_dark.min.js:3160:7)
```

## Causa

El armado de los txt recorre los comprobantes de a uno y reconstruye las base lines de cada uno vía `_get_rounded_base_and_tax_lines()`. El prefetch de Odoo queda acotado a las líneas de ese comprobante, así que cada comprobante dispara sus propios SELECTs.

Encima el cálculo se hace dos veces por comprobante: en nuestro `_check_invoices()` y otra vez en el `_vat_book_get_REGINFO_CV_ALICUOTAS()` de estándar.

## Solución

- `_vat_book_prefetch_invoice_lines()`: calienta la cache del ORM para las líneas de todos los comprobantes antes del loop, incluidos los `tax_ids`. Beneficia también al loop de `_vat_book_get_REGINFO_CV_CBTE()`.
- `account.move._get_vat()`: reusa el resultado vía un cache que el caller pasa en el contexto, así corre una vez por comprobante en lugar de dos. Devuelve copias para que ningún caller altere lo que recibe el siguiente.

Sin cambio funcional: mismos txt, mismo chequeo de diferencias de IVA.

## Cómo probarlo

1. Descargar el zip del Libro de IVA de un período con varios cientos de comprobantes: completa sin error y los txt son idénticos a los de la versión actual.
2. Con un comprobante con diferencia de IVA mayor a 0.5 centavos: sigue apareciendo el `RedirectWarning` con el botón "Corregir comprobantes".

Reportado en el ticket interno 124583.
