### PR TITLE
[FIX] account_tax_settlement: block deleting entries already settled

### DIFF
--- a/account_tax_settlement/README.rst
+++ b/account_tax_settlement/README.rst
@@ -21,6 +21,7 @@ Módulo que implementa las siguientes funcionalidades:
 * incorpora posibilidad de liquidar apuntes
 * incorpora lógica genérica para generar archivos de liquidación (se requiere extender en módulos que terminen de implementarlo). Al principió los formateabamos con qweb pero vimos que quedan feos y, además, que no tiene tanto sentido ya que no es algo que sea necesario estar actualizando desde interfaz.
 * Implementa funcionalidad para poder hacer liquidaciones sobre informes contables de odoo e implementa el caso específico de "Asiento de refundición" y "Asiento de cierre" utilizando esta funcionalidad
+* No permite eliminar un asiento cuyos apuntes de impuestos ya fueron liquidados. Si se elimina, esos apuntes salen de la liquidación (que conserva su importe pero pierde el detalle) y los que se creen después vuelven a quedar pendientes, con lo cual se liquidan y se declaran dos veces. Para liberarlos hay que eliminar primero el asiento de liquidación
 
 
 Installation

--- a/account_tax_settlement/models/account_move.py
+++ b/account_tax_settlement/models/account_move.py
@@ -1,4 +1,5 @@
-from odoo import fields, models
+from odoo import _, fields, models
+from odoo.exceptions import UserError
 
 
 class AccountMove(models.Model):
@@ -22,8 +23,27 @@ class AccountMove(models.Model):
         return self.settled_line_ids.get_tax_settlement_file(self.journal_id)
 
     def unlink(self):
-        """Recompute tax_state on settled lines after deleting settlement moves."""
-        settled_lines = self.mapped("settled_line_ids")
+        """Protect entries already settled and recompute tax_state on settled lines.
+
+        Deleting an entry whose tax lines are already included in a settlement silently
+        drops them from that settlement: the settlement entry keeps its amount but loses
+        the detail, and the tax lines re-created afterwards show up as pending again, so
+        they end up settled (and declared) twice. Block it and let the user delete the
+        settlement entry first, which is the operation that properly releases the lines.
+        """
+        settled_lines = self.line_ids.filtered("tax_settlement_move_id")
+        if settled_lines:
+            raise UserError(
+                _(
+                    "You can not delete an entry with tax lines already included in a tax settlement. "
+                    "Delete the settlement entry first:\n%s",
+                    "\n".join(
+                        "* %s -> %s" % (line.move_id.display_name, line.tax_settlement_move_id.display_name)
+                        for line in settled_lines
+                    ),
+                )
+            )
+        settlement_settled_lines = self.mapped("settled_line_ids")
         res = super().unlink()
-        settled_lines._compute_tax_state()
+        settlement_settled_lines._compute_tax_state()
         return res

--- a/account_tax_settlement/tests/__init__.py
+++ b/account_tax_settlement/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_settled_entry_unlink

--- a/account_tax_settlement/tests/test_settled_entry_unlink.py
+++ b/account_tax_settlement/tests/test_settled_entry_unlink.py
@@ -1,0 +1,85 @@
+from odoo import Command
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSettledEntryUnlink(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.settlement_tag = cls.env["account.account.tag"].create(
+            {
+                "name": "Settlement tag",
+                "applicability": "taxes",
+                "country_id": cls.env.company.account_fiscal_country_id.id,
+            }
+        )
+        cls.settled_tax = cls.env["account.tax"].create(
+            {
+                "name": "Settled tax 10%",
+                "amount_type": "percent",
+                "amount": 10.0,
+                "type_tax_use": "purchase",
+                "invoice_repartition_line_ids": [
+                    Command.create({"repartition_type": "base"}),
+                    Command.create({"repartition_type": "tax", "tag_ids": [Command.set(cls.settlement_tag.ids)]}),
+                ],
+                "refund_repartition_line_ids": [
+                    Command.create({"repartition_type": "base"}),
+                    Command.create({"repartition_type": "tax", "tag_ids": [Command.set(cls.settlement_tag.ids)]}),
+                ],
+            }
+        )
+        cls.settlement_journal = cls.env["account.journal"].create(
+            {
+                "name": "Tax Settlement Journal",
+                "code": "TSJ",
+                "type": "general",
+                "tax_settlement": "allow_per_line",
+                "settlement_partner_id": cls.partner_a.id,
+                "settlement_account_id": cls.company_data["default_account_payable"].id,
+                "settlement_account_tag_ids": [Command.set(cls.settlement_tag.ids)],
+            }
+        )
+
+    def _create_settled_bill(self):
+        """Return a posted bill and its tax line, already included in a settlement."""
+        bill = self._create_invoice_one_line(
+            move_type="in_invoice",
+            partner_id=self.partner_a,
+            price_unit=1000.0,
+            tax_ids=self.settled_tax,
+            post=True,
+        )
+        tax_line = bill.line_ids.filtered("tax_repartition_line_id")
+        self.assertEqual(tax_line.tax_state, "to_settle")
+        tax_line.create_tax_settlement_entry()
+        self.assertTrue(tax_line.tax_settlement_move_id)
+        return bill, tax_line
+
+    def test_unlink_settled_entry_is_blocked(self):
+        bill, dummy = self._create_settled_bill()
+        bill.button_draft()
+        with self.assertRaisesRegex(UserError, "already included in a tax settlement"):
+            bill.unlink()
+
+    def test_unlink_after_deleting_the_settlement(self):
+        bill, tax_line = self._create_settled_bill()
+        tax_line.tax_settlement_move_id.unlink()
+        self.assertFalse(tax_line.tax_settlement_move_id)
+        self.assertEqual(tax_line.tax_state, "to_settle")
+        bill.button_draft()
+        bill.unlink()
+
+    def test_unlink_unsettled_entry_is_allowed(self):
+        bill = self._create_invoice_one_line(
+            move_type="in_invoice",
+            partner_id=self.partner_a,
+            price_unit=1000.0,
+            tax_ids=self.settled_tax,
+            post=True,
+        )
+        bill.button_draft()
+        bill.unlink()


### PR DESCRIPTION
## Problem

`account.move.unlink()` lets you delete an entry whose tax lines are already included in a settlement. The settlement entry keeps its total but loses the detail of those lines, and the tax lines re-created afterwards come back with no settlement, so they show up as pending again and end up settled — and declared — twice.

We hit this with a data fix that regenerated the journal entry of payments carrying a write off: an income tax withholding already settled in one fortnight was pulled out of that settlement, went back to the pending list, and a later settlement took it again. Nothing in the UI or the logs points at the cause: both settlements look consistent on their own.

## Solution

Block the unlink when any line of the entry has `tax_settlement_move_id` set, naming the entry and the settlement in the error message.

The way out is unchanged and already supported: delete the settlement entry first. That releases the lines and recomputes `tax_state` — the same `unlink()` already did it, this commit only stops the other direction.

## Test plan

New `account_tax_settlement/tests/test_settled_entry_unlink.py`:

- deleting a settled entry raises `UserError`
- deleting the settlement first releases the line (`tax_state` back to `to_settle`) and then the entry can be deleted
- an entry whose tax line was never settled is still deletable

## Not covered on purpose

Resetting an entry to draft and re-posting it can drop the link the same way, without any unlink. It is a legitimate flow and probably deserves a warning rather than a hard block, so it is left for a separate discussion. Deletes issued in SQL never reach the ORM and are out of reach of any model-level guard.

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/125925
