### PR TITLE
[FIX] account_balance_import: keep the typed amount in the account currency on opening balances

### DIFF
--- a/account_balance_import/models/account_account.py
+++ b/account_balance_import/models/account_account.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
@@ -25,7 +27,14 @@ class AccountAccount(models.Model):
                 ("account_id", "in", self.ids),
             ]
         )
-        amount_by_account = {line.account_id.id: abs(line.amount_currency) for line in opening_lines}
+        # One amount per account, so at most one opening line can carry it:
+        # `_update_opening_move` rejects loading both sides on an account with an amount in
+        # its own currency. Summing is only to avoid keeping whichever line came last on the
+        # accounts that predate that check, which made the displayed value depend on the
+        # order the lines were read in.
+        amount_by_account = defaultdict(float)
+        for line in opening_lines:
+            amount_by_account[line.account_id.id] += line.amount_currency
         for account in self:
             account.amount_in_currency = amount_by_account.get(account.id, 0.0)
 
@@ -41,6 +50,20 @@ class AccountAccount(models.Model):
                     self.env.cr.precommit.data["account_opening_amount_in_currency"] = {}
                 data = self.env.cr.precommit.data["account_opening_amount_in_currency"]
                 data.setdefault(self.env.company.id, {})[account.id] = account.amount_in_currency
+
+                # Editing only this column has to re-apply the amount too. Core schedules
+                # `_load_precommit_update_opening_move` from `_set_opening_debit_credit`, so
+                # without a debit/credit write the opening move is never updated and the typed
+                # amount is silently dropped. Register the account with the balances it already
+                # has, unless a debit/credit write already did it for this same save.
+                # Only the sides that carry a balance: a zero would make core delete the
+                # corresponding line instead of leaving it alone.
+                opening_balances = self.env.cr.precommit.data.get("import_account_opening_balance", {})
+                if account.id not in opening_balances.get(self.env.company.id, {}):
+                    if account.opening_debit:
+                        account._set_opening_debit_credit(account.opening_debit, "debit")
+                    if account.opening_credit:
+                        account._set_opening_debit_credit(account.opening_credit, "credit")
 
     @api.constrains("amount_in_currency")
     def _check_amount_in_currency(self):

--- a/account_balance_import/models/res_company.py
+++ b/account_balance_import/models/res_company.py
@@ -1,4 +1,5 @@
-from odoo import models
+from odoo import _, models
+from odoo.exceptions import UserError
 
 
 class ResCompany(models.Model):
@@ -17,33 +18,72 @@ class ResCompany(models.Model):
         # Get the stored amount_in_currency values from precommit data
         amount_in_currency_data = self.env.cr.precommit.data.get("account_opening_amount_in_currency", {})
         amounts_by_account = amount_in_currency_data.get(self.id, {})
+        if not amounts_by_account:
+            return
 
-        for account, values in to_update.items():
+        # super() only updated the cache: `amount_currency` is still pending there with the
+        # value converted at the company rate. Send it to the database before overwriting the
+        # rows by SQL, otherwise the pending write is flushed afterwards and silently discards
+        # the amount the user typed.
+        opening_move.line_ids.flush_recordset()
+
+        updated_lines = self.env["account.move.line"]
+        for account in to_update:
             # Check if this account has an amount_in_currency value stored
             amount_in_currency_value = amounts_by_account.get(account.id)
 
             # Only process accounts with a specific currency and amount_in_currency set
-            if account.currency_id and amount_in_currency_value and account.currency_id != self.currency_id:
-                # Find the opening lines for this account
-                opening_lines = opening_move.line_ids.filtered(lambda l: l.account_id == account)
-                debit_amount, credit_amount = values[0], values[1]
+            if not amount_in_currency_value or not account.currency_id or account.currency_id == self.currency_id:
+                continue
 
