### PR TITLE
[FIX] l10n_ar_txt_sire: validar datos de nacimiento al generar el txt

### DIFF
--- a/l10n_ar_txt_sire/README.rst
+++ b/l10n_ar_txt_sire/README.rst
@@ -38,7 +38,7 @@ To configure this module, you need to:
 
    1. Crear diario de liquidación con la etiqueta para liquidación "Sire" y elegir "TXT Retenciones SIRE" en el campo "Impuesto de liquidación".
    2. Crear impuesto de sire y agregar la etiqueta "Sire" en cuadrículas de impuesto en vista formulario del impuesto y agregar codigo de regimen en el campo "Codigo de regimen IVA" en la solapa "Opciones avanzadas" del impuesto.
-   3. El contacto debe tener país y si es tipo 'individual' entonces tendrá que establecer el país de nacimiento y la fecha de nacimiento en la solapa "Datos Fiscales" de la vista formulario del contacto.
+   3. El contacto debe tener país y si es tipo 'individual' entonces tendrá que establecer el país de nacimiento y la fecha de nacimiento en la solapa "Datos Fiscales" de la vista formulario del contacto. Estos dos datos no se piden al guardar el contacto sino al momento de generar el archivo txt, que es cuando la especificación SIRE los exige (campos 28 y 29, obligatorios cuando el retenido es persona física).
    4. Establecer "Sire Codigo Alicuota" en la solapa "Datos Fiscales" de la vista formulario del contacto. Si no lo establece entonces en el pago será requerido que lo establezca.
 
 Usage

--- a/l10n_ar_txt_sire/models/account_journal.py
+++ b/l10n_ar_txt_sire/models/account_journal.py
@@ -187,6 +187,23 @@ class AccountJournal(models.Model):
                     button_text=_("Editar País"),
                 )
 
+            # Validamos los datos de nacimiento cuando el retenido es persona física. Según la seccion
+            # "3.2. F2003 - Validaciones", página 5 del pdf de la especificación, los campos 28 (país de
+            # nacimiento) y 29 (fecha de nacimiento) son obligatorios cuando el campo 27 (tipo de persona)
+            # es "F". Lo validamos acá, al generar el archivo, y no como requerido en la vista del contacto,
+            # porque esos campos viven en una solapa que no siempre está visible.
+            if es_persona and not (line.partner_id.sire_born_country_id and line.partner_id.sire_birthdate):
+                raise RedirectWarning(
+                    message=_(
+                        "El contacto '%(name)s' (id: %(id)s) es persona física, por lo que debe tener país de"
+                        " nacimiento y fecha de nacimiento establecidos para generar el archivo txt SIRE.",
+                        name=line.partner_id.name,
+                        id=line.partner_id.id,
+                    ),
+                    action=line.partner_id.get_formview_action(),
+                    button_text=_("Editar contacto"),
+                )
+
             # Validamos que el código de alícuota se encuentre entre 1 y 83 si no aplica CDI
             if not line.payment_id.sire_aplica_cdi and int(line.payment_id.sire_codigo_alicuota) > 83:
                 raise UserError(

--- a/l10n_ar_txt_sire/views/res_partner_view.xml
+++ b/l10n_ar_txt_sire/views/res_partner_view.xml
@@ -9,8 +9,8 @@
                 <field name="sire_aplica_cdi"/>
                 <field name="sire_aplica_acrecentamiento"/>
                 <field name="sire_codigo_alicuota"/>
-                <field name="sire_born_country_id" invisible="company_type != 'person'" required="company_type == 'person'"/>
-                <field name="sire_birthdate" invisible="company_type != 'person'" required="company_type == 'person'"/>
+                <field name="sire_born_country_id" invisible="company_type != 'person'"/>
+                <field name="sire_birthdate" invisible="company_type != 'person'"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
## Problema

Con `l10n_ar_txt_sire` instalado no se puede guardar ningún contacto de tipo individuo, y tampoco se ve dónde completar los campos que lo bloquean.

La vista del partner declaraba:

```xml
<field name="sire_born_country_id" invisible="company_type != 'person'" required="company_type == 'person'"/>
<field name="sire_birthdate" invisible="company_type != 'person'" required="company_type == 'person'"/>
```

Esos campos se insertan después de `impuestos_padron`, es decir dentro de la página **Fiscal Data** que agrega `l10n_ar_ux`, cuya condición de visibilidad es:

```
invisible="'AR' not in fiscal_country_codes or (not is_company and parent_id)"
```

Resultado: para un individuo que es contacto hijo de otro partner, o para cualquier individuo en una compañía cuyo país fiscal no es AR, el campo queda **required + invisible** — el registro no se puede guardar y no hay UI donde completarlo. De ahí también los problemas al interactuar con otras localizaciones.

## Fix

La especificación **sí** exige los dos datos, pero solo para el archivo. En la sección *3.2. F2003 - Validaciones* (página 5 de `doc/SIRE-especificacion-para-emision-por-lote.pdf`):

```
28 RETENIDO NACIMIENTO CONSTITUCION PAIS   Si C27 = F entonces es Obligatorio y Debe existir en la tabla PAIS
29 RETENIDO NACIMIENTO CONSTITUCION FECHA  Si C27 = F entonces es Obligatorio
```

Siendo C27 el tipo de persona (`F` = física / `J` = jurídica).

Entonces el requerimiento se mueve al momento en que la especificación lo pide:

- Se quitan los `required` de la vista. Los campos siguen visibles solo para `company_type == 'person'`, pero no bloquean el guardado.
- Se agrega la validación en `_sire_validations()`, junto a las demás validaciones de generación del archivo: si el retenido es persona física y le falta país o fecha de nacimiento, se levanta un `RedirectWarning` con botón para ir a editar el contacto.

Con eso el error aparece donde es accionable (al descargar el TXT, sobre el contacto concreto que falta completar) en vez de bloquear todos los contactos individuales de la base.

## Test plan

1. Instalar `l10n_ar_txt_sire` en una base AR.
2. Crear un contacto individual suelto (Contactos → Nuevo → Individuo) y guardar → guarda sin pedir País/Fecha de nacimiento.
3. Agregar un contacto hijo de tipo individuo a una compañía y guardar → guarda (antes fallaba con campo requerido invisible).
4. Repetir 2 con una compañía cuyo país fiscal no sea AR → guarda.
5. En un individuo, verificar que País de Nacimiento y Fecha de Nacimiento siguen visibles y editables en la pestaña Datos Fiscales, y que no aparecen para contactos de tipo compañía.
6. Pago con retención SIRE a un **individuo** del exterior sin País/Fecha de nacimiento → al generar el TXT Retenciones SIRE aparece el `RedirectWarning` con el nombre del contacto y el botón "Editar contacto". Completar los datos y regenerar → el archivo sale con las posiciones 28 y 29 informadas.
7. Mismo pago pero a una **compañía** del exterior → el TXT se genera sin pedir datos de nacimiento (C27 = J).

Ticket: 122186