### PR TITLE
[FIX] l10n_ar_account_reports: asiento de liquidación en cero (0.0)

### DIFF
--- a/l10n_ar_account_reports/i18n/es.po
+++ b/l10n_ar_account_reports/i18n/es.po
@@ -486,6 +486,12 @@ msgid "Company"
 msgstr "Companía"
 
 #. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
+msgid "Configure accounts"
+msgstr "Configurar cuentas"
+
+#. module: l10n_ar_account_reports
 #: model_terms:ir.ui.view,arch_db:l10n_ar_account_reports.inflation_adjustment_form
 msgid "Confirm"
 msgstr "Confirmar"
@@ -1198,6 +1204,12 @@ msgstr "Crédito impositivo"
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/account_return.py:0
+msgid "Tax groups"
+msgstr "Grupos de impuestos"
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
 msgid "Tax to pay"
 msgstr "Impuesto a pagar"
 
@@ -1254,6 +1266,17 @@ msgid ""
 msgstr ""
 "El tipo de identificación «%(identification_type)s» no tiene asignado ningún "
 "código ARCA."
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
+msgid ""
+"The following tax groups, used by the taxes of this period, are missing the "
+"accounts needed for the tax closing entry: %(tax_groups)s"
+msgstr ""
+"A los siguientes grupos de impuestos, utilizados por los impuestos de este "
+"período, les faltan las cuentas necesarias para el asiento de cierre: "
+"%(tax_groups)s"
 
 #. module: l10n_ar_account_reports
 #. odoo-python

--- a/l10n_ar_account_reports/i18n/l10n_ar_account_reports.pot
+++ b/l10n_ar_account_reports/i18n/l10n_ar_account_reports.pot
@@ -423,6 +423,12 @@ msgid "Company"
 msgstr ""
 
 #. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
+msgid "Configure accounts"
+msgstr ""
+
+#. module: l10n_ar_account_reports
 #: model_terms:ir.ui.view,arch_db:l10n_ar_account_reports.inflation_adjustment_form
 msgid "Confirm"
 msgstr ""
@@ -1107,6 +1113,12 @@ msgstr ""
 #. module: l10n_ar_account_reports
 #. odoo-python
 #: code:addons/l10n_ar_account_reports/models/account_return.py:0
+msgid "Tax groups"
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
 msgid "Tax to pay"
 msgstr ""
 
@@ -1150,6 +1162,14 @@ msgstr ""
 msgid ""
 "The identification type \"%(identification_type)s\" does not have ARCA code "
 "set."
+msgstr ""
+
+#. module: l10n_ar_account_reports
+#. odoo-python
+#: code:addons/l10n_ar_account_reports/models/account_return.py:0
+msgid ""
+"The following tax groups, used by the taxes of this period, are missing the "
+"accounts needed for the tax closing entry: %(tax_groups)s"
 msgstr ""
 
 #. module: l10n_ar_account_reports

--- a/l10n_ar_account_reports/models/account_return.py
+++ b/l10n_ar_account_reports/models/account_return.py
@@ -1,5 +1,5 @@
 from odoo import Command, _, fields, models
-from odoo.exceptions import UserError
+from odoo.exceptions import RedirectWarning, UserError
 
 
 class AccountReturn(models.Model):
@@ -46,15 +46,46 @@ class AccountReturn(models.Model):
         return domain
 
     def _ensure_tax_group_configuration_for_tax_closing(self):
+        """EXTENDS account_reports
+
+        Para las liquidaciones argentinas hacemos una validación propia y NO corremos la nativa de Odoo, porque
+        esa exige las cuentas en TODOS los grupos de impuestos de las compañías del return, participen o no de
+        la liquidación. En bases migradas eso obliga a configurar grupos duplicados y grupos de impuestos ajenos
+        a la declaración que se está liquidando. Acá pedimos las cuentas solo en los grupos de impuestos que
+        realmente se usan en la liquidación, es decir los de los apuntes que entran al asiento de este período.
+        Si no lo hiciéramos, el asiento de liquidación saldría en cero (0.0).
+
+        Para más detalle ver el mensaje del pull request / commit que introdujo este método.
         """
