### PR TITLE
[FIX] l10n_ar_account_reports: Mendoza withholdings TXT could not be generated

### DIFF
--- a/l10n_ar_account_reports/__manifest__.py
+++ b/l10n_ar_account_reports/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Accounting Reports Customized for Argentina",
-    "version": "19.0.1.20.0",
+    "version": "19.0.1.20.1",
     "category": "Accounting",
     "sequence": 14,
     "summary": "",

--- a/l10n_ar_account_reports/models/mendoza_report.py
+++ b/l10n_ar_account_reports/models/mendoza_report.py
@@ -94,12 +94,10 @@ class L10n_ArMendozaReportHandler(models.AbstractModel):
             # Campo 4: Comprobante char(12)- Número de Comprobante de Retención/Percepción según Res.40/2012.
             # Formato: 999999999999 (rellenar con ceros (0) a la izquierda) Ejemplo: 000000001521
             # Example "000000027860"
-            if len(line.name) > 12:
-                prefix, rest = line.name.split("-", 1)
-                exceso = len(line.name) - 12
-                rest = rest[exceso:]  # quitamos solo los ceros necesarios
-                name = prefix + "-" + rest
-            content += (name or "").rjust(12, "0")[:12]  # we are forcing 12 first numbers always.
+            # We drop the dash and keep the last 12 characters of the name, so a number longer than the field
+            # loses the receiptbook prefix instead of the voucher sequence, and zero pad on the left when it
+            # is shorter.
+            content += (line.name or "").replace("-", "")[-12:].rjust(12, "0")
 
             # Campo 5: Fecha Ret./Perc. char(8)- Fecha de efectuada la retención / percepción (ddmmaaaa)
             # Example "16052020"


### PR DESCRIPTION
## Problema

El botón **TXT Retenciones** del reporte de IIBB Mendoza (`l10n_ar.mendoza.report.handler`) no genera el archivo: al armar el Campo 4 (Comprobante), la variable `name` se asignaba **solo dentro** del `if len(line.name) > 12`, pero se usaba siempre en la línea siguiente. Con la secuencia de retención por defecto (8 dígitos) el nombre nunca pasa de 12 caracteres, así que la primera retención del archivo revienta con `UnboundLocalError`.

Peor todavía cuando una línea previa sí entró al `if`: `name` sobrevive a la iteración y la línea corta sale con el comprobante de la anterior — archivo bien formado, con el número de comprobante de otro contribuyente.

El mismo bloque tenía dos caminos más de excepción: `ValueError` si el nombre no trae guión (`split("-", 1)` desempaquetando en dos) y `TypeError` si `line.name` es `False`.

## Solución

Se toman los últimos 12 caracteres del nombre y se rellena con ceros a la izquierda cuando sobra lugar:

```python
content += (line.name or "")[-12:].rjust(12, "0")
```

El criterio es qué se sacrifica cuando el número no entra en el campo: recortando por la izquierda se pierde el prefijo del talonario y **nunca** el número de comprobante, que es el dato que identifica la retención. El campo es `char`, así que el separador puede viajar adentro sin romper el formato.

Ejemplos: `0002-00012345` → `002-00012345`; `002026-00012345` → `026-00012345`; `00001521` → `000000001521`; nombre vacío → `000000000000` (antes, excepción).

## Test plan

Generar el TXT de retenciones de Mendoza sobre un período que incluya:

- [ ] una retención con número de comprobante de 12 caracteres o menos → antes fallaba, ahora sale el archivo
- [ ] una retención con número largo primero y una corta después → la corta ya no arrastra el comprobante de la larga
- [ ] una retención con prefijo de talonario largo (`002026-00012345`) → Campo 4 conserva `00012345` completo
- [ ] verificar que el largo de registro se mantiene en 156 posiciones en todas las líneas

## Nota sobre cobertura

El caso está cubierto por `test_el_archivo_de_retenciones_de_mendoza_se_puede_generar`, que hoy vive en `l10n_ar_account_reports/tests/test_open_bugs.py` en la rama de #1146 (clase tagueada `-standard`, en rojo a propósito). Ese archivo documenta que, al llegar el fix, el test se saca de `test_open_bugs.py` y se lleva a la tabla de `test_txt_line_count.py`. Como la suite todavía no está en `19.0`, este PR no lo mueve: conviene coordinar el orden de merge con #1146 y hacer la mudanza del test ahí o en un PR de seguimiento.

Task: https://www.adhoc.inc/odoo/helpdesk.ticket/127173