### PR TITLE
[FIX] l10n_ar_arba_ws: recover DDJJ open on ARBA WS failure (18.0 backport)

### DIFF
--- a/l10n_ar_arba_ws/models/l10n_ar_dj_arba.py
+++ b/l10n_ar_arba_ws/models/l10n_ar_dj_arba.py
@@ -211,15 +211,21 @@ class L10nArDjArba(models.Model):
     def _ensure_dj(self, wh_date, company):
         """Encontrar la declaracion jurada que corresponde, que este en el mismo periodo de la retención.
 
+        Reusamos cualquier DDJJ existente del período (abierta o borrador) en lugar de crear una nueva.
+        Esto evita violar la constraint unique(company, period, state) y dejar borradores huérfanos cuando
+        un intento previo de abrir contra ARBA falló (ej. caída intermitente del webservice), lo que dejaba
+        al usuario bloqueado para informar cualquier retención de ese período.
+
         :return: DDJJ ARBA recordset of the matching DDJJ for the given period"""
         from_date, to_date = self._find_dates(wh_date)
         dj_arba = self.search(
             [
                 ("company_id", "=", company.id),
-                ("state", "=", "open"),
                 ("date", ">=", from_date),
                 ("date", "<=", to_date),
             ],
+            # Priorizamos una DDJJ ya abierta ('open') por sobre una en borrador ('draft')
+            order="state desc",
             limit=1,
         )
         if not dj_arba:
@@ -229,6 +235,7 @@ class L10nArDjArba(models.Model):
                     "date": wh_date,
                 }
             )
+        if dj_arba.state == "draft":
             dj_arba.action_open()
         return dj_arba
 
@@ -404,7 +411,12 @@ class L10nArDjArba(models.Model):
         )
         error_prefix = self.env._("Error opening the declaration: DDJJ ID number was not generated")
         if error:
-            self._process_arba_error(error, error_prefix)
+            # ARBA puede ya tener abierta la DDJJ del período (ej. un intento previo cuya respuesta se
+            # perdió por una caída intermitente del webservice). Intentamos recuperarla linkeando la DDJJ
+            # existente en ARBA en lugar de dejar el borrador colgado y bloquear el período.
+            self.action_find_existing()
+            if not self.name:
+                self._process_arba_error(error, error_prefix)
             return
 
         if response.get("id"):


### PR DESCRIPTION
Backport of #1120 (19.0) to 18.0 — the fix never reached 18.0 and the same failure chain hit an 18.0 database.

When opening a DDJJ against the ARBA webservice failed (e.g. an intermittent WS outage returning a connection reset), a draft DDJJ was left behind and the retry path created a second one, hitting the `unique(company, period, state)` constraint and permanently blocking the user from reporting any withholding for that period.

- `_ensure_dj` now reuses any existing DDJJ for the period (open or draft) instead of only matching 'open', preferring open over draft, so it no longer creates duplicates nor leaves orphan drafts.
- `action_open` falls back to `action_find_existing` when the open request fails, so a DDJJ already opened on ARBA (whose response was lost) is linked instead of leaving the period blocked.

Clean cherry-pick of 48a303f43c1c1ba789fa95bd26e5f552eda0597c; the only divergence vs 19.0 left in the file is the v19-only constraints API.

Internal ticket: https://www.adhoc.inc/odoo/helpdesk/125864