### PR TITLE
[FIX] l10n_ar_account_reports: adapt tax closing signature to core

### DIFF
--- a/l10n_ar_account_reports/models/account_return.py
+++ b/l10n_ar_account_reports/models/account_return.py
@@ -45,7 +45,7 @@ class AccountReturn(models.Model):
             domain += l10n_ar_domain
         return domain
 
-    def _ensure_tax_group_configuration_for_tax_closing(self):
+    def _ensure_tax_group_configuration_for_tax_closing(self, tax_group_ids=None):
         """EXTENDS account_reports
 
         Para las liquidaciones argentinas hacemos una validación propia y NO corremos la nativa de Odoo, porque
@@ -58,7 +58,7 @@ class AccountReturn(models.Model):
         Para más detalle ver el mensaje del pull request / commit que introdujo este método.
         """
         if not self.type_id.l10n_ar_is_simple_closing_return:
-            return super()._ensure_tax_group_configuration_for_tax_closing()
+            return super()._ensure_tax_group_configuration_for_tax_closing(tax_group_ids)
 
         self.ensure_one()
         # Usamos el tax_group_id del apunte (related stored) y no el catálogo de impuestos: así entran los


### PR DESCRIPTION
Upstream `account_reports` changed the signature of `_ensure_tax_group_configuration_for_tax_closing`: it now takes the tax groups that actually take part in the closing entry, and `_compute_tax_closing_entry` passes them.

Our override in `l10n_ar_account_reports` kept the old signature. Since it sits last in the MRO, the call from core blew up with a `TypeError` before executing a single line of the body, breaking **every** tax return validation that generates a closing entry (VAT, IIBB, withholdings), not just one return type.

```
File ".../account_reports/models/account_return.py", line 1895, in _compute_tax_closing_entry
    self._ensure_tax_group_configuration_for_tax_closing(tax_group_ids)
TypeError: AccountReturn._ensure_tax_group_configuration_for_tax_closing() takes 1 positional argument but 2 were given
```

## Changes

- Accept `tax_group_ids=None` and forward it to `super()`.

That is the whole fix — the AR-specific branch (`l10n_ar_is_simple_closing_return`) does its own validation and ignores the argument, so its behaviour is unchanged.

## Test plan

- Validate a return that goes through the AR simple closing branch: the closing entry is generated, and a tax group missing its payable/receivable accounts still raises the AR `RedirectWarning`.
- Validate a non-AR return (VAT): the call reaches core and the upstream validation now only complains about the tax groups involved in the period.

## Follow-up (not in this PR)

Core now filters its own check by `tax_group_ids`, which covers the original reason for this override. The remaining difference is real, though: we start from `account.move.line.tax_group_id` so that archived taxes carried by migrated payments are taken into account, while core starts from the `account.tax` catalogue. Worth evaluating whether the override can be narrowed down to just that difference instead of replacing the whole validation.

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/126511
