### PR TITLE
[FIX] l10n_ar_edi_ux: remove ARCA environment field from setup wizard

### DIFF
--- a/l10n_ar_edi_ux/wizards/l10n_ar_arca_connection_wizard.py
+++ b/l10n_ar_edi_ux/wizards/l10n_ar_arca_connection_wizard.py
@@ -26,13 +26,6 @@ class L10nArArcaConnectionWizard(models.TransientModel):
         help="Upload your ARCA certificate in PEM format obtained from the ARCA portal.",
     )
 
-    l10n_ar_afip_ws_environment = fields.Selection(
-        related="company_id.l10n_ar_afip_ws_environment",
-        string="Environment",
-        readonly=False,
-        help="Select the ARCA environment: Testing for homologation, Production for real invoices.",
-    )
-
     connection_status_html = fields.Html(
         string="Connection Status",
         compute="_compute_connection_status_html",

--- a/l10n_ar_edi_ux/wizards/l10n_ar_arca_connection_wizard_view.xml
+++ b/l10n_ar_edi_ux/wizards/l10n_ar_arca_connection_wizard_view.xml
@@ -14,9 +14,6 @@
                     <group>
                         <field name="company_id" invisible="1"/>
                         <field name="has_valid_certificate" invisible="1"/>
-                        <field name="l10n_ar_afip_ws_environment" widget="radio" options="{'horizontal': true}"/>
-                    </group>
-                    <group>
                         <field name="l10n_ar_afip_ws_key_id"
                                context="{'default_public': False}"
                                options="{'no_create': False, 'no_open': False}"/>
@@ -32,7 +29,6 @@
                 <div class="alert alert-secondary mt-3" role="alert">
                     <p><strong>Need help?</strong></p>
                     <ul>
-                        <li>For testing, you can use demo certificates from ARCA</li>
                         <li>For production, obtain your certificate from the ARCA portal</li>
                         <li>Certificates must be in PEM format</li>
                     </ul>


### PR DESCRIPTION
## Qué pasa hoy

El wizard `l10n_ar.arca.connection.wizard` (*ARCA Connection Setup*, al que se llega desde la guía de importación de saldos) expone `l10n_ar_afip_ws_environment` como campo *related* con `readonly=False`. Al guardar, el valor que tiene el diálogo se escribe sobre la compañía: si ese valor no refleja el que realmente tiene la compañía, el guardado termina cambiando el entorno de ARCA sin que nadie lo haya pedido explícitamente.

En una base productiva el efecto es que la compañía queda apuntando a homologación con un certificado productivo, y toda conexión falla con *"Certificado no emitido por AC de confianza"*.

El entorno, además, ya está resuelto por el tipo de base: en producción es `production`, y en bases duplicadas `server_mode` fuerza `testing` (`saas_client_l10n_ar`), módulo que justamente oculta el selector en Configuración a propósito. Este wizard era la única superficie que lo volvía a exponer al usuario.

## Cambio

- Se elimina `l10n_ar_afip_ws_environment` del wizard (modelo y vista): deja de ser editable y deja de escribirse sobre la compañía.
- Se colapsa el `<group>` que quedaba con solo campos invisibles, para no dejar una columna vacía en el diálogo.
- Se saca la sugerencia *"for testing, you can use demo certificates from ARCA"*, que ya no aplica sin selector de entorno.

El wizard sigue igual para cargar la clave privada, cargar el certificado y testear las conexiones.

## Test plan

1. Base con compañía argentina, `l10n_ar_edi_ux` instalado y `l10n_ar_afip_ws_environment = production`.
2. Contabilidad → Configuración → Contabilidad → *Import Wizard* → sección *ARCA Connection* → botón *Configure Connection*.
3. El diálogo ya no muestra el selector de entorno.
4. Guardar y cerrar; verificar que el valor almacenado de `res.company.l10n_ar_afip_ws_environment` sigue en `production`.

> Al verificar, mirar el campo **almacenado**: en una base de prueba `_get_environment_type()` devuelve `testing` por `server_mode` independientemente de lo guardado.

Ref: https://www.adhoc.inc/odoo/helpdesk.ticket/124900
