### PR TITLE
[FIX] account_balance_import: locate partners by internal code

### DIFF
--- a/account_balance_import/controllers/main.py
+++ b/account_balance_import/controllers/main.py
@@ -42,7 +42,10 @@ class GenerateXLS(http.Controller):
         sheet.col(5).width = 256 * 25  # Importe en Otra moneda
 
         # Write headers
-        sheet.write(0, 0, "Nombre / CUIT / Referencia Interna", style)
+        identifier_header = "Nombre / CUIT / Referencia Interna"
+        if "internal_code" in request.env["res.partner"]._fields:
+            identifier_header += " / Código Interno"
+        sheet.write(0, 0, identifier_header, style)
         sheet.write(0, 1, "Referencia / Documento", style)
         sheet.write(0, 2, "Importe", style)
         if import_type != "adjust":

--- a/account_balance_import/tests/test_account_balance_import.py
+++ b/account_balance_import/tests/test_account_balance_import.py
@@ -236,6 +236,26 @@ class TestAccountBalanceImport(TransactionCase):
 
         return base64.b64encode(generate_xls(data))
 
+    def test_partner_is_located_by_every_supported_identifier(self):
+        """The first column of the template accepts several identifiers.
+
+        Every one of them must resolve to the same partner, including the internal
+        code when `partner_internal_code` is installed: it is a different field than
+        the internal reference and used to be ignored, so those rows failed with
+        "No partner was found for the entered text" even though the partner existed.
+        """
+        partner = self.partner_1
+        partner.ref = "REF-001"
+        identifiers = [partner.name, partner.ref]
+        if "internal_code" in self.env["res.partner"]._fields:
+            partner.internal_code = "IC-001"
+            identifiers.append(partner.internal_code)
+
+        wizard = self.env["account.balance_import_wizard"]
+        for identifier in identifiers:
+            found = self.env["res.partner"].search(wizard._get_partner_domain(identifier))
+            self.assertEqual(found, partner, f"The partner should be located by '{identifier}'")
+
     def test_partner_balance_import_basic(self):
         """
         Basic partner balance import test

--- a/account_balance_import/wizards/account_balance_import.py
+++ b/account_balance_import/wizards/account_balance_import.py
@@ -127,6 +127,20 @@ class AccountBalanceImport(models.TransientModel):
         }
 
     @api.model
+    def _get_partner_domain(self, identifier):
+        """Domain used to locate the partner from the first column of the template.
+
+        Besides the name, the VAT and the internal reference, we also match the
+        partner internal code when `partner_internal_code` is installed: databases
+        using that module identify their partners by that code, which is a
+        different field than the internal reference.
+        """
+        fnames = ["name", "vat", "ref"]
+        if "internal_code" in self.env["res.partner"]._fields:
+            fnames.append("internal_code")
+        return ["|"] * (len(fnames) - 1) + [(fname, "=", identifier) for fname in fnames]
+
+    @api.model
     def locate_currency(self, currency):
         """This method return the currency, if wasn't find any currency that match with the name in xls we return empty recordset"""
         other_currency = self.env["res.currency"]
@@ -255,15 +269,7 @@ class AccountBalanceImport(models.TransientModel):
                 dict_data["name"] = str(int(dict_data["name"]))
 
             # Locate Partner
-            domain = [
-                "|",
-                "|",
-                ("name", "=", dict_data["name"]),
-                ("vat", "=", dict_data["name"]),
-                ("ref", "=", dict_data["name"]),
-            ]
-
-            partner = self.env["res.partner"].search(domain)
+            partner = self.env["res.partner"].search(self._get_partner_domain(dict_data["name"]))
 
             # Locate Currency
             other_currency = self.locate_currency(dict_data.get("currency"))

--- a/account_balance_import_checks/wizard/account_balance_import.py
+++ b/account_balance_import_checks/wizard/account_balance_import.py
@@ -184,15 +184,7 @@ class AccountBalanceImport(models.TransientModel):
                 continue
 
             # Locate Partner
-            domain = [
-                "|",
-                "|",
-                ("name", "=", dict_data["name"]),
-                ("vat", "=", dict_data["name"]),
-                ("ref", "=", dict_data["name"]),
-            ]
-
-            partner = self.env["res.partner"].search(domain)
+            partner = self.env["res.partner"].search(self._get_partner_domain(dict_data["name"]))
 
             # Locate Currency
             other_currency = self.locate_currency(dict_data["currency"])


### PR DESCRIPTION
### What

The initial balance import wizard resolved the partner of each row by `name`, `vat` and `ref` only. Databases that install `partner_internal_code` identify their partners by `internal_code`, which is a different field than the internal reference, so every row carrying that code failed validation with *"No partner was found for the entered text"* even though the partner existed and could be found by that very code from the Contacts search view.

### How

- New `_get_partner_domain` on `account.balance_import_wizard` builds the lookup domain and appends `internal_code` only when the field is present, so the module keeps working without adding a dependency on `partner_internal_code`.
- Both import wizards (partner balances and checks) use it, instead of each one repeating the same domain inline.
- The first column header of the downloaded template names the internal code when the field exists, so it advertises what the wizard actually accepts.

### Test plan

New test `test_partner_is_located_by_every_supported_identifier`: a partner is located by name, by internal reference and — when `partner_internal_code` is installed — by internal code.

Verified locally on a 19.0 database with `partner_internal_code` installed:

- Without the change the new test fails: `AssertionError: res.partner() != res.partner(53,) : The partner should be located by 'IC-001'`.
- With the change: `account_balance_import: 0 failed, 0 error(s) of 9 tests` and `account_balance_import_checks: 0 failed, 0 error(s) of 4 tests`.

Internal ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/125267