### PR TITLE
[IMP] l10n_ar_edi_ux: add selectable legend for A and M invoice PDFs

### DIFF
--- a/l10n_ar_edi_ux/README.rst
+++ b/l10n_ar_edi_ux/README.rst
@@ -19,6 +19,7 @@ Argentinian Electronic Invoicing UX
 * Logic to connect to AFIP Padron using connection approach in enterprise module l10n_ar_edi
 * Add button on electronic journals to get valid document types for the selected webservice. When is given the response and the Webservice used, returns a more legible message to be shown to the users.
 * Allow to set boarding permission (Permisos de embarque) in argentinian electronic exportation invoices.
+* Allow to configure, from the accounting settings, a legend to be printed below the Document Type letter on the Invoice PDF of documents with letter A and M: "Payment on Informed CBU" or "Operation Subject to Withholding" (ARCA RG 5762/2025). Backport of odoo/enterprise#102032, incorporated upstream in l10n_ar_edi from 20.0 on: to be reverted when migrating to that version.
 
 About Padron:
 

--- a/l10n_ar_edi_ux/__manifest__.py
+++ b/l10n_ar_edi_ux/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Argentinian Electronic Invoicing UX",
-    "version": "18.0.1.1.0",
+    "version": "18.0.1.2.0",
     "category": "Localization/Argentina",
     "sequence": 14,
     "author": "ADHOC SA",
@@ -19,6 +19,8 @@
         "views/account_journal_view.xml",
         "views/l10n_ar_boarding_permission_view.xml",
         "views/certificate_certificate_view.xml",
