### PR TITLE
[FIX] account_accountant_ux: reset bank transaction to draft crashes

### DIFF
--- a/account_accountant_ux/models/account_bank_statement_line.py
+++ b/account_accountant_ux/models/account_bank_statement_line.py
@@ -5,6 +5,20 @@ from odoo.exceptions import UserError
 class AccountBankStatementLine(models.Model):
     _inherit = "account.bank.statement.line"
 
+    def action_button_draft(self):
+        """Only let a real action through, never the boolean ``button_draft`` returns.
+
+        The server action ``account_accountant.model_account_statement_line_button_draft``
+        assigns this method's return value to its ``action`` variable, and
+        ``/web/action/run`` passes it to ``clean_action()`` without checking it is a
+        dict, so a truthy non-dict raises ``AttributeError: 'bool' object has no
+        attribute 'setdefault'``. Odoo's ``button_draft`` started returning ``True`` in
+        odoo/odoo 712718d9d. ``/web/dataset/call_button`` already applies a similar
+        guard, which is why the form-button path never broke. Ticket 125915.
+        """
+        res = super().action_button_draft()
+        return res if isinstance(res, dict) else False
+
     def _add_move_line_to_statement_line_move(self, vals_list):
         """If reconcile on company_currency is disabled → keep Odoo's native behavior, including
         the creation of exchange difference entries if applicable.


### PR DESCRIPTION
## What

The `account_accountant` server action `model_account_statement_line_button_draft`
("Reset to draft", bound to the `account.bank.statement.line` **list** view) fails with:

```
File "odoo/addons/web/controllers/action.py", line 59, in run
File "odoo/addons/web/controllers/utils.py", line 24, in clean_action
AttributeError: 'bool' object has no attribute 'setdefault'
```

The journal entry *is* reset to draft; the request fails on the return value.

## Why

Upstream chain, all standard code:

1. `account_accountant/views/bank_rec_widget_views.xml:549` — the server action runs `action = records.action_button_draft()`.
2. `account_accountant/models/account_bank_statement.py:98` — `action_button_draft()` returns `self.move_id.button_draft()`.
3. Since odoo/odoo `712718d9d` (*"[FIX] account, l10n\*: button_draft should not return None"*, 2026-07-15) `account.move.button_draft()` returns `True`. That commit adapted `l10n_es_edi_tbai`, `l10n_tr_nilvera_einvoice` and `l10n_latam_check`, but not this call site.
4. `/web/action/run` (`action.py:59`) forwards the result to `clean_action()` guarded only by truthiness.

The equivalent form-header button (`bank_rec_widget_views.xml:304`, `type="object"`, **same method**) is unaffected, because `/web/dataset/call_button` (`dataset.py:39`) guards with `isinstance(action, dict)`. This patch applies the same narrowing on the model side.

## Alternatives considered

- **Override `ir.actions.server._run_action_code_multi`** to drop non-dict returns. Mirrors the `call_button` guard, but changes server-action dispatch for every action in every database — the return value is consumed with dict semantics in several places (e.g. `base_automation` checks `'value' in res`), including actions written by hand. Too wide a blast radius for a one-line upstream regression.
- **Change `account.move.button_draft()`** to stop returning `True`. It is intentional upstream (`712718d9d` fixed an XML-RPC marshalling error) and the method is called throughout core, so this would change semantics for every caller.
- **Override the server action's XML `code`.** Same coverage, worse mechanics: overriding another module's data record is load-order dependent and gets rewritten on every `account_accountant` upgrade.

The defect is upstream. This override is local, documented with the upstream commit, and revertible once Odoo fixes it.

## Test plan

Accounting → Dashboard → bank journal card → **Transactions** (opens the list view) → tick a transaction whose journal entry is `posted` → cog **Actions → Reset to draft**.

Before: server error. After: the entry is reset to draft and the action ends cleanly.

Measured on a freshly created 19.0 database:

| | before | after |
|---|---|---|
| `move.button_draft()` | `True` | `True` (untouched) |
| `line.action_button_draft()` | `True` | `False` |
| `server_action.run()` | `True` → crash | `False` |
| entry state after the action | — | `posted` → `draft` |

`button_draft()` is deliberately left untouched so the other overrides in the ecosystem that do `return super().button_draft()` keep working.

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/125915
