### PR TITLE
[IMP] l10n_ar_account_tax_settlement: sircar redondear percepción a 2 decimales

### DIFF
--- a/l10n_ar_account_tax_settlement/models/account_journal.py
+++ b/l10n_ar_account_tax_settlement/models/account_journal.py
@@ -1011,7 +1011,7 @@ class AccountJournal(models.Model):
             content.append(format_amount(alicuot, 6, 2, "."))
 
             # 9 Monto percibido
-            content.append(format_amount(-line.balance, 12, 2, "."))
+            content.append(format_amount(float_round(-line.balance, precision_digits=2), 12, 2, "."))
 
             # 10 Tipo de Régimen de Percepción
             # (código correspondiente según tabla definida por la jurisdicción)


### PR DESCRIPTION
Si el cliente tiene en la moneda "ARS" factor de redondeo 0.000100 (decimal_places = 4) nosotros estamos llevando al archivo txt el monto de percepción truncado a 2 decimales. Con esta mejora llevamos el monto de percepción REDONDEADO a 2 decimales.
Ticket: 125204