-                # Determine the sign based on whether it's debit or credit
-                if debit_amount is not None and debit_amount != 0:
-                    final_amount_currency = amount_in_currency_value
-                elif credit_amount is not None and credit_amount != 0:
-                    final_amount_currency = -amount_in_currency_value
-                else:
-                    continue
-
-                # Update amount_currency directly via SQL to avoid triggering recomputations
-                # that could unbalance the move
-                for line in opening_lines:
-                    self.env.cr.execute(
-                        "UPDATE account_move_line SET amount_currency = %s WHERE id = %s",
-                        (final_amount_currency, line.id),
+            account_lines = opening_move.line_ids.filtered(lambda line: line.account_id == account)
+            if len(account_lines) > 1:
+                # `amount_in_currency` is a single value per account, so it can only describe
+                # one opening line. With a debit and a credit line at the same time there is
+                # no way to tell which side the amount belongs to: the value read back would
+                # be the two sides netted — an amount the user never typed — and the next
+                # save would apply that net over one side, silently dropping what was loaded
+                # on it. Ask for the net balance on a single side instead of guessing.
+                raise UserError(
+                    _(
+                        "The account %s has an amount in its own currency, so it can only carry one "
+                        "opening balance. Load the net balance on the debit or the credit side, not both.",
+                        account.display_name,
                     )
+                )
+            if not account_lines:
+                continue
 
-        # Invalidate cache to ensure the changes are reflected
-        if opening_move:
-            opening_move.line_ids.invalidate_recordset(["amount_currency"])
+            # The sign follows the side of the line the amount is applied on, read the same
+            # way core does it (`'debit' if line.balance > 0.0 or line.amount_currency > 0.0
+            # else 'credit'`, see `_update_opening_move` in account/models/company.py). It is
+            # not cosmetic: a credit line left with a positive `amount_currency` is rejected
+            # by `account_move_line_check_amount_currency_balance_sign`, and once stored it
+            # would be read back as a debit line on the next save, where `update_vals`
+            # overwrites or deletes it — which is why the opening credit never stuck.
+            final_amount_currency = amount_in_currency_value
+            if account_lines.balance < 0.0:
+                final_amount_currency = -amount_in_currency_value
+
+            # Update amount_currency directly via SQL to avoid triggering recomputations
+            # that could unbalance the move
+            self.env.cr.execute(
+                "UPDATE account_move_line SET amount_currency = %s WHERE id = %s",
+                (final_amount_currency, account_lines.id),
+            )
+            updated_lines |= account_lines
+
+        if not updated_lines:
+            return
+
+        # Drop the cache so the new values are read back from the database. `flush=False` is
+        # required: the default flushes the cache first, which would push the stale converted
+        # amount over the rows we just updated.
+        updated_lines.invalidate_recordset(["amount_currency"], flush=False)
+        # The raw UPDATE also bypasses the recomputation of the stored fields that depend on
+        # `amount_currency` — `amount_residual`, `amount_residual_currency` and `reconciled`
+        # (`_compute_amount_residual`) — which would leave the residual of a receivable or
+        # payable opening line out of sync with its amount, and drag that into the
+        # reconciliation against the payments. Mark them for recompute: core flushes right
+        # after this precommit callback (`_load_precommit_update_opening_move`).
+        updated_lines.modified(["amount_currency"])

--- a/account_balance_import/tests/test_account_balance_import.py
+++ b/account_balance_import/tests/test_account_balance_import.py
@@ -3,6 +3,7 @@ import datetime
 import io
 
 import xlwt
+from odoo.exceptions import UserError
 from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
@@ -91,6 +92,117 @@ class TestAccountBalanceImport(TransactionCase):
                 "company_ids": [(6, 0, [cls.company.id])],
             }
         )