+        "views/res_config_settings_view.xml",
+        "views/report_invoice.xml",
         "security/ir.model.access.csv",
     ],
     "demo": [

--- a/l10n_ar_edi_ux/i18n/es.po
+++ b/l10n_ar_edi_ux/i18n/es.po
@@ -570,3 +570,44 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_ar_edi_ux.view_move_form
 msgid "to"
 msgstr "a"
+
+#. module: l10n_ar_edi_ux
+#: model_terms:ir.ui.view,arch_db:l10n_ar_edi_ux.res_config_settings_view_form
+msgid "Add Legend to Invoice PDF"
+msgstr "Agregar leyenda al PDF de la factura"
+
+#. module: l10n_ar_edi_ux
+#: model_terms:ir.ui.view,arch_db:l10n_ar_edi_ux.res_config_settings_view_form
+msgid "Legend"
+msgstr "Leyenda"
+
+#. module: l10n_ar_edi_ux
+#: model:ir.model.fields.selection,name:l10n_ar_edi_ux.selection__res_company__l10n_ar_invoice_pdf_legend__operation_subject_to_withholding
+#: model:ir.model.fields.selection,name:l10n_ar_edi_ux.selection__res_config_settings__l10n_ar_invoice_pdf_legend__operation_subject_to_withholding
+msgid "Operation Subject to Withholding"
+msgstr "Operación sujeta a retención"
+
+#. module: l10n_ar_edi_ux
+#: model:ir.model.fields.selection,name:l10n_ar_edi_ux.selection__res_company__l10n_ar_invoice_pdf_legend__payment_on_informed_cbu
+#: model:ir.model.fields.selection,name:l10n_ar_edi_ux.selection__res_config_settings__l10n_ar_invoice_pdf_legend__payment_on_informed_cbu
+msgid "Payment on Informed CBU"
+msgstr "Pago en CBU informado"
+
+#. module: l10n_ar_edi_ux
+#: model:ir.model.fields,help:l10n_ar_edi_ux.field_res_company__l10n_ar_invoice_pdf_legend
+#: model:ir.model.fields,help:l10n_ar_edi_ux.field_res_config_settings__l10n_ar_invoice_pdf_legend
+msgid ""
+"Selected legend value will be added below the Document Type letter on the "
+"Invoice PDF."
+msgstr ""
+"La leyenda seleccionada se agregará debajo de la letra del comprobante en el "
+"PDF de la factura."
+
+#. module: l10n_ar_edi_ux
+#: model_terms:ir.ui.view,arch_db:l10n_ar_edi_ux.res_config_settings_view_form
+msgid ""
+"If this option is selected, the selected legend string will be added below "
+"the Document Type letter on the Invoice PDF."
+msgstr ""
+"Si se selecciona esta opción, la leyenda elegida se agregará debajo de la "
+"letra del comprobante en el PDF de la factura."

--- a/l10n_ar_edi_ux/models/res_company.py
+++ b/l10n_ar_edi_ux/models/res_company.py
@@ -1,9 +1,32 @@
-from odoo import _, api, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 
 class ResCompany(models.Model):
     _inherit = "res.company"
+
+    # TODO 20.0: drop this field, its compute and its views. It is a backport of
+    # odoo/enterprise#102032, which l10n_ar_edi already ships in 20.0. Copied from
+    # upstream except for its company_dependent=True: on res.company that keys the
+    # value by env.company instead of by the record, so the report would print the
+    # active company's legend instead of the one of the company that issued the
+    # invoice.
+    l10n_ar_invoice_pdf_legend = fields.Selection(
+        selection=[
+            ("payment_on_informed_cbu", "Payment on Informed CBU"),
+            ("operation_subject_to_withholding", "Operation Subject to Withholding"),
+        ],
+        compute="_compute_l10n_ar_invoice_pdf_legend",
+        store=True,
+        readonly=False,
+        help="Selected legend value will be added below the Document Type letter on the Invoice PDF.",
+    )
+
+    @api.depends("country_code")
+    def _compute_l10n_ar_invoice_pdf_legend(self):
+        for company in self:
+            if company.country_code != "AR":
+                company.l10n_ar_invoice_pdf_legend = False
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/l10n_ar_edi_ux/models/res_config_settings.py
+++ b/l10n_ar_edi_ux/models/res_config_settings.py
@@ -5,3 +5,4 @@ class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
     arba_cit = fields.Char(related="company_id.arba_cit", readonly=False)
+    l10n_ar_invoice_pdf_legend = fields.Selection(related="company_id.l10n_ar_invoice_pdf_legend", readonly=False)

--- a/l10n_ar_edi_ux/views/report_invoice.xml
+++ b/l10n_ar_edi_ux/views/report_invoice.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- TODO 20.0: drop. Backport of odoo/enterprise#102032, already shipped in
+         l10n_ar_edi 20.0. The condition differs from upstream: 18.0 has neither
+         span#withholding_legend nor document_type_code; l10n_ar.custom_header is
+         also used by reports whose record is not an account.move; and pre-printed
+         stationery prints no document letter to hang the legend from. -->
+    <template id="custom_header_inherit" inherit_id="l10n_ar.custom_header">
+        <xpath expr="//div[@name='center-upper']/span" position="inside">
+            <t t-if="o._name == 'account.move' and not pre_printed_report and o.l10n_latam_document_type_id.code in ['1', '2', '3', '51', '52', '53'] and o.company_id.l10n_ar_invoice_pdf_legend">
+                <br/>
+                <span class="d-block small mt-1 lh-1" t-field="o.company_id.l10n_ar_invoice_pdf_legend"/>
+            </t>
+        </xpath>
+    </template>
+
+</odoo>

--- a/l10n_ar_edi_ux/views/res_config_settings_view.xml
+++ b/l10n_ar_edi_ux/views/res_config_settings_view.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- TODO 20.0: drop. Backport of odoo/enterprise#102032, already shipped in
+         l10n_ar_edi 20.0. -->
+    <record model="ir.ui.view" id="res_config_settings_view_form">
+        <field name="name">res.config.settings.view.form</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="l10n_ar_edi.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+
+            <xpath expr="//block[@id='argentina_localization']" position="inside">
+                <setting string="Add Legend to Invoice PDF" company_dependent="1" help="If this option is selected, the selected legend string will be added below the Document Type letter on the Invoice PDF." invisible="country_code != 'AR'">
+                    <label for="l10n_ar_invoice_pdf_legend" string="Legend" class="o_light_label col-lg-3"/>
+                    <field name="l10n_ar_invoice_pdf_legend"/>
+                </setting>
+            </xpath>
+
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Backport a 18.0 de la funcionalidad de `l10n_ar_edi` que permite elegir la leyenda impresa debajo de la letra del comprobante en el PDF de facturas con letra A y M.

Upstream: odoo/enterprise#102032 (ya en master). En 18.0 `l10n_ar_edi` no tiene ni el booleano `l10n_ar_show_withholding_legend` ni el bloque de leyenda en el reporte, así que la funcionalidad se implementa completa acá.

ARCA RG 5762/2025 pide una segunda opción además de "Operation Subject to Withholding": "Payment on Informed CBU".

## Cambios

- `res.company`: campo selection `l10n_ar_invoice_pdf_legend`, con la definición del campo upstream (`compute` + `store` + `readonly=False`) menos el `company_dependent`, ver abajo.
- `res.config.settings`: related + nuevo setting en el bloque de localización argentina, oculto en compañías no argentinas (`invisible="country_code != 'AR'"`), igual que sus hermanos del bloque.
- Reporte: se hereda `l10n_ar.custom_header` y se imprime la leyenda seleccionada debajo de la letra del comprobante para los códigos de documento 1, 2, 3, 51, 52 y 53.
- Traducción al español de los términos nuevos, incluidos los `help` del campo y del setting.

## Sobre el revert

El campo, el compute y la vista se dejaron lo más parecido posible al patch upstream, y llevan un `TODO 20.0` para revertir todo cuando la funcionalidad venga incorporada en `l10n_ar_edi`.

Las divergencias respecto del patch upstream están anotadas en el código:

- Upstream declara el campo `company_dependent=True`. Sobre `res.company` eso indexa el valor por `env.company` en lugar de por el registro (el ORM lee `columna->'<env.company.id>'`), así que el reporte imprimiría la leyenda de la compañía **activa** y no la de la compañía que emitió la factura: con A y B permitidas y A activa, la factura de B sale con la leyenda de A o sin ninguna, y un cliente de portal descargando su factura la renderiza con su propia compañía activa. Por la misma vía se saltea la guarda de país. Acá el campo se guarda por registro de compañía, que es lo que se quiere.
- - `l10n_ar.custom_header` de 18.0 no tiene el `span#withholding_legend` sobre el que hace xpath el patch upstream, así que el xpath va por `//div[@name='center-upper']/span`.
- El reporte de 18.0 no define `document_type_code`, así que la condición usa `o.l10n_latam_document_type_id.code`.
- `l10n_ar.custom_header` lo comparten reportes cuyo registro no es un `account.move` (remito de `l10n_ar_stock_ux`, pedido de venta de `l10n_ar_sale`, orden de compra de `l10n_ar_purchase`, recibo y certificado de retención de `l10n_ar_tax`, transferencia interna de `l10n_ar_ux`), así que la condición chequea el modelo del registro antes de leer `l10n_latam_document_type_id`.
- La leyenda se omite en talonarios pre-impresos (`pre_printed_report`), donde el encabezado no imprime la letra del comprobante de la que colgarla.

No se diverge en el `compute`, aunque parezca incompleto: `_compute_l10n_ar_invoice_pdf_legend` no asigna nada cuando la compañía es argentina, igual que el patch upstream y que el `_compute_afip_crt` de `l10n_ar_edi` justo arriba. No levanta "Compute method failed to assign": en `odoo/orm/fields.py` ese `ValueError` se levanta solo para campos `readonly and not store`, y este es `store=True, readonly=False`, así que los registros sin asignar caen al fallback a `False`. Cambiarlo obligaría a leer el campo dentro de su propio compute, lo cual es más riesgoso que lo que arregla, y rompería la propiedad de "revert = borrado plano".

## Test plan

1. Contabilidad > Ajustes > Localización Argentina: aparece el setting "Add Legend to Invoice PDF" con el selector "Legend", solo en compañías argentinas.
2. Sin leyenda seleccionada, el PDF de una factura A sale igual que antes.
3. Con "Pago en CBU informado", el PDF de una factura A (códigos 1/2/3) y de una M (51/52/53) muestra la leyenda debajo de la letra.
4. El PDF de una factura B/C no muestra ninguna leyenda.
5. Con una leyenda seleccionada, imprimir remito, pedido de venta, orden de compra, recibo, certificado de retención y transferencia interna de una compañía argentina sigue funcionando (comparten `l10n_ar.custom_header`) y no muestran leyenda.
6. Con un diario de talonario pre-impreso (`II_IM`), el PDF de una factura A no muestra la leyenda.

## Alternativa

La misma funcionalidad está propuesta directamente sobre `l10n_ar_edi` en odoo/enterprise#130065. Se mergea una de las dos, no las dos.
