### PR TITLE
[FIX] l10n_ar_edi_ux: drop code widget on ARCA XML fields

### DIFF
--- a/l10n_ar_edi_ux/views/account_move_view.xml
+++ b/l10n_ar_edi_ux/views/account_move_view.xml
@@ -20,6 +20,17 @@
                 <field name="l10n_ar_afip_result" position="move"/>
             </xpath>
 
+            <!-- Sacamos el widget "code" (editor ace) de los campos XML de ARCA. Con
+                 account_invoice_extract instalado, hacer foco en el editor rompe el
+                 formulario de la factura con un error de cliente. Reportado a Odoo en
+                 https://github.com/odoo/odoo/issues/286871; revertir cuando esté resuelto. -->
+            <xpath expr="//page[@name='afip']//field[@name='l10n_ar_afip_xml_request']" position="attributes">
+                <attribute name="widget"/>
+            </xpath>
+            <xpath expr="//page[@name='afip']//field[@name='l10n_ar_afip_xml_response']" position="attributes">
+                <attribute name="widget"/>
+            </xpath>
+
             <!-- Mostrar datos relacionados a la verificacion de CAE solo si es compras y no es WS ARCA -->
             <label for="l10n_ar_afip_auth_code" position="attributes">
                 <attribute name="invisible" separator=" or " add="l10n_ar_afip_ws"/>


### PR DESCRIPTION
## Qué cambia

En la pestaña ARCA del formulario de factura, los campos
`l10n_ar_afip_xml_request` y `l10n_ar_afip_xml_response` dejan de usar
`widget="code"` (editor ace) y pasan a verse como texto plano.

## Por qué

Con `account_invoice_extract` instalado, hacer foco dentro del editor ace rompe
el formulario con un error de cliente:

```
TypeError: Cannot read properties of undefined (reading 'fields')
```

Es un bug nativo de Odoo 19, reproducido en un build de runbot de Odoo sin
código nuestro. La cadena es:

1. el template `web.AceField` renderiza un segundo `div.o_field_widget` **sin**
   atributo `name`, adentro del que ya genera el wrapper `Field`;
2. `account_invoice_extract` registra su renderer para `account_move_form` con
   `force: true`, así que el listener `focusin` de `iap_extract` corre en todas
   las facturas. Ese listener toma el div interno (sin `name`), arma el nombre
   `l10n_ar_afip_xml_request.null` y, como tiene un punto, entra en la rama de
   x2many de `getBoxType`:

```js
modelFieldType = this.props.record.data[parentField]?._config.fields[fieldName]?.type;
```

`record.data['l10n_ar_afip_xml_request']` es un string, así que es truthy y el
optional chaining no corta, pero no tiene `_config` → `undefined.fields`.

Reportado a Odoo: https://github.com/odoo/odoo/issues/286871

## Alcance

Los dos campos son de debug (`groups="base.group_no_one"`), así que lo único
que se pierde es el resaltado de sintaxis del XML. El cambio se revierte cuando
Odoo publique el fix.

## Cómo probarlo

Con `account_invoice_extract` instalado y modo desarrollador activo, abrir una
factura que tenga XML de ARCA cargado y hacer clic dentro de esos campos en la
pestaña ARCA. Antes salta el diálogo de error; con este cambio, no.

Ticket interno: https://www.adhoc.inc/odoo/helpdesk.ticket/127292
