### PR TITLE
[FIX] l10n_ar_edi_ux: no usar el certificado de otro contribuyente en el padrón

### DIFF
--- a/l10n_ar_edi_ux/models/res_partner.py
+++ b/l10n_ar_edi_ux/models/res_partner.py
@@ -109,20 +109,28 @@ class ResPartner(models.Model):
         self.ensure_one()
         vat = self.ensure_vat()
 
-        # if there is certificate for current company use that one, if not use the company with first certificate found
-        today = fields.Date.context_today(self.with_context(tz="America/Argentina/Buenos_Aires"))
-        valid_certificate = (
-            self.env["certificate.certificate"]
-            .sudo()
-            .search([("active", "=", True), ("date_end", ">=", today)])
-            .filtered(lambda c: c.country_code == "AR")
-        )
-        if self.env.company.sudo().l10n_ar_afip_ws_crt_id in valid_certificate:
-            company = self.env.company
-        else:
-            company = valid_certificate[:1].company_id if valid_certificate else False
+        # We use the certificate of the active company and, when it is not usable, the one of another
+        # company of the user, companies with the same CUIT first. A branch without a CUIT of its own
+        # stands on its parent company; one with a CUIT of its own only borrows the certificate of an
+        # ancestor that shares it. We never take any certificate of the database: ARCA only answers this
+        # web service to the certificates that have it delegated, and its error says nothing about the
+        # actual problem, usually an expired certificate.
+        company = self.env.company
+        while not company.partner_id.l10n_ar_vat and company.parent_id:
+            company = company.parent_id.sudo()
+        company_vat = company.partner_id.l10n_ar_vat
+        companies = company + company._l10n_ar_get_cert_ancestor() + self.env.companies
+        company = companies.filtered(
+            lambda x: x.country_code == "AR" and x.sudo().l10n_ar_afip_ws_crt_id.filtered("active").is_valid
+        ).sorted(lambda x: x.partner_id.l10n_ar_vat != company_vat)[:1]
         if not company:
-            raise UserError(_("Please configure an ARCA Certificate in order to continue"))
+            raise UserError(
+                _(
+                    'There is no valid ARCA certificate available for company "%s". Please check the certificate'
+                    " configured in the accounting settings.",
+                    self.env.company.name,
+                )
+            )
         client, auth = company._l10n_ar_get_connection("ws_sr_constancia_inscripcion")._get_client()
 
         error_msg = _(


### PR DESCRIPTION
Task: https://www.adhoc.inc/odoo/project.task/73855

## Problema

`res.partner.get_data_from_padron_afip` (botón "Actualizar datos desde ARCA") elegía la compañía con la que conectarse así:

```python
valid_certificate = self.env["certificate.certificate"].sudo().search(
    [("active", "=", True), ("date_end", ">=", today)]).filtered(lambda c: c.country_code == "AR")
if self.env.company.sudo().l10n_ar_afip_ws_crt_id in valid_certificate:
    company = self.env.company
else:
    company = valid_certificate[:1].company_id if valid_certificate else False
```

El `search` es `sudo()` y sin filtro de compañía, y `certificate.certificate._order = 'date_end DESC'`, así que el fallback es **el certificado que vence más tarde de toda la base**, sin relación con la compañía activa ni con las habilitadas para el usuario.

En una base multi-compañía, cuando vence el certificado de la compañía en la que está parado el usuario, la consulta sale con el certificado de otro contribuyente. ARCA solo responde el web service a los certificados que lo tienen delegado, así que el usuario ve:

> Computador no autorizado a acceder al servicio. PISTA: El certificado no está autorizado (delegado) para trabajar con este web service

que no dice nada del problema real. Se lee como "antes andaba y dejó de andar" sin que haya habido cambio de código.

## Solución

Un solo archivo, sin métodos nuevos. Los candidatos ahora son las compañías habilitadas para el usuario (más el ancestro que le presta el certificado), se filtran por certificado activo y vigente, y se ordenan poniendo primero las del mismo CUIT que la compañía activa. La activa encabeza la lista, así que gana cuando su certificado sirve.

Sucursales:

- **sin CUIT propio** (la compañía auxiliar típica): se apoya en la compañía padre, que es la que tiene el CUIT y el certificado. Es lo que hace el `while` que sube por `parent_id`, y vale aunque el padre no esté habilitado en el selector de compañías.
- **con CUIT propio**: `_l10n_ar_get_cert_ancestor` (ya existente) solo devuelve el ancestro que comparte el CUIT, así que no toma el certificado del padre — necesita el suyo.

Si ninguna compañía tiene certificado usable, el error nombra la compañía activa en vez de dejar que conteste ARCA.

## Test plan

Sin tests automáticos: el caso real es multi-compañía con certificados vencidos y vigentes, que hay que fabricar entero para armarlo. Se verificó a mano sobre una base con esta jerarquía, mockeando la conexión para ver qué compañía se elige:

- compañía activa con certificado vigente → se usa ella;
- certificado vencido + otra compañía del mismo CUIT vigente → se usa la del mismo CUIT;
- certificado vencido y solo otro CUIT disponible → se usa ese, como último recurso;
- el certificado que vence más tarde de la base, de una compañía no habilitada, nunca se elige (la regresión que motiva el PR);
- sucursal sin certificado con el CUIT del padre → usa el del padre, aunque el padre no esté habilitado;
- sucursal sin CUIT propio → usa el certificado del padre, incluso con otras compañías habilitadas;
- sucursal con CUIT propio y sin certificado → no toma el del padre;
- sin ninguna compañía con certificado usable → error que nombra la compañía activa.

Los 9 tests existentes del módulo siguen pasando.

Sin migration script ni bump de manifest → `nobump`.