### PR TITLE
[FIX] l10n_ar_account_tax_settlement: sicore aplicado, régimen desde el memo del pago

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -1205,6 +1205,22 @@ class AccountJournal(models.Model):
 
         # build txt file
         content = ""
+        # códigos de los regímenes de ganancias de la compañía (incluidos los archivados), los usamos
+        # para validar el régimen que tomamos del memo del pago en las retenciones migradas (ver abajo)
+        earnings_taxes = (
+            self.env["account.tax"]
+            .with_context(active_test=False)
+            .search(
+                [
+                    *self.env["account.tax"]._check_company_domain(self.company_id),
+                    ("l10n_ar_tax_type", "in", ["earnings", "earnings_scale"]),
+                    ("l10n_ar_code", "!=", False),
+                ]
+            )
+        )
+        earnings_codes = {
+            int(digits) for x in earnings_taxes.mapped("l10n_ar_code") if (digits := "".join(filter(str.isdigit, x)))
+        }
 
         for line in move_lines.filtered("amount_currency").sorted(key=lambda r: (r.date, r.id)):
             partner = line.partner_id
@@ -1290,6 +1306,16 @@ class AccountJournal(models.Model):
                 if tax.l10n_ar_tax_type in ["earnings", "earnings_scale"]:
                     content += "0217"
                     regimen = tax.l10n_ar_code
+                    # en v15 el régimen se cargaba en el grupo de pagos y el txt informaba ese código sin
+                    # tener en cuenta si el contacto tenía o no cargado el régimen de retención. Esas
+                    # retenciones migran con un impuesto backward inactivo y sin código de régimen (con lo
+                    # cual informábamos 000 y arca rechazaba el archivo), así que lo tomamos del memo del
+                    # pago, donde quedó como "94 - Locaciones de obra y/o ...".
+                    # el getattr es porque is_backward_tax lo agrega l10n_ar_tax_settlement_backward_comp
+                    if not regimen and not tax.active and getattr(tax, "is_backward_tax", False):
+                        regimen_memo = re.match(r"\s*(\d{1,3})(?!\d)\s*-", payment.memo or "")
+                        if regimen_memo and int(regimen_memo.group(1)) in earnings_codes:
+                            regimen = regimen_memo.group(1)
                     # necesitamos lo de filter porque hay dos regimenes que le
                     # agregamos caracteres
                     content += regimen and "%03d" % int("".join(filter(str.isdigit, str(regimen)))) or "000"


### PR DESCRIPTION
## Problema

En v15 el régimen de retención de ganancias se cargaba en el grupo de pagos, y el TXT de SICORE Aplicado informaba ese código **sin tener en cuenta si el contacto tenía o no cargado el régimen de retención de ganancias**.

Esas retenciones migran con un impuesto backward inactivo (`l10n_ar_tax_settlement_backward_comp`) que no tiene `l10n_ar_code`, con lo cual el TXT pasó a informar `000` como código de régimen y ARCA (SIAP) rechaza el archivo.

## Solución

En `account.journal.sicore_aplicado_files_values()`, cuando el impuesto no tiene código de régimen, está inactivo y es backward, el código se toma del `memo` del pago, donde quedó con el formato `\"94 - Locaciones de obra y/o servicios no ejecutados en relación de dependencia...\"`.

Para no informar cualquier número con el que el memo pueda empezar, se valida contra los códigos de régimen de ganancias de la compañía (incluidos los archivados), que se resuelven una sola vez al principio del método. Si no matchea, se sigue informando `000` como hasta ahora.

Los apuntes creados en la versión nueva no se ven afectados: ahí el impuesto está activo y se usa `tax.l10n_ar_code`.

## Test plan

1. Base migrada con un pago cuyo partner no tiene el régimen de ganancias cargado en el contacto y cuyo memo arranca con `\"94 - ...\"`.
2. Generar el TXT de SICORE Aplicado del período.
3. Las posiciones 49-51 de esa línea informan `094` en lugar de `000`.
4. Un pago con memo que no arranca con un régimen válido (ej. `\"1234 - Factura\"`) sigue informando `000` y el largo de la línea no cambia.
5. Un pago de la versión nueva (impuesto activo, con `l10n_ar_code`) sigue informando el código del impuesto.

Ref. ticket 125122.