+
+        # Account in a currency other than the company one, to load opening balances at a
+        # rate the user types instead of the one the system holds. The currency is taken by
+        # xml id and activated: a database can perfectly hold the company currency as the
+        # only active one, and searching among the active ones came back empty there, which
+        # left the account without currency and made every test below fail on the
+        # amount_in_currency constraint.
+        cls.foreign_currency = cls.env.ref("base.USD")
+        if cls.foreign_currency == cls.company.currency_id:
+            cls.foreign_currency = cls.env.ref("base.EUR")
+        cls.foreign_currency.active = True
+        cls.account_fx = cls.env["account.account"].create(
+            {
+                "code": "TESTFX",
+                "name": "Test Account Foreign Currency",
+                "account_type": "asset_current",
+                "currency_id": cls.foreign_currency.id,
+                "company_ids": [(6, 0, [cls.company.id])],
+            }
+        )
+        # A bank account in the same currency: its lines carry a residual
+        # (`_compute_amount_residual` only runs on reconcilable and cash accounts), which is
+        # what the opening amount is reconciled against later on.
+        cls.account_fx_bank = cls.env["account.account"].create(
+            {
+                "code": "TESTFXB",
+                "name": "Test Bank Account Foreign Currency",
+                "account_type": "asset_cash",
+                "currency_id": cls.foreign_currency.id,
+                "company_ids": [(6, 0, [cls.company.id])],
+            }
+        )
+
+    def _save_opening(self, account, values):
+        """Write on the opening columns the way the chart of accounts list does, and let the
+        precommit callbacks that build the opening move run, as they do at the end of the
+        request."""
+        account.write(values)
+        self.env.cr.precommit.run()
+        self.env.invalidate_all()
+
+    def _opening_lines(self, account):
+        return self.company.account_opening_move_id.line_ids.filtered(lambda l: l.account_id == account)
+
+    def test_opening_debit_keeps_typed_amount_in_currency(self):
+        """The amount typed in the account currency is kept on a debit opening balance"""
+        self._save_opening(self.account_fx, {"amount_in_currency": 100.0, "opening_debit": 4000.0})
+
+        self.assertEqual(self.account_fx.opening_debit, 4000.0)
+        self.assertAlmostEqual(self.account_fx.amount_in_currency, 100.0, places=2)
+
+        line = self._opening_lines(self.account_fx)
+        self.assertEqual(len(line), 1, "Should have exactly one opening line")
+        self.assertAlmostEqual(line.amount_currency, 100.0, places=2)
+
+    def test_both_sides_are_rejected_on_an_account_with_its_own_currency(self):
+        """One amount per account describes one side: loading both is rejected, not guessed"""
+        self._save_opening(self.account_fx, {"amount_in_currency": 100.0, "opening_debit": 4000.0})
+
+        # The savepoint rolls the failed save back the way the request does.
+        with self.assertRaises(UserError), self.env.cr.savepoint():
+            self._save_opening(self.account_fx, {"amount_in_currency": 50.0, "opening_credit": 1000.0})
+
+    def test_the_side_already_loaded_is_kept_after_the_rejection(self):
+        """The amount loaded on one side survives an attempt to load the other one"""
+        self._save_opening(self.account_fx, {"amount_in_currency": 100.0, "opening_debit": 4000.0})
+
+        with self.assertRaises(UserError), self.env.cr.savepoint():
+            self._save_opening(self.account_fx, {"amount_in_currency": 50.0, "opening_credit": 1000.0})
+
+        self.assertEqual(self.account_fx.opening_debit, 4000.0)
+        self.assertEqual(self.account_fx.opening_credit, 0.0)
+        line = self._opening_lines(self.account_fx)
+        self.assertEqual(len(line), 1, "Should have exactly one opening line")
+        self.assertAlmostEqual(line.amount_currency, 100.0, places=2)
+
+    def test_opening_residual_follows_the_typed_amount_in_currency(self):
+        """The residual stored on the line must follow the amount the SQL update forced"""
+        self._save_opening(self.account_fx_bank, {"amount_in_currency": 100.0, "opening_debit": 4000.0})
+        # Second save: the line is updated instead of created, which is where the amount used
+        # to be lost.
+        self._save_opening(self.account_fx_bank, {"amount_in_currency": 250.0, "opening_debit": 10000.0})
+
+        line = self._opening_lines(self.account_fx_bank)
+        self.assertAlmostEqual(line.amount_currency, 250.0, places=2)
+        self.assertAlmostEqual(
+            line.amount_residual_currency,
+            250.0,
+            places=2,
+            msg="The residual is stored and computed from amount_currency, so the raw UPDATE "
+            "has to mark it for recompute: otherwise the opening line of an account in a "
+            "foreign currency is left with a residual that does not match its amount, and "
+            "that is dragged into the reconciliation against the payments",
+        )
+        self.assertAlmostEqual(line.amount_residual, 10000.0, places=2)
+
+    def test_opening_amount_in_currency_alone_is_applied(self):
+        """Editing only the amount in the account currency also updates the opening move"""
+        self._save_opening(self.account_fx, {"amount_in_currency": 100.0, "opening_debit": 4000.0})
+        self._save_opening(self.account_fx, {"amount_in_currency": 250.0})
+
+        self.assertEqual(self.account_fx.opening_debit, 4000.0, "The balance must not be touched")
+        self.assertAlmostEqual(self.account_fx.amount_in_currency, 250.0, places=2)
+        self.assertAlmostEqual(self._opening_lines(self.account_fx).amount_currency, 250.0, places=2)
+
+    def test_opening_move_stays_balanced(self):
+        """Forcing the amount in currency must not unbalance the opening entry"""
+        self._save_opening(self.account_fx, {"amount_in_currency": 100.0, "opening_credit": 4000.0})
+
+        move = self.company.account_opening_move_id
+        self.assertAlmostEqual(sum(move.line_ids.mapped("balance")), 0.0, places=2)
 
     def _generate_partner_balance_excel(self):
         """Generate Excel file with test partner balance data"""


