### PR TITLE
[IMP] l10n_ar_account_reports: add test suite

### DIFF
--- a/l10n_ar_account_reports/tests/__init__.py
+++ b/l10n_ar_account_reports/tests/__init__.py
@@ -1,0 +1,4 @@
+from . import test_txt_line_count
+from . import test_sicore_txt
+from . import test_txt_field_format
+from . import test_open_bugs

--- a/l10n_ar_account_reports/tests/common.py
+++ b/l10n_ar_account_reports/tests/common.py
@@ -1,0 +1,249 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import Command, fields
+from odoo.addons.l10n_ar_withholding.tests.test_withholding_ar_ri import TestArWithholdingArRi
+
+# Datos de régimen que los archivos exigen en el impuesto: sin el código de
+# régimen (SIRCAR, IVA) o el artículo e inciso (Santa Fe) el handler frena
+# antes de escribir el primer registro. Es configuración de la base, no
+# comportamiento a probar.
+PERCEPTION_REGIME = {
+    "l10n_ar_code": "001",
+    "api_articulo_inciso_calculo_percepcion": "001",
+    "api_codigo_articulo_percepcion": "021",
+}
+WITHHOLDING_REGIME = {
+    "l10n_ar_code": "112",
+    "api_articulo_inciso_calculo_retencion": "001",
+    "api_codigo_articulo_retencion": "001",
+}
+
+# Impuestos del plan AR por jurisdicción, con la alícuota que se les pone: el
+# plan los trae en 0 y así no se puede verificar ningún importe.
+PERCEPTIONS_APPLIED = {"C": "caba", "B": "ba", "S": "sf", "N": "mi", "T": "tn"}
+WITHHOLDINGS_APPLIED = {"C": "caba", "B": "ba", "S": "sf", "N": "ms", "M": "mza", "T": "t"}
+PERCEPTIONS_SUFFERED = {"C": "caba", "S": "sf"}
+
+
+class TestL10nArAccountReportsCommon(TestArWithholdingArRi):
+    """Escenario común de las suites del módulo.
+
+    Los helpers son ``classmethod`` porque el escenario se arma una vez por
+    clase: los archivos TXT informan todo lo que hay en el período, así que un
+    documento creado en un test entra en el archivo de los demás.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Percepciones de IIBB aplicadas en ventas.
+        cls.perception_taxes = {
+            code: cls._setup_perception("ri_tax_percepcion_iibb_%s_aplicada" % slug)
+            for code, slug in PERCEPTIONS_APPLIED.items()
+        }
+        # Retenciones de IIBB practicadas en pagos a proveedores.
+        cls.withholding_taxes = {
+            code: cls._setup_withholding("ex_tax_withholding_iibb_%s_applied" % slug, amount=2.0)
+            for code, slug in WITHHOLDINGS_APPLIED.items()
+        }
+        # Percepciones sufridas (las que le hacen a la compañía en sus compras).
+        cls.perception_suffered_taxes = {
+            code: cls._setup_perception("ri_tax_percepcion_iibb_%s_sufrida" % slug)
+            for code, slug in PERCEPTIONS_SUFFERED.items()
+        }
+
+        # Impuestos nacionales, sin jurisdicción: son los que informa SICORE.
+        cls.tax_perception_vat = cls._setup_perception("ri_tax_percepcion_iva_aplicada")
+        cls.tax_perception_vat_suffered = cls._setup_perception("ri_tax_percepcion_iva_sufrida")
+        cls.tax_withholding_vat = cls._setup_withholding("ex_tax_withholding_vat_applied")
+        # Ganancias tiene mínimo no sujeto a retención: con bases chicas el
+        # importe da cero y el registro no se informa.
+        cls.tax_withholding_earnings = cls._company_tax("ex_tax_withholding_profits_regimen_112_insc")
+        cls.tax_withholding_earnings.l10n_ar_withholding_sequence_id = cls.tax_wth_seq
+        cls.earnings_base = 500000.0
+
+        # El plan AR no trae retenciones sufridas con jurisdicción ni de IVA:
+        # se arman copiando las practicadas y dándolas vuelta.
+        cls.withholding_suffered_iibb = cls.withholding_taxes["C"].copy(
+            {"name": "Ret IIBB CABA sufrida (test)", "l10n_ar_withholding_payment_type": "customer"}
+        )
+        cls.withholding_suffered_vat = cls.tax_withholding_vat.copy(
+            {"name": "Ret IVA sufrida (test)", "l10n_ar_withholding_payment_type": "customer"}
+        )
+
+        cls.journal_bank = cls.env["account.journal"].search(
+            [("type", "=", "bank"), ("company_id", "=", cls.company_ri.id)], limit=1
+        )
+        # Contacto con todos los datos fiscales que piden los archivos: sin
+        # esto los handlers frenan antes del primer registro.
+        cls.partner_perceived = cls.env["res.partner"].create(
+            {
+                "name": "Perceived Partner SA",
+                "is_company": True,
+                "street": "Corrientes 1234",
+                "city": "Rosario",
+                "zip": "2000",
+                "state_id": cls.env.ref("base.state_ar_s").id,
+                "country_id": cls.env.ref("base.ar").id,
+                "l10n_latam_identification_type_id": cls.env.ref("l10n_ar.it_cuit").id,
+                "vat": "30710158254",
+                "l10n_ar_afip_responsibility_type_id": cls.env.ref("l10n_ar.res_IVARI").id,
+                "l10n_ar_gross_income_type": "local",
+                "l10n_ar_gross_income_number": "901-99999999",
+            }
+        )
+        cls._document_number_seq = 0
+
+    # ------------------------------------------------------------------
+    # Escenario
+    # ------------------------------------------------------------------
+    @classmethod
+    def _company_tax(cls, template_code):
+        """Los impuestos del plan se instalan con el id de la compañía de prefijo."""
+        return cls.env.ref("account.%i_%s" % (cls.company_ri.id, template_code))
+
+    @classmethod
+    def _setup_perception(cls, template_code, amount=3.0):
+        tax = cls._company_tax(template_code)
+        tax.write(dict(PERCEPTION_REGIME, amount=amount, amount_type="percent"))
+        return tax
+
+    @classmethod
+    def _setup_withholding(cls, template_code, amount=3.0):
+        tax = cls._company_tax(template_code)
+        tax.write(
+            dict(
+                WITHHOLDING_REGIME,
+                amount=amount,
+                amount_type="percent",
+                l10n_ar_withholding_sequence_id=cls.tax_wth_seq.id,
+            )
+        )
+        return tax
+
+    @classmethod
+    def _next_document_number(cls):
+        cls._document_number_seq += 1
+        return "0001-%08d" % cls._document_number_seq
+
+    @classmethod
+    def _create_invoice(cls, taxes=None, date=None, price_unit=1000.0, document_number=None, **vals):
+        """Comprobante publicado con los impuestos indicados."""
+        invoice = cls.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": cls.partner_perceived.id,
+                "date": date,
+                "invoice_date": date,
+                "invoice_line_ids": [
+                    Command.create(
+                        {
+                            "product_id": cls.product_a.id,
+                            "price_unit": price_unit,
+                            "tax_ids": [Command.set((cls.tax_21 + (taxes or cls.env["account.tax"])).ids)],
+                        }
+                    )
+                ],
+                **vals,
+            }
+        )
+        invoice.l10n_latam_document_number = document_number or cls._next_document_number()
+        invoice.action_post()
+        return invoice
+
+    @classmethod
+    def _create_refund(cls, invoice, taxes, date):
+        """Nota de crédito con su percepción y el comprobante que corrige.
+
+        No se usa ``_reverse_moves``: la reversión recalcula los impuestos
+        desde la posición fiscal y se pierde la percepción, que es justamente
+        lo que estos archivos informan.
+        """
+        return cls._create_invoice(
+            taxes,
+            date,
+            move_type="out_refund",
+            l10n_latam_document_type_id=cls.env.ref("l10n_ar.dc_a_nc").id,
+            reversed_entry_id=invoice.id,
+        )
+
+    @classmethod
+    def _create_payment_with_withholdings(cls, taxes, date, price_unit=1000.0, **vals):
+        """Pago con retenciones, del lado que indique el comprobante.
+
+        Con ``in_invoice`` (default) son las que la compañía practica a un
+        proveedor; con ``out_invoice``, las que le practican a la compañía.
+        """
+        vals.setdefault("move_type", "in_invoice")
+        invoice = cls._create_invoice(date=date, price_unit=price_unit, **vals)
+        payment = (
+            cls.env["account.payment"]
+            .with_context(**invoice.action_register_payment()["context"])
+            .create({"journal_id": cls.journal_bank.id, "amount": invoice.amount_total, "date": date})
+        )
+        payment.l10n_ar_withholding_line_ids = [Command.clear()] + [
+            Command.create({"tax_id": tax.id, "base_amount": price_unit}) for tax in taxes
+        ]
+        # Sin el recálculo queda el importe que arrastra el registro de pagos.
+        payment.l10n_ar_withholding_line_ids._compute_amount()
+        payment.action_post()
+        cls.env.flush_all()
+        return payment
+
+    @classmethod
+    def _report_options(cls, report, date_from, date_to):
+        """Las opciones que consumen los handlers, pedidas al reporte.
+
+        Se piden al reporte y no se arman a mano para que el test use el mismo
+        diccionario que la pantalla.
+        """
+        return report.get_options(
+            previous_options={
+                "date": {
+                    "date_from": fields.Date.to_string(fields.Date.to_date(date_from)),
+                    "date_to": fields.Date.to_string(fields.Date.to_date(date_to)),
+                    "filter": "custom",
+                    "mode": "range",
+                },
+            }
+        )
+
+    @classmethod
+    def _tax_move_lines(cls, moves, tax):
+        """Los apuntes de impuesto de un comprobante o pago, para un impuesto dado."""
+        return moves.mapped("line_ids").filtered(lambda line: line.tax_line_id == tax)
+
+    # ------------------------------------------------------------------
+    # Invariantes de los archivos de declaración
+    # ------------------------------------------------------------------
+    def assert_fixed_width_records(self, records, width, ctx=""):
+        """Cada registro mide lo que fija la especificación y corta con CRLF.
+
+        Los organismos leen por posición: un carácter de más o de menos no
+        falla, corre los campos siguientes e informa el dato de otro campo.
+        """
+        for index, record in enumerate(records, start=1):
+            self.assertTrue(record.endswith("\r\n"), "%s: el registro %s no termina en CRLF" % (ctx, index))
+            self.assertEqual(
+                len(record),
+                width + 2,
+                "%s: el registro %s mide %s y la especificación pide %s (+CRLF).\n%r"
+                % (ctx, index, len(record) - 2, width, record),
+            )
+
+    def assert_latin1_safe(self, records, ctx=""):
+        """Ningún carácter del registro se pierde al codificar en ISO-8859-1.
+
+        Los handlers codifican con ``errors="ignore"``: un carácter fuera de
+        latin-1 no da error, se cae del archivo y corre las posiciones siguientes.
+        """
+        for index, record in enumerate(records, start=1):
+            dropped = [char for char in record if char.encode("ISO-8859-1", "ignore") == b""]
+            self.assertFalse(
+                dropped,
+                "%s: el registro %s pierde %s carácter(es) al codificar en ISO-8859-1: %s"
+                % (ctx, index, len(dropped), dropped),
+            )

--- a/l10n_ar_account_reports/tests/test_open_bugs.py
+++ b/l10n_ar_account_reports/tests/test_open_bugs.py
@@ -1,0 +1,48 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+"""Hallazgos abiertos: tests que documentan bugs vivos del módulo.
+
+Salieron de escribir esta suite y todavía no tienen fix. Afirman el
+comportamiento correcto —la especificación dice qué tiene que pasar— y por eso
+quedan en rojo. La clase va tagueada ``-standard`` para no teñir el build de
+runbot: al corregir el bug hay que sacar su test de acá y llevarlo a la suite
+que corresponde (el de Mendoza, a la tabla de ``test_txt_line_count.py``).
+"""
+
+from odoo.tests import tagged
+
+from .common import TestL10nArAccountReportsCommon
+
+# Largos de la especificación SAREPE (doc/Mendoza/SAREPE.pdf): CUIT formateado,
+# denominación, fecha de comprobante, número de comprobante, fecha de la
+# retención, base imponible, alícuota e importe retenido.
+MENDOZA_RECORD_WIDTH = 13 + 80 + 8 + 12 + 8 + 15 + 5 + 15
+
+
+@tagged("post_install_l10n", "post_install", "-at_install", "-standard")
+class TestOpenBugs(TestL10nArAccountReportsCommon):
+    def test_el_archivo_de_retenciones_de_mendoza_se_puede_generar(self):
+        """``mendoza_report.py:102`` usa la variable ``name``, que solo se
+        asigna dentro del ``if len(line.name) > 12`` de la línea 97. Con la
+        secuencia de retención por defecto (8 dígitos) el nombre nunca pasa de
+        12 caracteres, así que si es la primera retención del archivo revienta
+        con ``UnboundLocalError``, y si vino después de una de más de 12
+        informa el número de comprobante de la retención anterior: el archivo
+        sale bien formado y con el dato de otro contribuyente. La
+        especificación SAREPE pide rellenar con ceros a la izquierda.
+        """
+        payment = self._create_payment_with_withholdings(self.withholding_taxes["M"], "2035-01-10")
+        move_lines = self._tax_move_lines(payment.move_id, self.withholding_taxes["M"])
+        self.assertTrue(move_lines, "el escenario tiene que dejar el apunte de la retención")
+
+        records = self.env["l10n_ar.mendoza.report.handler"]._get_mendoza_txt_content(move_lines)
+
+        self.assertEqual(len(records), len(move_lines), "el archivo tiene que informar la retención del período")
+        self.assert_fixed_width_records(records, MENDOZA_RECORD_WIDTH, "retención de Mendoza")
+        # CUIT del retenido con guiones en las primeras 13 posiciones, y la
+        # denominación completada con blancos a la derecha hasta 80.
+        record = records[0]
+        self.assertEqual(record[:13], self.partner_perceived.l10n_ar_formatted_vat)
+        self.assertEqual(record[13:93].rstrip(), self.partner_perceived.name)

--- a/l10n_ar_account_reports/tests/test_sicore_txt.py
+++ b/l10n_ar_account_reports/tests/test_sicore_txt.py
@@ -1,0 +1,106 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.exceptions import RedirectWarning
+from odoo.tests import tagged
+
+from .common import TestL10nArAccountReportsCommon
+
+# Largo del registro SICORE según el aplicativo SICORE v9.0 r22 (doc/Sicore/).
+# Retenciones y percepciones comparten largo: es un único archivo.
+SICORE_RECORD_WIDTH = 145
+
+
+@tagged("post_install_l10n", "post_install", "-at_install")
+class TestSicoreTxt(TestL10nArAccountReportsCommon):
+    """Arquetipo de layout posicional: el registro de SICORE campo por campo.
+
+    Los diez handlers del módulo escriben archivos de ancho fijo que el
+    organismo lee por posición, así que un campo corrido no falla: informa el
+    dato de otro campo. Verificar las posiciones de los diez layouts es un PR
+    por familia; acá queda SICORE completo como arquetipo —es el que usan todas
+    las bases— y los otros nueve quedan cubiertos a nivel de cantidad de
+    renglones y codificación por ``test_txt_line_count.py``.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.handler = cls.env["l10n_ar.sicore.report.handler"]
+
+    def test_registro_de_retencion_de_ganancias(self):
+        """El registro identifica el impuesto por el tipo de retención (0217
+        ganancias), el régimen por el código del impuesto y el comprobante por
+        el tipo de pago."""
+        payment = self._create_payment_with_withholdings(
+            self.tax_withholding_earnings, "2035-01-10", price_unit=self.earnings_base
+        )
+        move_lines = self._tax_move_lines(payment.move_id, self.tax_withholding_earnings)
+        self.assertTrue(move_lines, "el escenario tiene que dejar el apunte de la retención de ganancias")
+
+        records = [content for *_key, content in self.handler._get_sicore_withholding_content(move_lines)]
+
+        self.assert_fixed_width_records(records, SICORE_RECORD_WIDTH, "retención de ganancias")
+        record = records[0]
+        # Pago a proveedor: código de comprobante 06.
+        self.assertEqual(record[0:2], "06")
+        self.assertEqual(record[2:12], "10/01/2035")
+        # Número de comprobante: 16 posiciones, solo dígitos.
+        self.assertTrue(record[12:28].isdigit(), "el número de comprobante tiene que salir numérico")
+        # Ganancias es el impuesto 0217 y el régimen sale del código del impuesto.
+        self.assertEqual(record[44:48], "0217")
+        self.assertEqual(record[48:51], self.tax_withholding_earnings.l10n_ar_code)
+        # Código de operación 1 = retención, condición 01 para ganancias.
+        self.assertEqual(record[51:52], "1")
+        self.assertEqual(record[76:78], "01")
+        # Base e importe son campos distintos: ganancias descuenta el mínimo no
+        # sujeto a retención, así que el importe no es base por alícuota.
+        withholding = payment.l10n_ar_withholding_line_ids
+        self.assertEqual(record[52:66], "%014.2f" % self.earnings_base)
+        self.assertEqual(record[79:93], "%014.2f" % withholding.amount)
+        self.assertNotEqual(
+            withholding.amount,
+            self.earnings_base,
+            "el importe retenido no puede ser la base: son campos distintos del registro",
+        )
+        # Porcentaje de exclusión fijo, tipo y número de documento del retenido,
+        # certificado original en ceros.
+        self.assertEqual(record[93:99], "000.00")
+        self.assertEqual(record[109:111], "80")
+        self.assertEqual(record[111:131].rstrip(), self.partner_perceived.vat)
+        self.assertEqual(record[131:145], "0" * 14)
+
+    def test_registro_de_percepcion_de_iva(self):
+        """La percepción de IVA usa el impuesto 0767 y el código de operación 2,
+        y el comprobante sale del tipo de documento."""
+        invoice = self._create_invoice(self.tax_perception_vat, "2035-01-11")
+        move_lines = self._tax_move_lines(invoice, self.tax_perception_vat)
+        self.assertTrue(move_lines, "el escenario tiene que dejar el apunte de la percepción de IVA")
+
+        records = [content for *_key, content in self.handler._get_sicore_perception_content(move_lines)]
+
+        self.assert_fixed_width_records(records, SICORE_RECORD_WIDTH, "percepción de IVA")
+        record = records[0]
+        # Factura de cliente: código de comprobante 01.
+        self.assertEqual(record[0:2], "01")
+        self.assertEqual(record[2:12], "11/01/2035")
+        # 5 posiciones de punto de venta y 11 de número.
+        self.assertEqual(record[12:17], "00001")
+        self.assertEqual(record[17:28], "%011d" % int(invoice.l10n_latam_document_number.split("-")[1]))
+        # IVA es el impuesto 0767 y el código de operación 2 es percepción.
+        self.assertEqual(record[44:48], "0767")
+        self.assertEqual(record[51:52], "2")
+
+    def test_no_se_informa_un_retenido_sin_cuit(self):
+        """Control positivo compartido por todos los archivos: sin CUIT el
+        registro sale con el campo vacío y corre todas las posiciones
+        siguientes, así que hay que frenar antes de escribirlo."""
+        partner = self.partner_perceived.copy({"name": "Retenido sin CUIT", "vat": False})
+        payment = self._create_payment_with_withholdings(
+            self.tax_withholding_earnings, "2035-01-12", partner_id=partner.id, price_unit=self.earnings_base
+        )
+        move_lines = self._tax_move_lines(payment.move_id, self.tax_withholding_earnings)
+
+        with self.assertRaises(RedirectWarning):
+            self.handler._get_sicore_withholding_content(move_lines)

