### PR TITLE
[FIX] account_accountant_ux: show outstanding lines with no payment

### DIFF
--- a/account_accountant_ux/models/bank_rec_widget.py
+++ b/account_accountant_ux/models/bank_rec_widget.py
@@ -7,15 +7,54 @@ from odoo.exceptions import UserError
 class BankRecWidget(models.Model):
     _inherit = "bank.rec.widget"
 
+    def _get_rec_pay_matching_domain(self):
+        """Dominio del filtro "Cliente/Proveedor" del tablero de conciliación.
+
+        El de core pide ``payment_id != False`` en la rama de las cuentas de pagos pendientes,
+        así que ahí solo entran los asientos que son el asiento de un ``account.payment``.
+        Cualquier otro asiento que viva en esas cuentas queda clasificado como "Misc" y el filtro
+        lo esconde, aunque sea exactamente lo que el usuario está buscando conciliar: el caso que
+        motivó esto es el débito de un cheque propio, que se asienta contra la cuenta de pagos
+        pendientes del diario pero no tiene pago de origen.
+
+        Como acá abajo dejamos el filtro activo por default, esconder esos apuntes obliga al
+        usuario a sacar el filtro para encontrarlos. Alcanza con que la línea esté en una cuenta
+        de pagos pendientes del diario: si no está conciliada y vive ahí, es una contrapartida de
+        pago legítima.
+        """
+        self.ensure_one()
+        journal = self.st_line_id.journal_id
+        outstanding_accounts = (
+            journal._get_journal_inbound_outstanding_payment_accounts()
+            | journal._get_journal_outbound_outstanding_payment_accounts()
+        ) - journal.default_account_id
+        return [
+            "|",
+            # Facturas.
+            "&",
+            ("account_id.account_type", "in", ("asset_receivable", "liability_payable")),
+            ("payment_id", "=", False),
+            # Contrapartidas de pagos.
+            ("account_id", "in", outstanding_accounts.ids),
+        ]
+
     def _prepare_embedded_views_data(self):
         data = super()._prepare_embedded_views_data()
         data["amls"]["context"]["default_st_line_id"] = self.st_line_id.id
 
-        # Activate the partner filter by default
-        for dynamic_filter in data["amls"].get("dynamic_filters", []):
-            if dynamic_filter["name"] == "receivable_payable_matching":
-                dynamic_filter["is_default"] = True
-                break
+        dynamic_filters = {
+            dynamic_filter.get("name"): dynamic_filter for dynamic_filter in data["amls"].get("dynamic_filters", [])
+        }
+        rec_pay_filter = dynamic_filters.get("receivable_payable_matching")
+        if rec_pay_filter:
+            # Activate the partner filter by default
+            rec_pay_filter["is_default"] = True
+            domain = self._get_rec_pay_matching_domain()
+            # super() ya dejó los dominios stringificados, así que los reemplazamos igual de armados.
+            rec_pay_filter["domain"] = str(domain)
+            misc_filter = dynamic_filters.get("misc_matching")
+            if misc_filter:
+                misc_filter["domain"] = str(["!"] + domain)
 
         if bool(self.env["ir.config_parameter"].sudo().get_param("account_accountant_ux.use_search_filter_amount")):
             data["amls"]["context"]["search_default_same_amount"] = True


### PR DESCRIPTION
- Add _get_rec_pay_matching_domain: same domain as core for the Customer/Vendor dynamic filter, without the payment_id != False leaf on the outstanding-accounts branch
- Apply it in _prepare_embedded_views_data to both receivable_payable_matching and misc_matching (its negation), so every aml still falls in exactly one of the two filters
- Replace the loop that flagged the filter as default with a name-indexed lookup of the dynamic filters

Change note: Al conciliar el extracto bancario, el asiento del débito de un cheque propio ahora aparece entre los apuntes sugeridos sin tener que sacar el filtro "Cliente/Proveedor". Antes quedaba escondido y había que quitar ese filtro para encontrarlo. También quedan visibles los asientos manuales hechos contra las cuentas de pagos o cobros pendientes del diario