### PR DESCRIPTION
Loading opening balances on an account with a foreign currency does not keep the amount
typed in the "Amount in Account Currency" column, and on the credit side the opening
balance itself is dropped.

### Cause

Two independent problems in the `_update_opening_move()` override.

**1. The SQL patch was undone by the cache.** `super()` writes the opening move lines
through the ORM (`opening_move.write(...)` in `account/models/company.py`), so
`amount_currency` is still pending in the cache with the value converted at the company
rate. The trailing `invalidate_recordset(["amount_currency"])` then flushes — `flush=True`
is the default — pushing that stale cached value back over the rows the SQL just updated.

This also explains why it looked intermittent: on the very first save the balancing line is
created rather than updated, and the `create` flushes the pending line values early, so the
SQL update sticks. From the second save on, every line is a `Command.update`.

**2. The amount was written over every line of the account, with a single sign.** The sign
was taken from the debit side first (`if debit_amount ... elif credit_amount`) and then
applied to `opening_move.line_ids.filtered(lambda l: l.account_id == account)` — both
sides. Once an account holds a debit and a credit opening line, saving a credit pushed a
negative `amount_currency` onto the debit line, and the save was rejected by
`account_move_line_check_amount_currency_balance_sign`, so the opening credit the user
typed never stuck.

The sign is not cosmetic either. Core decides the side of an existing line with:

```python
'debit' if line.balance > 0.0 or line.amount_currency > 0.0 else 'credit'
```

so a credit line left with a positive `amount_currency` is read back as a debit line on the
next save, and `update_vals` overwrites it or deletes it through `del_lines`.

Two smaller gaps produce the same symptom:

- `_compute_amount_in_currency` built `{account_id: abs(amount_currency)}` from a line
  loop, keeping whichever line was read last when the account had both sides — the
  displayed value depended on the read order.
- Editing only the "Amount in Account Currency" column did nothing. Core schedules
  `_load_precommit_update_opening_move` from `_set_opening_debit_credit`, so without a
  debit/credit write the opening move is never updated and the typed amount is silently
  dropped.

### Fix

- Flush the opening move lines before the SQL update, and invalidate afterwards with
  `flush=False`. Return early when there is no `amount_in_currency` to apply.
- Mark the lines as modified after the raw `UPDATE`. The stored fields computed from
  `amount_currency` — `amount_residual`, `amount_residual_currency` and `reconciled`
  (`_compute_amount_residual`) — are bypassed by SQL, which left the opening line of a
  receivable, payable or bank account in a foreign currency with a residual that does not
  match its amount, and dragged that into the reconciliation against the payments. Core
  flushes right after this precommit callback, so the recompute lands in the same request.
- One `amount_in_currency` per account can only describe one opening line, so loading both
  sides on an account that carries one is rejected instead of guessed: the value read back
  would be the two sides netted — an amount nobody typed — and the next save would apply
  that net over one side, silently dropping what was loaded on it.
- Take the sign from the side of the line the amount is applied on, read the way core reads
  it, so no line is left with a sign inconsistent with its balance.
- Register the account in the core precommit data when only the currency amount changes,
  with the balances it already has and only for the sides that carry one, so a zero does
  not make core delete the corresponding line.

### Test plan

Covered by tests in `account_balance_import/tests/`; three of them fail without this
change, two on the save being rejected and one on the amount not being applied.

Manually, on a company whose currency differs from the account currency, with a rate loaded
that is *not* the one to apply:

1. Accounting > Configuration > Import Assistant > Review your Chart of Accounts.
2. On an account with a foreign currency set, fill "Amount in Account Currency" and the
   opening debit with the equivalent at the desired rate. Save, reopen the screen: the
   amount in account currency must still be the value typed.
3. Same on the opening credit of another account.
4. Save the same account again with a different amount: the line keeps the amount typed, no
   line is duplicated, and the opening entry stays balanced.
5. Load the opposite side on an account that already carries an amount in its own currency:
   the save is rejected with a message asking for the net balance on a single side, and what
   was already loaded is kept.
6. Edit only "Amount in Account Currency": the new amount must be applied.
7. On a bank account in a foreign currency, the residual amount in currency of the opening
   line matches the amount typed.

Reported in helpdesk ticket [#123611](https://www.adhoc.inc/odoo/helpdesk.ticket/123611).
