### PR TITLE
[IMP] l10n_ar_account_reports: número de retención sifere txt

### DIFF
--- a/l10n_ar_account_reports/models/sifere_report.py
+++ b/l10n_ar_account_reports/models/sifere_report.py
@@ -149,7 +149,7 @@ class L10n_ArSifereReportHandler(models.AbstractModel):
                     continue
 
                 # el numero de la retencion
-                pos, number = get_pos_and_number(line.withholding_id.name)
+                pos, number = get_pos_and_number(line.name)
                 content += f"{pos:>04s}"
                 content += f"{number:>016s}"
             else:


### PR DESCRIPTION
El número de retención de sifere se puede obtener del name del apunte contable, no hace falta buscar la retención (withholding_id) para obtener el número de retención. Esto lo hacemos así porque puede haber algunos casos donde withholding_id sea False porque si el pago es de una branch entonces el impuesto del apunte contable queda vinculado al impuesto equivalente de la padre pero las retenciones del pago quedan vinculados a los impuestos que eran de la branch. Debido a esto lo que sucede es que el withholding_id del apunte contable queda en False y no se puede obtener el número de retención. Por eso se opta por obtener el número de retención del name del apunte contable.
Ticket: 125999