### PR TITLE
[FIX] l10n_ar_edi_ux: follow shared_to_branches becoming a scope

### DIFF
--- a/l10n_ar_edi_ux/__manifest__.py
+++ b/l10n_ar_edi_ux/__manifest__.py
@@ -8,6 +8,7 @@
     "license": "AGPL-3",
     "summary": "",
     "depends": [
+        "account_ux",  # shared_to_branches, que este asistente escribe en el diario que crea
         "l10n_ar_ux",
         "l10n_ar_edi",
         "l10n_ar_reports_simple",

--- a/l10n_ar_edi_ux/wizards/l10n_ar_arca_journal_wizard_line.py
+++ b/l10n_ar_edi_ux/wizards/l10n_ar_arca_journal_wizard_line.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import fields, models
+from odoo.addons.account_ux.models.shared_to_branches_mixin import SHARED_TO_BRANCHES_SELECTION
 
 
 class L10nArArcaJournalWizardLine(models.TransientModel):
@@ -36,8 +37,14 @@ class L10nArArcaJournalWizardLine(models.TransientModel):
         help="Select a branch to assign this journal to a specific branch. Leave empty for the main company.",
     )
 
-    shared_to_branches = fields.Boolean(
-        string="Shared to Branches", help="If checked, this journal will be shared with all branches."
+    # Se pasa tal cual al diario que se crea, así que tiene que ser el mismo scope y no un
+    # booleano. El default es "no compartir", que es lo que hacía el booleano sin tildar y lo
+    # que computa el diario para los de tipo venta, que son los que crea este asistente.
+    shared_to_branches = fields.Selection(
+        SHARED_TO_BRANCHES_SELECTION,
+        string="Shared to Branches",
+        default="none",
+        help="Which branches of the company can use the journal that gets created.",
     )
 
     company_id = fields.Many2one(related="wizard_id.company_id", store=True)


### PR DESCRIPTION
Follows `shared_to_branches` becoming a selection in ingadhoc/account-financial-tools#1021 (all branches / same legal entity / not shared) instead of a boolean.

The ARCA journal wizard writes `shared_to_branches` on the journals it creates, so the line of the wizard has to carry the scope and not a checkbox. It defaults to *not shared*, which is both what the unchecked boolean did and what the journal computes for sale journals — the only kind this wizard creates.

Also declares `account_ux` in the manifest. That dependency was already there in practice, since the wizard writes a field that module defines; it just was not written down, so the module would have failed at create time on a database without it. Now it is explicit and the module imports the vocabulary of the selection from there instead of repeating it.

Same branch name as the other three PRs of this change, so runbot builds them together.

## Test plan

Run the ARCA journal wizard on a company with branches: the scope column now offers the three values, defaults to *not shared*, and the journals it creates come out with the value picked on each line.