-        Skip tax group account validation for AR simple closing returns,
-        since we use the partner's AP/AR accounts instead of tax group accounts.
-        NOTA: esto de acá no suma tanto porque si se quiere liquidar el informde "vat" u otro igual se van a chequear
-        todas las cuentas
-        """
-        if self.type_id.l10n_ar_is_simple_closing_return:
-            return
-        return super()._ensure_tax_group_configuration_for_tax_closing()
+        if not self.type_id.l10n_ar_is_simple_closing_return:
+            return super()._ensure_tax_group_configuration_for_tax_closing()
+
+        self.ensure_one()
+        # Usamos el tax_group_id del apunte (related stored) y no el catálogo de impuestos: así entran los
+        # impuestos archivados que arrastran los pagos migrados de la versión anterior, que son justamente los
+        # que suelen tener el grupo sin configurar.
+        domain = [
+            ("company_id", "in", self.company_ids.ids),
+            ("date", ">=", self.date_from),
+            ("date", "<=", self.date_to),
+            ("parent_state", "=", "posted"),
+            ("tax_repartition_line_id.use_in_tax_closing", "=", True),
+            "|",
+            ("tax_group_id.tax_payable_account_id", "=", False),
+            ("tax_group_id.tax_receivable_account_id", "=", False),
+        ] + self._get_vat_closing_entry_additional_domain()
+        groups_read = self.env["account.move.line"].sudo()._read_group(domain, groupby=["tax_group_id"])
+        incomplete_tax_groups = self.env["account.tax.group"].union(*(group for (group,) in groups_read))
+        if incomplete_tax_groups:
+            raise RedirectWarning(
+                message=_(
+                    "The following tax groups, used by the taxes of this period, are missing the accounts needed "
+                    "for the tax closing entry: %(tax_groups)s",
+                    tax_groups=", ".join(f"{group.name} ({group.company_id.name})" for group in incomplete_tax_groups),
+                ),
+                action=incomplete_tax_groups._get_records_action(name=_("Tax groups")),
+                button_text=_("Configure accounts"),
+            )
 
     def _get_tax_closing_payable_and_receivable_accounts(self):
         """Para simple closing returns argentinos, usamos la cuenta configurada en el return type


### PR DESCRIPTION
Si el impuesto de los apuntes utilizados en la liquidación de impuestos no tiene
tax_receivable_account_id y/o tax_payable_account_id en su grupo de impuestos, entonces el asiento de
liquidación sale en cero (0.0). Eso sucede porque "_compute_tax_closing_entry" de
account_reports/models/account_return.py descarta todo grupo al que le falte alguna de esas dos cuentas
y, con el grupo descartado, move_vals_lines y tax_group_subtotal quedan vacíos y el asiento sale en cero.

En este pull request editamos el método "_ensure_tax_group_configuration_for_tax_closing" de
l10n_ar_account_reports/models/account_return.py, que extendemos de
account_reports/models/account_return.py, para que en las liquidaciones argentinas se haga una validación
custom en lugar de la nativa de Odoo. La nativa no nos sirve porque verifica que TODOS los grupos de
impuestos tengan las cuentas cargadas, independientemente de si se usan o no en la liquidación: en bases
migradas eso obliga a configurar grupos duplicados y grupos de impuestos ajenos a la declaración que se
está liquidando. La validación custom exige las cuentas solo en los grupos de impuestos utilizados en la
liquidación, resolviéndolos desde los apuntes que entran al asiento del período. De esta manera, si no
están establecidas, Odoo lanza un error accionable y no se puede generar el asiento en cero (0.0).

Dos detalles de la implementación:

* Los grupos se resuelven desde el tax_group_id del apunte y no desde el catálogo de impuestos, para que
  entren los impuestos archivados que arrastran los pagos migrados de la versión anterior — que son
  justamente los que suelen tener el grupo sin configurar.
* El universo de apuntes se toma del mismo hook que alimenta la query del asiento de cierre
  (_get_vat_closing_entry_additional_domain), para no tener dos criterios distintos de qué entra en la
  liquidación.

Una aclaración: dichas cuentas tax_receivable_account_id y/o tax_payable_account_id, luego de establecidas
en el grupo de impuestos, no van a ser utilizadas en el asiento de liquidación, ya que nosotros hacemos que
en su lugar se use la cuenta de cierre (l10n_ar_account_id) configurada en el tipo de devolución
(account.return.type). Pero por la cuestión técnica explicada más arriba, es necesario que estén
establecidas para que Odoo pueda generarlo: en Argentina funcionan como una compuerta, no como
configuración contable. Lo correcto de fondo sería un hook en core sobre ese descarte de grupos, para no
pedirle al usuario cuentas que el asiento argentino nunca usa; queda pendiente.

Change note: al liquidar un impuesto argentino, si a algún grupo de impuestos usado en esa liquidación le
faltan las cuentas contables que necesita el asiento de cierre, el sistema avisa con un error accionable
—listando los grupos incompletos con su compañía y con un botón para ir a configurarlos— en lugar de
generar el asiento en cero. Ya no pide configurar grupos de impuestos que no participan de la liquidación.

Tarea: 72048
