### PR TITLE
[FIX] l10n_ar_edi_ux: heredar la vista que agrega actividad_monotributo_padron

### DIFF
--- a/l10n_ar_edi_ux/views/res_partner_view.xml
+++ b/l10n_ar_edi_ux/views/res_partner_view.xml
@@ -11,6 +11,17 @@
                     <button name="button_update_partner_data_from_afip" string="Update From ARCA" class="oe_link oe_inline" type="object" invisible="not vat or (not is_company and parent_id)"/>
                 </span>
             </xpath>
+        </field>
+    </record>
+
+    <!-- actividades_padron se ancla en actividad_monotributo_padron, que agrega
+         l10n_ar_ux en otra rama de la herencia: heredamos de esa vista y no de
+         la de l10n_latam_base, para no depender del orden de combinación. -->
+    <record id="view_partner_property_form" model="ir.ui.view">
+        <field name="name">res.partner.form</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="l10n_ar_ux.view_partner_property_form"/>
+        <field name="arch" type="xml">
             <xpath expr="//field[@name='actividad_monotributo_padron']" position="after">
                 <field name="actividades_padron" widget="many2many_tags"/>
             </xpath>


### PR DESCRIPTION
## Qué pasa

`l10n_ar_edi_ux.view_partner_form` hereda de `l10n_latam_base.view_partner_latam_form` y hace xpath sobre `//field[@name='actividad_monotributo_padron']`. Ese campo no lo agrega esa vista ni ninguna descendiente suya: lo agrega `l10n_ar_ux.view_partner_property_form`, que cuelga de otra rama del árbol (`account.view_partner_property_form`).

## Por qué funciona hoy

El xpath se resuelve contra el arch combinado, no contra la vista declarada en `inherit_id`. `_combine()` recorre el árbol en DFS pre-order con los hijos ordenados por `priority, id`:

```
base.view_partner_form
├── account.view_partner_property_form      priority 2   → l10n_ar → l10n_ar_ux (agrega el campo)
└── base_vat.view_partner_base_vat_form     priority 15  → l10n_latam_base → l10n_ar_edi_ux (el xpath)
```

Como la rama de `account` tiene menor priority, `l10n_ar_ux` se combina entera antes y el campo ya está en el arch acumulado cuando corre nuestro xpath. Es una dependencia implícita en las prioridades de dos vistas de Odoo estándar: si alguna cambia en un upgrade, la vista rompe con `Element ... cannot be located in parent view`.

## Qué cambia

Se parte el record en dos:

- `view_partner_form` sigue heredando de `l10n_latam_base.view_partner_latam_form` para el botón *Update From ARCA*, anclado en el `vat` que esa misma vista agrega.
- `view_partner_property_form` (nuevo) hereda de `l10n_ar_ux.view_partner_property_form` y agrega `actividades_padron`.

La dependencia a `l10n_ar_ux` ya estaba declarada en el manifest.

## Test plan

- El formulario de contacto abre sin error, con el botón *Update From ARCA* al lado del CUIT.
- En la pestaña **Datos Fiscales**, grupo ARCA, `actividades_padron` aparece debajo de `actividad_monotributo_padron`.

Sin cambio de comportamiento ni de schema. Sugerido `nobump` (no hay migration script).

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/127549