### PR TITLE
[FIX] l10n_ar_import_bill: only claim spreadsheets, not every attachment

### DIFF
--- a/l10n_ar_import_bill/models/account_journal.py
+++ b/l10n_ar_import_bill/models/account_journal.py
@@ -7,6 +7,16 @@ import pandas as pd
 from odoo import _, models
 from odoo.exceptions import UserError
 
+# Los formatos de planilla que puede tener un listado de ARCA. Cualquier otro
+# adjunto sigue el flujo normal de creación de facturas: enumerar lo que este
+# módulo sabe leer evita tener que saber qué lee el resto.
+SPREADSHEET_MIMETYPES = (
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",  # .xlsx
+    "application/vnd.ms-excel",  # .xls
+    "application/vnd.oasis.opendocument.spreadsheet",  # .ods
+    "text/csv",
+)
+
 
 class AccountJournal(models.Model):
     _inherit = "account.journal"
@@ -26,7 +36,13 @@ class AccountJournal(models.Model):
 
             if not attachments:
                 raise UserError(_("No attachment was provided"))
-            return journal.import_bills_from_xls(attachments)
+            # Sin este filtro se manda cualquier adjunto al parser de planillas:
+            # arrastrar un PDF o una foto de factura sobre el diario de compras
+            # moria con "File is not a zip file" en vez de crear la factura.
+            # Se reclama solo si TODO lo soltado son planillas, para no quedarnos
+            # en silencio con la mitad de un arrastre mixto.
+            if attachments.filtered(lambda a: a.mimetype in SPREADSHEET_MIMETYPES) == attachments:
+                return journal.import_bills_from_xls(attachments)
         return super().create_document_from_attachment(attachment_ids)
 
     def import_bills_from_xls(self, attachments):


### PR DESCRIPTION
Dropping a PDF or a photo of an invoice on a purchase journal fails with:

> Error reading the file. Please verify it is a valid .xlsx file.
> Error: File is not a zip file

`create_document_from_attachment` hands **every** attachment to the ARCA
spreadsheet parser as soon as the journal is a purchase one of an AR company
with responsibility 1/4/6, without looking at the file type, and it does not
call `super()` on that branch. A scanned bill therefore never reaches the
standard attachment-to-bill flow — nor any other module extending it — and comes
out as a zip error instead.

The importer now claims only what it can read: the spreadsheet formats an ARCA
listing comes in. Enumerating what this module handles, rather than what it
should keep its hands off, means it does not have to track the file types other
modules take, and a format nobody lists reaches the standard flow instead of
dying here.

It only claims when *every* dropped file is a spreadsheet, so a mixed drop is
not half-swallowed in silence.

### Test plan

On a database whose company is Argentine and set to Responsable Inscripto, drop
files on the purchase journal card of the Accounting dashboard:

| file | before | after |
|---|---|---|
| `.jpeg` / `.pdf` invoice | `.xlsx` error | goes to the normal bill creation |
| `.gif` (a type nothing claims) | `.xlsx` error | goes to the normal bill creation |
| `.xlsx` ARCA listing | imported | imported, unchanged |

Verified on a database in exactly that setup, checking all three.