--- a/l10n_ar_account_reports/tests/test_txt_field_format.py
+++ b/l10n_ar_account_reports/tests/test_txt_field_format.py
@@ -1,0 +1,50 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo.addons.l10n_ar_account_reports.models.helpers import (
+    format_amount,
+    get_pos_and_number,
+    remove_accents_and_dieresis,
+)
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install_l10n", "post_install", "-at_install")
+class TestTxtFieldFormat(TransactionCase):
+    """Formato de los campos que comparten todos los archivos de declaración.
+
+    Son las funciones de ``models/helpers.py``: las usan los diez handlers, así
+    que un error acá corre las posiciones de todos los archivos a la vez.
+    """
+
+    def test_los_importes_llenan_el_campo_y_el_signo_no_lo_agranda(self):
+        for label, amount, padding, decimals, sep, expected in (
+            # Importe de percepción de PBA: 13 posiciones con separador coma.
+            ("percepción", 1234.56, 13, 2, ",", "0000001234,56"),
+            # Nota de crédito: el "-" entra en la primera posición y el largo
+            # no cambia, que es lo que hace que el campo siguiente no se corra.
+            ("nota de crédito", -1234.56, 13, 2, ",", "-000001234,56"),
+            # Alícuota de CABA: 5 posiciones.
+            ("alícuota", 3.0, 5, 2, ",", "03,00"),
+            # Sin separador el campo es todo numérico y mantiene el largo.
+            ("sin separador", 1234.56, 16, 2, "", "0000000000123456"),
+            ("cero", 0.0, 13, 2, ",", "0000000000,00"),
+        ):
+            with self.subTest(label):
+                result = format_amount(amount, padding, decimals, sep)
+                self.assertEqual(result, expected)
+                self.assertEqual(len(result), padding, "el campo tiene que medir exactamente %s" % padding)
+
+    def test_el_numero_de_comprobante_se_parte_en_punto_de_venta_y_numero(self):
+        for label, full_number, expected in (
+            ("con guion", "0001-00000001", ("0001", "00000001")),
+            # Sin guion no hay punto de venta que informar.
+            ("sin guion", "12345", ("0", "12345")),
+            ("con letras", "A0001-00000123", ("0001", "00000123")),
+        ):
+            with self.subTest(label):
+                self.assertEqual(get_pos_and_number(full_number), expected)
+
+    def test_la_razon_social_se_informa_sin_acentos(self):
+        self.assertEqual(remove_accents_and_dieresis("Ñandú Perón S.A."), "Nandu Peron S.A.")

