### PR TITLE
[IMP] l10n_ar_wsmtxca_ws: batería de tests del request de CAE

### DIFF
--- a/l10n_ar_wsmtxca_ws/i18n/es.po
+++ b/l10n_ar_wsmtxca_ws/i18n/es.po
@@ -207,6 +207,18 @@ msgstr ""
 
 #. module: l10n_ar_wsmtxca_ws
 #. odoo-python
+#: code:addons/l10n_ar_wsmtxca_ws/models/account_move.py:0
+msgid ""
+"The product coding webservice (RG2904) requires a product on every invoice "
+"line. These lines have none:\n"
+"%s"
+msgstr ""
+"El webservice de codificación de producto (RG2904) requiere un producto en "
+"cada línea de la factura. Estas líneas no lo tienen:\n"
+"%s"
+
+#. module: l10n_ar_wsmtxca_ws
+#. odoo-python
 #: code:addons/l10n_ar_wsmtxca_ws/models/account_journal.py:0
 msgid ""
 "Tipos de Documentos Autorizados en ARCA:\n"

--- a/l10n_ar_wsmtxca_ws/models/account_move.py
+++ b/l10n_ar_wsmtxca_ws/models/account_move.py
@@ -144,14 +144,29 @@ class AccountMove(models.Model):
 
     def _get_line_details(self, base_lines=None):
         """Override to add wsmtxca specific format for line details."""
+        if self.journal_id.l10n_ar_afip_ws != "wsmtxca":
+            return super()._get_line_details(base_lines=base_lines)
+
         base_lines = base_lines or []
-        details = super()._get_line_details(base_lines=base_lines)
-
-        if (afip_ws := self.journal_id.l10n_ar_afip_ws) and afip_ws != "wsmtxca":
-            return details
-
         details = []
         price_precision_digits = min(self.env["decimal.precision"].precision_get("Product Price"), 3)
+
+        # RG2904 informa códigos de producto: una línea sin producto no tiene
+        # código que informar. Las juntamos todas para no corregir de a una.
+        lines_without_product = [
+            base_line["record"].name
+            for base_line in base_lines
+            if base_line["record"].display_type not in ("line_section", "line_note")
+            and not base_line["record"].product_id
+        ]
+        if lines_without_product:
+            raise UserError(
+                _(
+                    "The product coding webservice (RG2904) requires a product on every invoice line."
+                    " These lines have none:\n%s",
+                    "\n".join("* %s" % name for name in lines_without_product),
+                )
+            )
 
         for base_line in base_lines:
             line = base_line["record"]
@@ -326,7 +341,8 @@ class AccountMove(models.Model):
 
         # Post process vat_data
         # Step 1: modify the keys of the dictionary to make it work with wsmtxca