--- a/l10n_ar_account_reports/tests/test_txt_line_count.py
+++ b/l10n_ar_account_reports/tests/test_txt_line_count.py
@@ -1,0 +1,202 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+import io
+import zipfile
+
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+from .common import TestL10nArAccountReportsCommon
+
+DATE_FROM = "2035-01-01"
+DATE_TO = "2035-01-31"
+
+CABA_LINES = ["caba_withholdings_line", "caba_perceptions_line"]
+SANTA_FE_LINES = ["santa_fe_withholdings_line", "santa_fe_perceptions_line"]
+TUCUMAN_LINES = ["tucuman_withholdings_line", "tucuman_perceptions_line"]
+
+# Los archivos que exporta el módulo. Del prefijo salen el reporte
+# (``l10n_ar_<prefijo>_report``), su handler y las líneas de la liquidación.
+#
+#   only      recorte cuando dos archivos se reparten los apuntes de la misma
+#             línea: CABA y Tucumán separan las notas de crédito
+#   records   registros esperados, contados sobre el escenario de abajo
+#   header    renglones del archivo que no son un apunte
+#
+# Mendoza no está: su archivo no se puede generar (ver ``test_open_bugs.py``).
+# Cuando se corrija hay que sumarlo acá.
+#
+# prefijo  | método del archivo | líneas del reporte | only | records | header
+TXT_FILES = [
+    # PBA: las retenciones van por lote A122R y las percepciones tienen dos
+    # archivos —general y actividad 7— sobre los mismos apuntes.
+    ("pba", "pba_alta_ret_lote_a122r_01032026_txt", ["pba_withholdings_line"], None, 1, 0),
+    ("pba", "pba_perc_desde_01032026_txt", ["pba_perceptions_line"], None, 1, 0),
+    ("pba", "pba_perc_act_7_desde_01032026_txt", ["pba_perceptions_line"], None, 1, 0),
+    # CABA informa retenciones y percepciones en un archivo y las NC en otro.
+    ("caba", "caba_ret_perc_txt", CABA_LINES, "invoices", 3, 0),
+    ("caba", "nc_caba_ret_perc_txt", CABA_LINES, "refunds", 1, 0),
+    # SICORE es una sola presentación: ganancias, retención de IVA y percepción
+    # de IVA salen intercaladas en el mismo archivo.
+    (
+        "sicore",
+        "sicore_book_export_files_to_txt",
+        ["profits_line", "vat_withholding_line", "vat_perception_line"],
+        None,
+        3,
+        0,
+    ),  # noqa: E501
+    ("sifere", "sifere_ret_txt", ["sifere_withholdings_line"], None, 1, 0),
+    ("sifere", "sifere_perc_txt", ["sifere_perceptions_line"], None, 1, 0),
+    # Los despachos de importación no se importan en el aplicativo: el archivo
+    # es un aviso para cargarlos a mano y arranca con un renglón de texto.
+    ("sifere", "sifere_despachos_txt", ["sifere_despachos_line"], None, 1, 1),
+    # SIRCAR entrega un zip con un archivo por jurisdicción.
+    ("sircar", "sircar_ret_txt", ["sircar_withholdings_line"], None, 3, 0),
+    ("sircar", "sircar_perc_txt", ["sircar_perceptions_line"], None, 2, 0),
+    ("misiones", "misiones_ret_txt", ["misiones_withholdings_line"], None, 1, 0),
+    ("misiones", "misiones_perc_txt", ["misiones_perceptions_line"], None, 1, 0),
+    ("santa_fe", "santa_fe_ret_perc_txt", SANTA_FE_LINES, None, 2, 0),
+    # Tucumán presenta tres archivos: dos con todos los apuntes y uno solo con
+    # las notas de crédito.
+    ("tucuman", "tucuman_datos_txt", TUCUMAN_LINES, None, 4, 0),
+    ("tucuman", "tucuman_retper_txt", TUCUMAN_LINES, None, 4, 0),
+    ("tucuman", "tucuman_ncfact_txt", TUCUMAN_LINES, "refunds", 1, 0),
+    ("iva", "ret_iva_sufridas_txt", ["iva_withholdings_line"], None, 1, 0),
+    ("iva", "perc_iva_sufridas_txt", ["iva_perceptions_line"], None, 1, 0),
+]
+
+
+@tagged("post_install_l10n", "post_install", "-at_install")
+class TestTxtLineCount(TestL10nArAccountReportsCommon):
+    """Lo que informa la liquidación es lo que sale en el archivo.
+
+    Es el control que hace el usuario antes de presentar: mira cuántas
+    percepciones y retenciones tiene el período, baja el TXT y cuenta los
+    renglones. Si no coinciden, la presentación va incompleta (o con datos de
+    más) y el archivo igual sale bien formado, así que nada falla.
+
+    Un solo escenario cubre diecinueve de los veinte archivos porque es el
+    mismo control. Tiene operaciones de varias jurisdicciones a la vez y en los
+    dos sentidos, que es lo que hace que un dominio flojo se note: si un
+    archivo se lleva un apunte de otra provincia o de otro régimen, no da.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Percepciones de IIBB aplicadas en ventas, una por jurisdicción.
+        for state_code, day in (("C", "05"), ("B", "06"), ("S", "07"), ("N", "08"), ("T", "09")):
+            cls._create_invoice(cls.perception_taxes[state_code], "2035-01-%s" % day)
+        # Percepción de IVA: la informa SICORE junto con las retenciones.
+        cls._create_invoice(cls.tax_perception_vat, "2035-01-10")
+
+        # Notas de crédito de CABA y de Tucumán, que tienen archivo propio.
+        refunded_caba = cls._create_invoice(cls.perception_taxes["C"], "2035-01-11")
+        cls._create_refund(refunded_caba, cls.perception_taxes["C"], "2035-01-12")
+        refunded_tucuman = cls._create_invoice(cls.perception_taxes["T"], "2035-01-13")
+        cls._create_refund(refunded_tucuman, cls.perception_taxes["T"], "2035-01-14")
+
+        # Las seis retenciones de IIBB practicadas en el mismo pago a proveedor.
+        cls._create_payment_with_withholdings(
+            cls.env["account.tax"].union(*cls.withholding_taxes.values()), "2035-01-15", price_unit=100000.0
+        )
+        # Retenciones nacionales (IVA y ganancias), las que informa SICORE. La
+        # base es grande porque ganancias tiene mínimo no sujeto a retención.
+        cls._create_payment_with_withholdings(
+            cls.tax_withholding_vat + cls.tax_withholding_earnings, "2035-01-16", price_unit=cls.earnings_base
+        )
+
+        # Percepciones sufridas en compras: IIBB va a SIFERE, IVA al archivo de
+        # IVA sufrido.
+        cls._create_invoice(cls.perception_suffered_taxes["C"], "2035-01-17", move_type="in_invoice")
+        cls._create_invoice(cls.tax_perception_vat_suffered, "2035-01-18", move_type="in_invoice")
+        # Retenciones sufridas en una cobranza.
+        cls._create_payment_with_withholdings(
+            cls.withholding_suffered_iibb + cls.withholding_suffered_vat,
+            "2035-01-19",
+            move_type="out_invoice",
+            price_unit=100000.0,
+        )
+        # Despacho de importación: SIFERE lo separa del resto de las sufridas.
+        cls._create_invoice(
+            cls.perception_suffered_taxes["S"],
+            "2035-01-20",
+            move_type="in_invoice",
+            l10n_latam_document_type_id=cls.env.ref("l10n_ar.dc_desp_imp").id,
+            document_number="1234567890123456",
+        )
+
+    def _reported_move_lines(self, report, prefix, options, line_names, only=None):
+        """Los apuntes que informa la liquidación en las líneas indicadas.
+
+        Salen del mismo método que usa el botón de auditoría del reporte
+        (``_get_audit_line_domain``): es lo que ve el usuario cuando hace clic
+        en el importe de la liquidación.
+        """
+        move_lines = self.env["account.move.line"]
+        for line_name in line_names:
+            report_line = self.env.ref("l10n_ar_account_reports.l10n_ar_%s_report_%s" % (prefix, line_name))
+            expression = report_line.expression_ids.filtered(lambda expr: expr.label == "balance")
+            for column_group_key in options["column_groups"]:
+                move_lines |= self.env["account.move.line"].search(
+                    report._get_audit_line_domain(
+                        report._get_column_group_options(options, column_group_key),
+                        expression,
+                        {"calling_line_dict_id": report._get_generic_line_id("account.report.line", report_line.id)},
+                    )
+                )
+        if only:
+            is_refund = only == "refunds"
+            move_lines = move_lines.filtered(lambda line: (line.move_id.move_type == "out_refund") is is_refund)
+        return move_lines
+
+    def _txt_records(self, file_content):
+        """Los renglones del archivo, sea un TXT o el zip que entrega SIRCAR."""
+        if file_content[:2] == b"PK":
+            with zipfile.ZipFile(io.BytesIO(file_content)) as archive:
+                return [
+                    record
+                    for name in archive.namelist()
+                    for record in archive.read(name).decode("ISO-8859-1").splitlines()
+                ]
+        return file_content.decode("ISO-8859-1").splitlines()
+
+    def test_los_renglones_del_txt_son_los_apuntes_de_la_liquidacion(self):
+        for prefix, method_name, line_names, only, expected, header in TXT_FILES:
+            with self.subTest(method_name):
+                report = self.env.ref("l10n_ar_account_reports.l10n_ar_%s_report" % prefix)
+                options = self._report_options(report, DATE_FROM, DATE_TO)
+                move_lines = self._reported_move_lines(report, prefix, options, line_names, only)
+
+                # El escenario primero: si esto falla, el archivo se está
+                # probando con otros datos y la comparación de abajo no dice nada.
+                self.assertEqual(
+                    len(move_lines),
+                    expected,
+                    "%s: la liquidación informa %s apunte(s) y el escenario tiene %s: %s"
+                    % (method_name, len(move_lines), expected, move_lines.mapped("tax_line_id.name")),
+                )
+
+                handler = self.env["l10n_ar.%s.report.handler" % prefix]
+                records = self._txt_records(getattr(handler, method_name)(options)["file_content"])
+                self.assertEqual(
+                    len(records) - header,
+                    len(move_lines),
+                    "%s: la liquidación informa %s apunte(s) y el archivo trae %s registro(s)\n%s"
+                    % (method_name, len(move_lines), len(records) - header, "\n".join(r[:80] for r in records)),
+                )
+                self.assert_latin1_safe(records, method_name)
+
+    def test_ningun_archivo_se_genera_con_asientos_no_publicados(self):
+        """Un archivo con retenciones en borrador se presenta al organismo con
+        datos que todavía no existen, y después hay que rectificar."""
+        for prefix, method_name, *_rest in TXT_FILES:
+            with self.subTest(method_name):
+                report = self.env.ref("l10n_ar_account_reports.l10n_ar_%s_report" % prefix)
+                options = dict(self._report_options(report, DATE_FROM, DATE_TO), all_entries=True)
+                with self.assertRaises(UserError):
+                    getattr(self.env["l10n_ar.%s.report.handler" % prefix], method_name)(options)


### PR DESCRIPTION
El módulo no tenía tests. Esta es la primera suite, armada sobre un escenario común (`tests/common.py`) con percepciones y retenciones de varias jurisdicciones a la vez, notas de crédito y un despacho de importación. No cambia código de producción.

Tarea: https://www.adhoc.inc/odoo/project.task/72661

## Qué cubre

| Suite | Qué verifica |
|---|---|
| `test_txt_line_count.py` | 19 de los 20 archivos TXT: los renglones del archivo son los apuntes que informa la liquidación en pantalla (mismo dominio que el botón de auditoría del reporte). Verifica también que la codificación ISO-8859-1 no pierda caracteres y que ningún archivo se genere con asientos en borrador |
| `test_sicore_txt.py` | El registro de SICORE campo por campo, como arquetipo de los layouts posicionales, más el corte cuando el retenido no tiene CUIT |
| `test_txt_field_format.py` | Los helpers que comparten los handlers (largo y signo de los importes, punto de venta y número, acentos): un error acá corre las posiciones de todos los archivos a la vez |
| `test_open_bugs.py` | Un bug vivo que salió al escribir la suite (abajo) |

El control central es el de cantidad de renglones porque es el que hace el usuario antes de presentar: si el archivo no informa exactamente los apuntes del período, la presentación va incompleta o con datos de más y el archivo igual sale bien formado, así que nada falla solo.

## Hallazgo abierto

**El archivo de retenciones de Mendoza no se puede generar.** `mendoza_report.py:102` usa la variable `name`, que solo se asigna dentro del `if len(line.name) > 12` de la línea 97. Con la secuencia de retención por defecto (8 dígitos) nunca entra: si es la primera retención del archivo revienta con `UnboundLocalError`, y si vino después de una de más de 12 caracteres informa el número de comprobante de la retención anterior — el archivo sale bien formado y con el dato de otro contribuyente.

`test_open_bugs.py` afirma el comportamiento correcto y por eso queda en rojo, tagueado `-standard` para no teñir el build. Al corregir el bug hay que sacarlo de ahí y sumar Mendoza a la tabla de `test_txt_line_count.py`.

## Qué queda afuera

Los layouts posicionales de las otras nueve familias de archivos (PBA, CABA, SIFERE, SIRCAR, Santa Fe, Misiones, Tucumán, IVA sufrido) quedan verificados a nivel de cantidad de renglones y codificación, no campo por campo. SICORE queda completo como arquetipo y extenderlo es mecánico sobre ese patrón: da para un PR aparte.

## Test plan

```
odoo -d <base> -u l10n_ar_account_reports --test-tags /l10n_ar_account_reports --stop-after-init
```

Para ver el hallazgo de Mendoza en rojo, correr además la suite tagueada:

```
odoo -d <base> --test-tags /l10n_ar_account_reports:TestOpenBugs --stop-after-init
```