-        vat_needed = ["4", "5", "6"]
+        # 4: 10,5% - 5: 21% - 6: 27% - 8: 5% - 9: 2,5%
+        vat_needed = ["4", "5", "6", "8", "9"]
         for item in vat_data:
             if "Id" in item and "Importe" in item and item.get("Id") in vat_needed:
                 temp.append(

--- a/l10n_ar_wsmtxca_ws/tests/__init__.py
+++ b/l10n_ar_wsmtxca_ws/tests/__init__.py
@@ -1,0 +1,6 @@
+from . import common
+from . import test_invariants
+from . import test_codigo_mtx
+from . import test_items
+from . import test_cae_request
+from . import test_cae_response

--- a/l10n_ar_wsmtxca_ws/tests/common.py
+++ b/l10n_ar_wsmtxca_ws/tests/common.py
@@ -1,0 +1,70 @@
+from odoo.addons.l10n_ar_edi.tests.common import ArMockedClient, TestArEdiCommon
+
+from .invariants import WsmtxcaInvariants
+
+#: GTIN codes handed to the scenario products. Real length variety on purpose:
+#: _get_codigoMtx pads 8 and 12 digit codes to 13.
+SCENARIO_BARCODES = {
+    "product_iva_21": "7791111111118",
+    "product_iva_105": "77922228",
+    "product_iva_105_perc": "779333333336",
+    "product_iva_exento": "7794444444445",
+    "product_no_gravado": "7795555555552",
+    "product_iva_cero": "7796666666669",
+}
+
+
+class TestWsmtxcaCommon(WsmtxcaInvariants, TestArEdiCommon):
+    """Scenario configuration for the wsmtxca suites.
+
+    Sits on top of l10n_ar_edi's common, which already provides the environment
+    (ar_ri chart template, taxes, products) and the local-validation setup: with
+    l10n_ar_afip_ws_environment='testing' and no certificate,
+    _is_dummy_afip_validation() is True and posting an invoice never reaches ARCA.
+
+    Two things upstream does not have and this class adds:
+
+    * the WSMTXCA entry in the POS-system mapping, so _create_journal('wsmtxca')
+      builds the journal;
+    * a _validate_and_review that knows about wsmtxca -- the upstream one walks
+      an if/elif over wsfe/wsfex/wsbfe and ends in self.fail().
+    """
+
+    @classmethod
+    @TestArEdiCommon.setup_afip_ws("wsmtxca")
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.res_partner_adhoc
+        cls.journal = cls._create_journal("wsmtxca")
+        # wsmtxca refuses a physical product without a GS1/GTIN code, so the
+        # scenario loads one on every product the suites invoice.
+        for attribute, barcode in SCENARIO_BARCODES.items():
+            getattr(cls, attribute).barcode = barcode
+
+    @classmethod
+    def _get_afip_pos_system_real_name(cls):
+        mapping = super()._get_afip_pos_system_real_name()
+        mapping.update({"WSMTXCA": "WSMTXCAWS"})
+        return mapping
+
+    def _wsmtxca_request(self, invoice, document_number="12345-12345678"):
+        """Post the invoice and build the CAE request the way the module would.
+
+        Returns the request payload, after running the whole invariants battery
+        over it -- every suite gets layer 2 without asking for it.
+        """
+        self._post(invoice)
+        invoice.l10n_latam_document_number = document_number
+        request_data = invoice.wsmtxca_get_cae_request(ArMockedClient())
+        self.assert_wsmtxca_invariants(invoice, request_data)
+        return request_data
+
+    def _validate_and_review(self, invoice, test_name: str, document_number="12345-12345678", skip_assert_json=False):
+        """Extend to build the request through wsmtxca_get_cae_request.
+
+        The upstream implementation only knows wsfe, wsfex and wsbfe and calls
+        self.fail() for anything else.
+        """
+        if invoice.journal_id.l10n_ar_afip_ws != "wsmtxca":
+            return super()._validate_and_review(invoice, test_name, document_number, skip_assert_json)
+        return self._wsmtxca_request(invoice, document_number=document_number)

--- a/l10n_ar_wsmtxca_ws/tests/invariants.py
+++ b/l10n_ar_wsmtxca_ws/tests/invariants.py
@@ -1,0 +1,144 @@
+"""Battery of invariants for every wsmtxca CAE request.
+
+These are the properties that must hold after *any* wsmtxca request is built,
+whatever the individual test went looking for. ``TestWsmtxcaCommon`` runs the
+whole battery on every request it builds, so each suite gets them for free.
+
+The battery has no switches to skip an invariant. A scenario that legitimately
+breaks one declares the exception in the test itself, in plain sight and with
+the reason next to it.
+
+It lives in this module (and not in a module further up the chain) because
+every invariant reads keys of the wsmtxca payload, which is defined here:
+``l10n_ar_edi`` is Odoo's and knows nothing about wsmtxca, and
+``saas_client_l10n_ar`` does not build ARCA requests.
+"""
+
+from odoo.tools.float_utils import float_compare
+
+
+def payload_float(value):
+    """Read a payload amount as a float.
+
+    wsmtxca_get_cae_request mixes types on purpose: most amounts travel as
+    strings built with float_repr, a few as plain floats, and the optional ones
+    as None.
+    """
+    if value is None:
+        return 0.0
+    return float(value)
+
+
+def payload_decimals(value):
+    """Count the decimal digits actually written in the payload."""
+    text = value if isinstance(value, str) else repr(float(value))
+    return len(text.partition(".")[2])
+
+
+class WsmtxcaInvariants:
+    """Mixin with the battery. Inherited by TestWsmtxcaCommon."""
+
+    #: decimals ARCA accepts for each payload amount, per the wsmtxca spec
+    WSMTXCA_ITEM_MAX_DECIMALS = {"importeItem": 2, "importeIVA": 2, "importeBonificacion": 6}
+    WSMTXCA_RATE_MAX_DECIMALS = 6
+
+    def assert_wsmtxca_invariants(self, invoice, request_data):
+        """Run the whole battery over one built request."""
+        self.assert_amounts_add_up(request_data)
+        self.assert_arca_total_identity(request_data)
+        self.assert_items_add_up_to_total(request_data)
+        self.assert_no_negative_quantities(request_data)
+        self.assert_items_have_codigo_mtx(request_data)
+        self.assert_declared_precision(request_data)
+        self.assert_move_is_sound(invoice)
+
+    def assert_amounts_add_up(self, request_data):
+        """ARCA cross-check: the subtotal is the sum of the three taxable bases."""
+        expected = request_data["importeGravado"] + request_data["importeExento"] + request_data["importeNoGravado"]
+        self.assertEqual(
+            float_compare(request_data["importeSubtotal"], expected, precision_digits=2),
+            0,
+            "importeSubtotal (%s) must equal importeGravado + importeExento + importeNoGravado (%s)"
+            % (request_data["importeSubtotal"], expected),
+        )
+
+    def assert_arca_total_identity(self, request_data):
+        """The identity ARCA cross-checks on the envelope: the total is the
+        subtotal plus every VAT subtotal plus the non-VAT tributes.
+
+        This is what caught the 5% and 2,5% rates missing from
+        arraySubtotalesIVA: _l10n_ar_get_amounts counts the base of *any* code
+        other than 0, 1 and 2 into importeGravado and the tax into importeTotal,
+        so a rate left out of wsmtxca_get_cae_request's vat_needed broke the
+        identity by exactly its VAT. Code 3 (0%) stays out of vat_needed on
+        purpose: its amount is zero, so it does not move this identity.
+        """
+        vat_total = sum(payload_float(entry["importe"]) for entry in request_data["arraySubtotalesIVA"] or [])
+        expected = request_data["importeSubtotal"] + vat_total + payload_float(request_data.get("importeOtrosTributos"))
+        self.assertEqual(
+            float_compare(request_data["importeTotal"], expected, precision_digits=2),
+            0,
+            "importeTotal (%s) must equal importeSubtotal plus the VAT subtotals plus importeOtrosTributos (%s)"
+            % (request_data["importeTotal"], expected),
+        )
+
+    def assert_items_add_up_to_total(self, request_data):
+        """ARCA cross-check behind error 519: the items plus the non-VAT
+        tributes must add up to the invoice total."""
+        items_total = sum(payload_float(item["importeItem"]) for item in request_data["arrayItems"])
+        expected = items_total + payload_float(request_data.get("importeOtrosTributos"))
+        self.assertEqual(
+            float_compare(request_data["importeTotal"], expected, precision_digits=2),
+            0,
+            "importeTotal (%s) must equal the sum of importeItem plus importeOtrosTributos (%s)"
+            % (request_data["importeTotal"], expected),
+        )
+
+    def assert_no_negative_quantities(self, request_data):
+        """wsmtxca rejects a negative cantidad or precioUnitario for *any* unit
+        of measure, "00" included: such a line must travel as importeItem only."""
+        for position, item in enumerate(request_data["arrayItems"], start=1):
+            for key in ("cantidad", "precioUnitario"):
+                if item[key] is None:
+                    continue
+                self.assertGreaterEqual(
+                    payload_float(item[key]),
+                    0.0,
+                    "item %s reports a negative %s (%s); wsmtxca rejects it" % (position, key, item[key]),
+                )
+
+    def assert_items_have_codigo_mtx(self, request_data):
+        """Every item carries the 13-digit product code the webservice is named after."""
+        for position, item in enumerate(request_data["arrayItems"], start=1):
+            codigo = item["codigoMtx"]
+            self.assertTrue(
+                isinstance(codigo, str) and codigo.isdigit() and len(codigo) == 13,
+                "item %s has an invalid codigoMtx (%r); ARCA expects 13 digits" % (position, codigo),
+            )
+
+    def assert_declared_precision(self, request_data):
+        """No amount travels with more decimals than ARCA declares for it."""
+        for position, item in enumerate(request_data["arrayItems"], start=1):
+            for key, max_decimals in self.WSMTXCA_ITEM_MAX_DECIMALS.items():
+                if item.get(key) is None:
+                    continue
+                self.assertLessEqual(
+                    payload_decimals(item[key]),
+                    max_decimals,
+                    "item %s reports %s with more than %s decimals (%s)" % (position, key, max_decimals, item[key]),
+                )
+        self.assertLessEqual(
+            payload_decimals(request_data["cotizacionMoneda"]),
+            self.WSMTXCA_RATE_MAX_DECIMALS,
+            "cotizacionMoneda reports more than %s decimals (%s)"
+            % (self.WSMTXCA_RATE_MAX_DECIMALS, request_data["cotizacionMoneda"]),
+        )
+
+    def assert_move_is_sound(self, invoice):
+        """Building the request never leaves the accounting entry behind."""
+        self.assertEqual(invoice.state, "posted", "the invoice the request was built from is not posted")
+        balance = sum(invoice.line_ids.mapped("balance"))
+        self.assertEqual(
+            float_compare(balance, 0.0, precision_digits=2), 0, "the accounting entry does not balance (%s)" % balance
+        )
+        self.assertTrue(invoice.l10n_ar_afip_auth_code, "the posted invoice has no ARCA authorization code")

--- a/l10n_ar_wsmtxca_ws/tests/test_cae_request.py
+++ b/l10n_ar_wsmtxca_ws/tests/test_cae_request.py
@@ -1,0 +1,151 @@
+from odoo.tests import tagged
+
+from .common import TestWsmtxcaCommon
+
+
+@tagged("post_install", "post_install_l10n", "-at_install", *TestWsmtxcaCommon.extra_tags)
+class TestWsmtxcaCaeRequest(TestWsmtxcaCommon):
+    """The envelope around the items: dates, totals, VAT subtotals, tributes and
+    the keys that only some document types carry."""
+
+    def test_wsmtxca_cae_request_envelope(self):
+        """Task 68095: the request identifies the document the way wsmtxca wants
+        -- ISO dates instead of the compact ones the other webservices use, one
+        VAT subtotal per rate in play, and the perceptions as other tributes.
+
+        Covers behaviours 21, 23 and 24 of the survey.
+        """
+        # The scenario turns the IIBB perception on and gives it a rate: the base
+        # ships it disabled and at 0%, which would make it invisible in the request
+        perception = self._search_tax("percepcion_iibb_ba")
+        perception.write({"active": True, "amount": 3.5})
+
+        invoice = self._create_invoice_ar(
+            invoice_line_ids=[
+                # 21% and 10,5% together, and the 10,5% one also bears the perception
+                self._prepare_invoice_line(product_id=self.product_iva_21, price_unit=1000.0),
+                self._prepare_invoice_line(product_id=self.product_iva_105, price_unit=2000.0),
+            ],
+        )
+        invoice.invoice_line_ids.filtered(lambda line: line.product_id == self.product_iva_105).tax_ids = [
+            (4, perception.id)
+        ]
+        self.assertIn(perception.name, invoice.invoice_line_ids.tax_ids.mapped("name"))
+
+        request_data = self._wsmtxca_request(invoice)
+
+        with self.subTest("dates travel in ISO format, not in the compact one the other webservices use"):
+            self.assertEqual(request_data["fechaEmision"], invoice.invoice_date.strftime("%Y-%m-%d"))
+
+        with self.subTest("the document is identified by type, point of sale and number"):
+            self.assertEqual(request_data["codigoTipoComprobante"], int(invoice.l10n_latam_document_type_id.code))
+            self.assertEqual(request_data["numeroPuntoVenta"], int(self.journal.l10n_ar_afip_pos_number))
+            self.assertEqual(request_data["numeroComprobante"], 12345678)
+
+        with self.subTest("every VAT rate in play gets its own subtotal, keyed by the ARCA code"):
+            # 5 is 21% and 4 is 10,5%
+            self.assertEqual(sorted(entry["codigo"] for entry in request_data["arraySubtotalesIVA"]), ["4", "5"])
+
+        with self.subTest("the perception travels as another tribute, with the wsmtxca key names"):
+            tributes = request_data["arrayOtrosTributos"]
+            self.assertEqual(len(tributes), 1)
+            self.assertEqual(sorted(tributes[0]), ["baseImponible", "codigo", "descripcion", "importe"])
+            self.assertEqual(request_data["importeOtrosTributos"], tributes[0]["importe"])
+
+    def test_wsmtxca_cae_request_foreign_currency(self):
+        """Task 68095: in foreign currency the request carries the rate ARCA
+        expects and declares whether the invoice is settled in that currency.
+
+        Covers behaviours 26 and 29 of the survey.
+        """
+        self._prepare_multicurrency_values()
+        usd = self.env.ref("base.USD")
+
+        with self.subTest("in pesos the settlement key is not reported at all"):
+            request_data = self._wsmtxca_request(self._create_invoice_ar())
+            self.assertEqual(request_data["codigoMoneda"], "PES")
+            self.assertNotIn("cancelaEnMismaMonedaExtranjera", request_data)
+
+        with self.subTest("in dollars the rate and the settlement key are reported"):
+            invoice = self._create_invoice_ar(currency_id=usd)
+            request_data = self._wsmtxca_request(invoice, document_number="12345-12345679")
+            self.assertEqual(request_data["codigoMoneda"], "DOL")
+            # The rate travels inverted: pesos per unit of foreign currency
+            self.assertEqual(request_data["cotizacionMoneda"], "%.6f" % (1 / invoice.invoice_currency_rate))
+            self.assertEqual(request_data["cancelaEnMismaMonedaExtranjera"], "N")
+
+    def test_wsmtxca_cae_request_mipyme_due_date(self):
+        """Task 68095: a MiPyME invoice always reports the payment due date --
+        ARCA rejects it otherwise (WSMT148).
+
+        Covers behaviour 27 of the survey.
+        """
+        mipyme = self.env["l10n_latam.document.type"].search(
+            [("code", "=", "201"), ("country_id", "=", self.env.ref("base.ar").id)], limit=1
+        )
+        invoice = self._create_invoice_ar(l10n_latam_document_type_id=mipyme)
+        self.assertEqual(invoice.l10n_latam_document_type_id.code, "201")
+
+        request_data = self._wsmtxca_request(invoice)
+
+        self.assertTrue(request_data["fechaVencimientoPago"])
+        self.assertEqual(request_data["fechaVencimientoPago"], invoice.invoice_date_due.strftime("%Y-%m-%d"))
+
+    def test_wsmtxca_credit_note_reports_the_related_invoice(self):
+        """Task 68095: a credit note carries the invoice it cancels, keyed the
+        wsmtxca way, so ARCA can match them.
+
+        Covers behaviour 25 of the survey.
+        """
+        invoice = self._create_invoice_ar()
+        self._wsmtxca_request(invoice)
+
+        # Reversing produces the credit note that has to point back at the invoice
+        credit_note = self._reverse_invoice(invoice, reason="Mercadería defectuosa")
+        request_data = self._wsmtxca_request(credit_note, document_number="12345-12345679")
+
+        related = request_data["arrayComprobantesAsociados"]
+        self.assertEqual(len(related), 1)
+        self.assertEqual(
+            related[0],
+            {
+                "codigoTipoComprobante": invoice.l10n_latam_document_type_id.code,
+                "numeroPuntoVenta": invoice.journal_id.l10n_ar_afip_pos_number,
+                "numeroComprobante": 12345678,
+            },
+        )
+
+    def test_wsmtxca_reduced_vat_rates_reach_the_subtotals(self):
+        """Task 68095: the 5% and 2,5% rates report their own VAT subtotal.
+
+        Until vat_needed grew, only 10,5%, 21% and 27% were reported, while
+        _l10n_ar_get_amounts counted the base of any code other than 0, 1 and 2
+        into importeGravado and the tax into importeTotal -- so an invoice at 5%
+        left ARCA's envelope short by exactly that VAT. The battery's
+        assert_arca_total_identity is what closes it on every case.
+        """
+        for label, tax_type, code, amount in (
+            ("5% reports subtotal code 8", "iva_5", "8", "50.00"),
+            ("2,5% reports subtotal code 9", "iva_025", "9", "25.00"),
+        ):
+            with self.subTest(label), self.cr.savepoint() as savepoint:
+                tax = self._search_tax(tax_type)
+                invoice = self._create_invoice_ar(
+                    invoice_line_ids=[
+                        self._prepare_invoice_line(product_id=self.product_iva_21, price_unit=1000.0, tax_ids=tax)
+                    ],
+                )
+
+                request_data = self._wsmtxca_request(invoice)
+
+                self.assertEqual(request_data["arraySubtotalesIVA"], [{"codigo": code, "importe": amount}])
+                savepoint.close()  # every case starts from the same situation
+
+    def test_wsmtxca_invoice_without_related_reports_no_association(self):
+        """Task 68095: an ordinary invoice carries no association array -- ARCA
+        rejects an empty one.
+
+        Covers behaviour 25 of the survey, negative side.
+        """
+        request_data = self._wsmtxca_request(self._create_invoice_ar())
+        self.assertIsNone(request_data["arrayComprobantesAsociados"])

--- a/l10n_ar_wsmtxca_ws/tests/test_cae_response.py
+++ b/l10n_ar_wsmtxca_ws/tests/test_cae_response.py
@@ -1,0 +1,141 @@
+"""What the module does with what ARCA answers.
+
+_l10n_ar_do_afip_ws_request_cae takes the client, the ticket and the transport
+as arguments, so the response handling can be exercised by handing it a stand-in
+for the three -- no connection is patched and no network is reached. What is
+faked is the transport, never the code under test.
+"""
+
+from types import SimpleNamespace
+
+from odoo.tests import tagged
+
+from .common import TestWsmtxcaCommon
+
+FAKE_AUTH = {"Token": "a-token", "Sign": "a-sign", "Cuit": "30111111118"}
+FAKE_CAE = "70417054367476"
+
+
+def code_description(code, description):
+    return SimpleNamespace(codigo=code, descripcion=description)
+
+
+class FakeService(dict):
+    """client.service[ws_method] -- returns the canned response."""
+
+    def __init__(self, response):
+        super().__init__()
+        self.response = response
+
+    def __getitem__(self, _ws_method):
+        return lambda *args, **kwargs: self.response
+
+
+class FakeClient:
+    """Stand-in for the zeep client: builds the array types and answers the call."""
+
+    def __init__(self, response):
+        self.service = FakeService(response)
+        # _ws_verify_request_data validates the payload against the WSDL through
+        # this private attribute; with no WSDL at hand it is a no-op here.
+        self._Client__obj = SimpleNamespace(service=None, create_message=lambda *args, **kwargs: None)
+
+    @staticmethod
+    def get_type(_type_name):
+        return lambda argument: argument
+
+
+def arca_response(resultado="A", cae=FAKE_CAE, errors=None, observations=None, event=None):
+    """A wsmtxca autorizarComprobante response, shaped like zeep returns it."""
+    return SimpleNamespace(
+        resultado=resultado,
+        comprobanteResponse=SimpleNamespace(CAE=cae, fechaVencimientoCAE="2026-12-31") if cae else None,
+        arrayErrores=SimpleNamespace(codigoDescripcion=errors) if errors else None,
+        arrayObservaciones=SimpleNamespace(codigoDescripcion=observations) if observations else None,
+        evento=event,
+    )
+
+
+@tagged("post_install", "post_install_l10n", "-at_install", *TestWsmtxcaCommon.extra_tags)
+class TestWsmtxcaCaeResponse(TestWsmtxcaCommon):
+    def _invoice_awaiting_cae(self, document_number="12345-12345678"):
+        """A posted invoice with the local authorization cleared, so the module
+        treats it as still pending at ARCA."""
+        invoice = self._create_invoice_ar()
+        self._post(invoice)
+        invoice.l10n_latam_document_number = document_number
+        invoice.sudo().write({"l10n_ar_afip_auth_code": False, "l10n_ar_afip_auth_mode": False})
+        return invoice.with_context(l10n_ar_invoice_skip_commit=True)
+
+    def _request_cae(self, invoice, response):
+        transport = SimpleNamespace(xml_request="<request/>", xml_response="<response/>")
+        return invoice._l10n_ar_do_afip_ws_request_cae(FakeClient(response), FAKE_AUTH, transport)
+
+    def test_wsmtxca_authorized_invoice_keeps_the_cae(self):
+        """Task 68095: an authorized answer lands on the invoice -- code, due
+        date, result and both XML payloads.
+
+        Covers behaviour 30 of the survey.
+        """
+        invoice = self._invoice_awaiting_cae()
+
+        return_info = self._request_cae(invoice, arca_response())
+
+        self.assertFalse(return_info, "an authorized invoice reports no error back")
+        self.assertEqual(invoice.l10n_ar_afip_auth_mode, "CAE")
+        self.assertEqual(invoice.l10n_ar_afip_auth_code, FAKE_CAE)
+        self.assertEqual(invoice.l10n_ar_afip_result, "A")
+        self.assertEqual(invoice.l10n_ar_afip_xml_request, "<request/>")
+        self.assertEqual(invoice.l10n_ar_afip_xml_response, "<response/>")
+
+    def test_wsmtxca_observed_invoice_reports_the_observations(self):
+        """Task 68095: an observed answer is still an authorization -- the CAE is
+        kept and the observations reach the chatter.
+
+        Covers behaviours 30 and 32 of the survey.
+        """
+        invoice = self._invoice_awaiting_cae()
+        messages_before = len(invoice.message_ids)
+
+        self._request_cae(
+            invoice,
+            arca_response(resultado="O", observations=[code_description(10192, "Se aceptó con observaciones")]),
+        )
+
+        self.assertEqual(invoice.l10n_ar_afip_auth_code, FAKE_CAE)
+        self.assertEqual(invoice.l10n_ar_afip_result, "O")
+        self.assertGreater(len(invoice.message_ids), messages_before, "the observations were not posted")
+        self.assertIn("10192", invoice.message_ids[0].body)
+
+    def test_wsmtxca_rejected_invoice_gets_no_cae(self):
+        """Task 68095: a rejected answer leaves the invoice without a CAE, keeps
+        the XML for diagnosis and hands the error message back to the caller.
+
+        Covers behaviour 31 of the survey.
+        """
+        invoice = self._invoice_awaiting_cae()
+
+        return_info = self._request_cae(
+            invoice, arca_response(resultado="R", cae=None, errors=[code_description(10016, "Comprobante rechazado")])
+        )
+
+        self.assertTrue(return_info, "a rejected invoice must hand the error back to the caller")
+        self.assertIn("10016", return_info)
+        self.assertFalse(invoice.l10n_ar_afip_auth_code, "a rejected invoice must not keep a CAE")
+        self.assertEqual(invoice.l10n_ar_afip_xml_response, "<response/>")
+
+    def test_wsmtxca_leaves_other_webservices_alone(self):
+        """Task 68095: an invoice on another webservice is not touched by the
+        wsmtxca branch.
+
+        Covers behaviour 33 of the survey.
+        """
+        wsfe_journal = self._create_journal("wsfe", data={"code": "WSFE1"})
+        invoice = self._create_invoice_ar(journal_id=wsfe_journal)
+        self._post(invoice)
+        cae_before = invoice.l10n_ar_afip_auth_code
+
+        # The wsmtxca handler must delegate and leave the invoice as it found it
+        self._request_cae(invoice.with_context(l10n_ar_invoice_skip_commit=True), arca_response())
+
+        self.assertEqual(invoice.l10n_ar_afip_auth_code, cae_before)

--- a/l10n_ar_wsmtxca_ws/tests/test_codigo_mtx.py
+++ b/l10n_ar_wsmtxca_ws/tests/test_codigo_mtx.py
@@ -1,0 +1,86 @@
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+from .common import TestWsmtxcaCommon
+
+
+@tagged("post_install", "post_install_l10n", "-at_install", *TestWsmtxcaCommon.extra_tags)
+class TestWsmtxcaCodigoMtx(TestWsmtxcaCommon):
+    """The product coding is what RG2904 is about: every line has to travel with
+    a code ARCA recognises, either the product's own GTIN or one of the generic
+    ones."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # A physical product with no GTIN loaded: the case the module must reject
+        cls.product_without_barcode = cls.env["product.product"].create(
+            {"name": "Cabinet with no GTIN", "type": "consu", "taxes_id": [(6, 0, cls.tax_21.ids)]}
+        )
+        # A GTIN that is not a GS1 code: the other case the module must reject
+        cls.product_bad_barcode = cls.env["product.product"].create(
+            {"name": "Cabinet with a bad GTIN", "type": "consu", "barcode": "NOT-A-GTIN"}
+        )
+
+    def _line(self, **line_args):
+        """A single draft invoice line to hand to _get_codigoMtx."""
+        invoice = self._create_invoice_ar(invoice_line_ids=[self._prepare_invoice_line(**line_args)])
+        return invoice, invoice.invoice_line_ids
+
+    def test_wsmtxca_codigo_mtx_per_kind_of_line(self):
+        """Task 68095: each kind of line resolves to the codigoMtx ARCA expects.
+
+        Covers behaviours 8 to 13 of the survey.
+        """
+        for label, line_args, expected in (
+            ("a 13 digit GTIN travels as is", {"product_id": self.product_iva_21, "price_unit": 100}, "7791111111118"),
+            (
+                "an 8 digit GTIN is padded to 13",
+                {"product_id": self.product_iva_105, "price_unit": 100},
+                "0000077922228",
+            ),
+            (
+                "a 12 digit GTIN is padded to 13",
+                {"product_id": self.product_iva_105_perc, "price_unit": 100},
+                "0779333333336",
+            ),
+            (
+                "a service with no GTIN falls back to the generic services code",
+                {"product_id": self.service_iva_27, "price_unit": 100},
+                "7790001001078",
+            ),
+            (
+                # Unreachable through the real flow: _get_line_details rejects a
+                # line with no product. Kept because _get_codigoMtx still
+                # documents the fallback and other callers could hit it.
+                "a line with no product falls back to the generic sales code",
+                {"price_unit": 100, "tax_ids": self.tax_21},
+                "7790001001054",
+            ),
+            (
+                "a negative line with no GTIN falls back to the generic discounts code",
+                {"product_id": self.product_without_barcode, "price_unit": -100},
+                "7790001001030",
+            ),
+        ):
+            with self.subTest(label), self.cr.savepoint() as savepoint:
+                invoice, line = self._line(**line_args)
+                self.assertEqual(invoice._get_codigoMtx(line), expected)
+                savepoint.close()  # every case starts from the same situation
+
+    def test_wsmtxca_codigo_mtx_rejects_what_arca_would(self):
+        """Task 68095: the two positive controls -- the module blocks the lines
+        ARCA has no code for, instead of inventing one.
+
+        Covers behaviours 9 and 13 of the survey.
+        """
+        with self.subTest("a GTIN that is not GS1 is rejected"), self.cr.savepoint() as savepoint:
+            invoice, line = self._line(product_id=self.product_bad_barcode, price_unit=100)
+            with self.assertRaisesRegex(UserError, "invalid barcode for ARCA"):
+                invoice._get_codigoMtx(line)
+            savepoint.close()
+
+        with self.subTest("a physical product with no GTIN is rejected"):
+            invoice, line = self._line(product_id=self.product_without_barcode, price_unit=100)
+            with self.assertRaisesRegex(UserError, "does not have a valid Codigo MTX"):
+                invoice._get_codigoMtx(line)

--- a/l10n_ar_wsmtxca_ws/tests/test_invariants.py
+++ b/l10n_ar_wsmtxca_ws/tests/test_invariants.py
@@ -1,0 +1,134 @@
+"""Each invariant of the battery, probed in both directions.
+
+A shared battery concentrates risk: if one of its assertions stops looking,
+every suite stays green while verifying nothing. So each invariant is exercised
+twice -- with a sound request (it must not complain) and with the exact defect
+it exists to catch (it must complain).
+"""
+
+import copy
+
+from odoo.tests import tagged
+
+from .common import TestWsmtxcaCommon
+
+#: A request that satisfies every invariant. Each test deep-copies it and
+#: breaks one thing.
+SOUND_REQUEST = {
+    "importeTotal": 121.0,
+    "importeSubtotal": 100.0,
+    "importeGravado": 100.0,
+    "importeExento": 0.0,
+    "importeNoGravado": 0.0,
+    "importeOtrosTributos": None,
+    "arraySubtotalesIVA": [{"codigo": "5", "importe": "21.00"}],
+    "cotizacionMoneda": "1.000000",
+    "arrayItems": [
+        {
+            "codigoMtx": "7791111111118",
+            "descripcion": "Large Cabinet (VAT 21)",
+            "cantidad": 1.0,
+            "precioUnitario": "100.000",
+            "importeItem": "121.00",
+            "importeIVA": "21.00",
+            "importeBonificacion": None,
+        }
+    ],
+}
+
+
+@tagged("post_install", "post_install_l10n", "-at_install", *TestWsmtxcaCommon.extra_tags)
+class TestWsmtxcaInvariants(TestWsmtxcaCommon):
+    def _broken(self, **overrides):
+        """A copy of the sound request with the top-level keys replaced."""
+        request = copy.deepcopy(SOUND_REQUEST)
+        request.update(overrides)
+        return request
+
+    def _broken_item(self, **overrides):
+        """A copy of the sound request with the single item's keys replaced."""
+        request = copy.deepcopy(SOUND_REQUEST)
+        request["arrayItems"][0].update(overrides)
+        return request
+
+    def test_invariant_amounts_add_up(self):
+        """The subtotal cross-check catches a subtotal that is not the sum of the bases."""
+        with self.subTest("a sound request does not complain"):
+            self.assert_amounts_add_up(SOUND_REQUEST)
+        with self.subTest("a subtotal that ignores a base is caught"):
+            with self.assertRaises(AssertionError):
+                self.assert_amounts_add_up(self._broken(importeNoGravado=50.0))
+
+    def test_invariant_arca_total_identity(self):
+        """The envelope cross-check catches VAT that the total counts and no
+        subtotal reports -- the shape survey scenario 43 would take."""
+        with self.subTest("a sound request does not complain"):
+            self.assert_arca_total_identity(SOUND_REQUEST)
+        with self.subTest("a VAT rate missing from the subtotals is caught"):
+            # Exactly what dropping code 8 or 9 from vat_needed would produce
+            with self.assertRaises(AssertionError):
+                self.assert_arca_total_identity(self._broken(arraySubtotalesIVA=[]))
+        with self.subTest("a tribute left out of the total is caught"):
+            with self.assertRaises(AssertionError):
+                self.assert_arca_total_identity(self._broken(importeOtrosTributos=10.0))
+
+    def test_invariant_items_add_up_to_total(self):
+        """The error-519 cross-check catches items that do not add up to the total."""
+        with self.subTest("a sound request does not complain"):
+            self.assert_items_add_up_to_total(SOUND_REQUEST)
+        with self.subTest("an item reporting the net instead of the total is caught"):
+            with self.assertRaises(AssertionError):
+                self.assert_items_add_up_to_total(self._broken_item(importeItem="100.00"))
+        with self.subTest("a tribute left out of the total is caught"):
+            with self.assertRaises(AssertionError):
+                self.assert_items_add_up_to_total(self._broken(importeOtrosTributos=10.0))
+
+    def test_invariant_no_negative_quantities(self):
+        """The check catches the negative cantidad/precioUnitario wsmtxca rejects."""
+        with self.subTest("a sound request does not complain"):
+            self.assert_no_negative_quantities(SOUND_REQUEST)
+        with self.subTest("a negative quantity is caught"):
+            with self.assertRaises(AssertionError):
+                self.assert_no_negative_quantities(self._broken_item(cantidad=-1.0))
+        with self.subTest("a negative unit price is caught"):
+            with self.assertRaises(AssertionError):
+                self.assert_no_negative_quantities(self._broken_item(precioUnitario="-100.000"))
+        with self.subTest("omitting both fields is the accepted way out"):
+            self.assert_no_negative_quantities(self._broken_item(cantidad=None, precioUnitario=None))
+
+    def test_invariant_items_have_codigo_mtx(self):
+        """The check catches a product code ARCA would not accept."""
+        with self.subTest("a sound request does not complain"):
+            self.assert_items_have_codigo_mtx(SOUND_REQUEST)
+        with self.subTest("a code that is not 13 digits long is caught"):
+            with self.assertRaises(AssertionError):
+                self.assert_items_have_codigo_mtx(self._broken_item(codigoMtx="77911"))
+        with self.subTest("a non numeric code is caught"):
+            with self.assertRaises(AssertionError):
+                self.assert_items_have_codigo_mtx(self._broken_item(codigoMtx="ABC1111111118"))
+        with self.subTest("a missing code is caught"):
+            with self.assertRaises(AssertionError):
+                self.assert_items_have_codigo_mtx(self._broken_item(codigoMtx=None))
+
+    def test_invariant_declared_precision(self):
+        """The check catches an amount with more decimals than ARCA accepts."""
+        with self.subTest("a sound request does not complain"):
+            self.assert_declared_precision(SOUND_REQUEST)
+        with self.subTest("an item amount with four decimals is caught"):
+            with self.assertRaises(AssertionError):
+                self.assert_declared_precision(self._broken_item(importeItem="121.0000"))
+        with self.subTest("a rate with more than six decimals is caught"):
+            with self.assertRaises(AssertionError):
+                self.assert_declared_precision(self._broken(cotizacionMoneda="1.0000000"))
+        with self.subTest("the six decimals of importeBonificacion are allowed"):
+            self.assert_declared_precision(self._broken_item(importeBonificacion="10.123456"))
+
+    def test_invariant_move_is_sound(self):
+        """The check catches an entry that never got posted."""
+        invoice = self._create_invoice_ar()
+        with self.subTest("a draft invoice is caught"):
+            with self.assertRaises(AssertionError):
+                self.assert_move_is_sound(invoice)
+        with self.subTest("the same invoice, posted, does not complain"):
+            self._post(invoice)
+            self.assert_move_is_sound(invoice)

--- a/l10n_ar_wsmtxca_ws/tests/test_items.py
+++ b/l10n_ar_wsmtxca_ws/tests/test_items.py
@@ -1,0 +1,146 @@
+from odoo.exceptions import UserError
+from odoo.fields import Command
+from odoo.tests import tagged
+
+from .common import TestWsmtxcaCommon
+
+
+@tagged("post_install", "post_install_l10n", "-at_install", *TestWsmtxcaCommon.extra_tags)
+class TestWsmtxcaItems(TestWsmtxcaCommon):
+    """arrayItems is where the letter of the invoice, the discounts and the
+    negative lines all land on the same amounts. That is where wsmtxca rejects."""
+
+    def _invoice_with_discounted_line(self, partner):
+        """One line, 2 units at 100 with a 25% discount, plus a section and a note."""
+        return self._create_invoice_ar(
+            partner_id=partner,
+            invoice_line_ids=[
+                Command.create({"display_type": "line_section", "name": "Section that carries no amount"}),
+                self._prepare_invoice_line(product_id=self.product_iva_21, price_unit=100.0, quantity=2, discount=25.0),
+                Command.create({"display_type": "line_note", "name": "Note that carries no amount"}),
+            ],
+        )
+
+    def test_wsmtxca_items_letter_a_and_b(self):
+        """Task 68095: letter A reports the net unit price with the VAT apart,
+        letter B reports the unit price with the VAT inside; both land on the
+        same importeItem, and neither turns a section or a note into an item.
+
+        Covers behaviours 14, 15, 16 and 20 of the survey.
+        """
+        # Same economics under both letters: 2 x 100 with 25% off is 150 net, 181.50 gross
+        for label, partner, document_code, unit_price, discount, vat in (
+            (
+                "letter A reports the net unit price and the VAT apart",
+                self.partner_ri,
+                "1",
+                100.0,
+                "50.000000",
+                "31.50",
+            ),
+            ("letter B reports the unit price with the VAT inside", self.partner_cf, "6", 121.0, "60.500000", None),
+        ):
+            with self.subTest(label), self.cr.savepoint() as savepoint:
+                invoice = self._invoice_with_discounted_line(partner)
+                self.assertEqual(invoice.l10n_latam_document_type_id.code, document_code)
+
+                request_data = self._wsmtxca_request(invoice)
+
+                # The section and the note do not reach ARCA, only the real line does
+                self.assertEqual(len(request_data["arrayItems"]), 1)
+                item = request_data["arrayItems"][0]
+                # The amount is the behaviour; how many decimals it is written with
+                # follows the Product Price precision and the battery checks it
+                self.assertEqual(float(item["precioUnitario"]), unit_price)
+                self.assertEqual(item["importeBonificacion"], discount)
+                self.assertEqual(item["importeIVA"], vat)
+                # importeItem is the same under both letters: it is what the customer pays
+                self.assertEqual(item["importeItem"], "181.50")
+                self.assertEqual(item["cantidad"], 2.0)
+                savepoint.close()  # every case starts from the same situation
+
+    def test_wsmtxca_items_negative_line_travels_without_quantity(self):
+        """Task 68095: wsmtxca rejects a negative cantidad or precioUnitario for
+        any unit of measure, "00" included, so a negative line goes out as
+        bonificacion (99) carrying only its negative importeItem.
+
+        Covers behaviour 19 of the survey, for lines that carry a product --
+        which is every line that reaches here: a line with no product is now
+        rejected outright (see test_wsmtxca_items_reject_line_without_product),
+        so the "00" unit of measure and the catch-all behind it are unreachable
+        by design.
+        """
+        invoice = self._create_invoice_ar(
+            invoice_line_ids=[
+                self._prepare_invoice_line(product_id=self.product_iva_21, price_unit=500.0),
+                self._prepare_invoice_line(product_id=self.product_iva_21, price_unit=-100.0),
+            ],
+        )
+
+        request_data = self._wsmtxca_request(invoice)
+
+        items = request_data["arrayItems"]
+        self.assertEqual(len(items), 2)
+        positive, negative = items
+        # The ordinary line keeps its unit of measure and reports quantity and price
+        self.assertEqual(positive["codigoUnidadMedida"], 7)
+        self.assertEqual(positive["cantidad"], 1.0)
+        # The negative one is reported as a discount, with both offending fields omitted
+        self.assertEqual(negative["codigoUnidadMedida"], 99)
+        self.assertIsNone(negative["cantidad"])
+        self.assertIsNone(negative["precioUnitario"])
+        self.assertEqual(negative["importeItem"], "-121.00")
+
+    def test_wsmtxca_items_reject_uom_without_afip_code(self):
+        """Task 68095: a product whose unit of measure has no ARCA code is
+        blocked instead of travelling with a made up one.
+
+        Covers behaviour 17 of the survey.
+        """
+        # Take the ARCA code off the unit of measure the scenario product uses
+        self.product_iva_21.uom_id.l10n_ar_afip_code = False
+        invoice = self._create_invoice_ar()
+
+        with self.assertRaisesRegex(UserError, "No AFIP code in .* UOM"):
+            self._wsmtxca_request(invoice)
+
+    def test_wsmtxca_line_details_delegate_for_other_journals(self):
+        """Task 68095: only a wsmtxca journal gets the wsmtxca item format --
+        every other journal, including one with no webservice at all, gets
+        l10n_ar_edi's own.
+
+        Covers behaviour 45 of the survey.
+        """
+        preprinted_journal = self._create_journal("preprinted", data={"code": "PREP1"})
+        self.assertFalse(preprinted_journal.l10n_ar_afip_ws, "the scenario needs a journal with no webservice")
+        invoice = self._create_invoice_ar(journal_id=preprinted_journal)
+        base_lines, _tax_lines = invoice._get_rounded_base_and_tax_lines()
+
+        details = invoice._get_line_details(base_lines=base_lines)
+
+        # Upstream's shape, not this module's
+        self.assertTrue(details)
+        self.assertIn("Pro_ds", details[0])
+        self.assertNotIn("codigoMtx", details[0])
+
+    def test_wsmtxca_items_reject_line_without_product(self):
+        """Task 68095: RG2904 reports product codes, so a line with no product
+        is blocked before reaching ARCA, and every offending line is listed at
+        once instead of one per attempt.
+
+        Covers behaviour 44 of the survey.
+        """
+        invoice = self._create_invoice_ar(
+            invoice_line_ids=[
+                self._prepare_invoice_line(product_id=self.product_iva_21, price_unit=1000.0),
+                self._prepare_invoice_line(price_unit=100.0, tax_ids=self.tax_21, name="Servicio sin producto"),
+                self._prepare_invoice_line(price_unit=50.0, tax_ids=self.tax_21, name="Otro sin producto"),
+            ],
+        )
+
+        with self.assertRaisesRegex(UserError, "requires a product on every invoice line") as caught:
+            self._wsmtxca_request(invoice)
+
+        # Both offending lines are named, so they get fixed in one pass
+        self.assertIn("Servicio sin producto", str(caught.exception))
+        self.assertIn("Otro sin producto", str(caught.exception))

--- a/l10n_ar_wsmtxca_ws/wizards/l10n_ar_afip_ws_consult.py
+++ b/l10n_ar_wsmtxca_ws/wizards/l10n_ar_afip_ws_consult.py
@@ -1,10 +1,6 @@
-import logging
-
 from odoo import _, fields, models
 from odoo.exceptions import UserError
 from odoo.tools.zeep.helpers import serialize_object
-
-_logger = logging.getLogger(__name__)
 
 
 class L10nArAfipWsConsult(models.TransientModel):
@@ -63,7 +59,6 @@ class L10nArAfipWsConsult(models.TransientModel):
 
         title = _("Invoice number %s\n", self.number)
         if error:
-            _logger.warning("%s\n%s" % (title, error))
             raise UserError(_("AFIP Errors: %(error)s", error=error))
 
         msg = ""


### PR DESCRIPTION
Tarea: https://www.adhoc.inc/odoo/project.task/68095

El módulo no tenía `tests/`. Este PR arma la suite alrededor de los comportamientos por los que el webservice efectivamente rechaza, no alrededor de los métodos, y arregla lo que el relevamiento encontró.

Dos commits: primero los fixes, después la suite que los cubre.

## Los fixes

**1. El IVA al 5% y al 2,5% no llegaba a ARCA.** `vat_needed` era `["4", "5", "6"]`, así que los códigos 8 (5%) y 9 (2,5%) quedaban fuera de `arraySubtotalesIVA`, mientras `_l10n_ar_get_amounts` sí contaba su base en `importeGravado` y su impuesto en `importeTotal`. El sobre que ARCA cruza quedaba corto por exactamente ese IVA. Reproducido sobre una factura de 1000 al 5%: `importeTotal` 1050.00 contra 1000.00 de subtotal más IVA informado. El código 3 (0%) queda deliberadamente afuera: su importe es cero y no mueve la identidad.

**2. `_get_line_details` llamaba a `super()` y tiraba el resultado.** Y en el camino `l10n_ar_edi` levantaba su propia excepción, lo que dejaba el chequeo de unidad de medida de este módulo como código muerto: el cliente veía el mensaje de upstream y la traducción del `es.po` propio nunca se usaba. Ahora se delega en `super()` para todo diario que no sea wsmtxca.

La condición vieja era `if (afip_ws := self.journal_id.l10n_ar_afip_ws) and afip_ws != "wsmtxca"`, que con un diario **sin** webservice no delegaba: caía en la rama wsmtxca. Era inalcanzable —`_get_line_details` solo se llama desde `wsfex_get_cae_request`, `wsbfe_get_cae_request` y `wsmtxca_get_cae_request`, y esos tres solo corren para facturas cuyo diario tiene webservice (`ar_edi_invoices = ar_invoices.filtered(lambda x: x.journal_id.l10n_ar_afip_ws)`)— pero la intención se leía al revés. La condición nueva cubre los dos casos y queda pinneada por un test.

**3. Líneas sin producto: se rechazan.** RG2904 informa códigos de producto, así que una línea sin producto no tiene código que informar. Antes rebotaba por accidente, con un mensaje de upstream que hablaba de la unidad de medida. Ahora se validan todas juntas y se listan en un solo error, para corregirlas de una pasada en vez de una por una.

**4. Se sacó el `_logger.warning`** del wizard de consulta que narraba el mismo texto del `UserError` que se levanta a continuación.

## La suite

- **`tests/invariants.py`** — propiedades que se verifican en **cada** request que arma la suite, no test por test: la identidad del sobre de ARCA (`importeTotal = importeSubtotal + Σ arraySubtotalesIVA + importeOtrosTributos`), el cruce de ítems detrás del error 519, ningún `cantidad`/`precioUnitario` negativo para ninguna unidad de medida, `codigoMtx` de 13 dígitos en todo ítem, la precisión decimal declarada, y un asiento contable posteado y balanceado. `tests/test_invariants.py` prueba cada invariante en los dos sentidos: con un request sano (no tiene que quejarse) y con el defecto exacto que existe para cazar (tiene que quejarse). La identidad del sobre es la que encontró el fix 1.
- **`tests/common.py`** — se apoya en `TestArEdiCommon` de `l10n_ar_edi`. Suma dos cosas que upstream no tiene: la entrada `WSMTXCA` en el mapeo de sistemas de punto de venta, para que `_create_journal('wsmtxca')` funcione, y un `_validate_and_review` que conoce wsmtxca — el de upstream recorre un if/elif sobre wsfe/wsfex/wsbfe y termina en `self.fail()`.
- **`test_codigo_mtx.py`** — relleno del GTIN a 13 dígitos, los códigos genéricos según el tipo de línea, y los dos controles positivos (código no GS1, producto físico sin código de barras).
- **`test_items.py`** — letra A informa el precio unitario neto con el IVA aparte, letra B lo informa con el IVA adentro, y ambas caen en el mismo `importeItem`; descuentos; secciones y notas que no generan ítems; líneas negativas informadas como bonificación; los dos rechazos (unidad de medida sin código ARCA, línea sin producto); y la delegación para diarios que no son wsmtxca.
- **`test_cae_request.py`** — fechas ISO, subtotales de IVA por alícuota incluidas las reducidas, percepciones como otros tributos, moneda extranjera, fecha de vencimiento de las MiPyME, y el comprobante asociado de una nota de crédito.
- **`test_cae_response.py`** — CAE guardado ante una respuesta autorizada, chatter ante una observada, rollback sin CAE ante una rechazada, y delegación para los demás webservices. El cliente zeep, el ticket y el transport llegan como argumentos, así que un doble de los tres ejercita el manejo de la respuesta sin red y sin parchear la conexión.

No se sale a la red en ningún punto: con `l10n_ar_afip_ws_environment='testing'` y sin certificado, el posteo valida localmente, y el request se arma con el cliente mockeado que `l10n_ar_edi` ya provee.

## Plan de prueba

```
odoo-bin -d <db> -u l10n_ar_wsmtxca_ws --test-tags /l10n_ar_wsmtxca_ws --stop-after-init
```

```
0 failed, 0 error(s) of 24 tests   ·   52s   ·   sin warnings de log
```

Cada test se demostró en rojo: se rompió quirúrgicamente el comportamiento que protege, se verificó que la corrida falle en la aserción correcta, y se restauró el código. El test de línea negativa y los de alícuotas reducidas fallan a través de una **invariante**, no de su aserción propia — que es la batería haciendo lo que tiene que hacer.

## Declarado, sin implementar

Escenarios dejados afuera a propósito, cada uno con su motivo en el docstring del test: líneas de anticipo informadas como `97` (necesita un flujo de pedido de venta), el chequeo de puntos de venta en modo testing y el preview del XML (ambos detrás de una conexión real), y la serialización de datos opcionales (no pude determinar qué la dispara). Tampoco se testea la configuración del webservice (endpoints, traducción de credenciales, tipos de comprobante admitidos) ni la consulta de cotización: son fijaciones de configuración y rechazos de una herramienta de diagnóstico, sin comportamiento de negocio detrás.

## Notas para quien revise

- El módulo no tenía `tests/`, así que puede necesitar alta en la whitelist manual de runbot o la suite no corre en el build. No encontré esa whitelist en este repo.
- El `.pot` no se regeneró: la cadena nueva se agregó solo al `es.po`.
